### PR TITLE
Add OIDC autodiscovery via -webauth-issuer flag

### DIFF
--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -23,29 +23,31 @@ func main() {
 	addr := flag.String("addr", ":8080", "listen address")
 
 	// Auth flags.
-	webauthURL := flag.String("webauth-url", "", "base URL of webauth server (e.g. https://auth.infodancer.net)")
+	webauthIssuer := flag.String("webauth-issuer", "", "OIDC issuer URL, e.g. https://auth.infodancer.net/t/infodancer (enables autodiscovery)")
+	webauthURL := flag.String("webauth-url", "", "base URL of webauth server; derived from -webauth-issuer when omitted")
 	jwtCookie := flag.String("jwt-cookie", "infodancer_jwt", "name of the JWT cookie set by webauth")
-	jwksURL := flag.String("jwks-url", "", "JWKS endpoint URL (e.g. https://auth.infodancer.net/.well-known/jwks.json)")
+	jwksURL := flag.String("jwks-url", "", "JWKS endpoint URL; overrides autodiscovery when set")
 	pemKeyPath := flag.String("jwt-public-key", "", "path to RSA public key PEM file (dev fallback when JWKS not yet live)")
 	jwtIssuer := flag.String("jwt-issuer", "", "expected JWT issuer claim (empty = skip validation)")
-	webauthTenant := flag.String("webauth-tenant", "", "webauth tenant ID used for OIDC endpoints (e.g. infodancer)")
+	webauthTenant := flag.String("webauth-tenant", "", "webauth tenant ID for manual OIDC endpoint construction (not needed with -webauth-issuer)")
 	webauthClientID := flag.String("webauth-client-id", "", "Herald's registered OIDC client ID")
 	webauthCallbackURL := flag.String("webauth-callback-url", "", "Herald's registered OIDC callback URL (e.g. https://herald.infodancer.net/auth/callback)")
 
 	flag.Parse()
 
-	if *webauthURL == "" {
-		fmt.Fprintln(os.Stderr, "herald-web: -webauth-url is required")
+	if *webauthIssuer == "" && *webauthURL == "" {
+		fmt.Fprintln(os.Stderr, "herald-web: -webauth-issuer or -webauth-url is required")
 		os.Exit(1)
 	}
-	if *jwksURL == "" && *pemKeyPath == "" {
-		fmt.Fprintln(os.Stderr, "herald-web: one of -jwks-url or -jwt-public-key is required")
+	if *webauthIssuer == "" && *jwksURL == "" && *pemKeyPath == "" {
+		fmt.Fprintln(os.Stderr, "herald-web: one of -jwks-url or -jwt-public-key is required (or use -webauth-issuer for autodiscovery)")
 		os.Exit(1)
 	}
 
 	validator, err := auth.NewValidator(auth.ValidatorConfig{
 		Issuer:       *jwtIssuer,
 		CookieName:   *jwtCookie,
+		IssuerURL:    *webauthIssuer,
 		WebauthURL:   *webauthURL,
 		JWKSEndpoint: *jwksURL,
 		PEMKeyPath:   *pemKeyPath,

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -30,13 +30,23 @@ type ValidatorConfig struct {
 	Issuer string
 	// CookieName is the name of the cookie containing the JWT.
 	CookieName string
+
+	// IssuerURL is the OIDC issuer URL, e.g. "https://auth.infodancer.net/t/infodancer".
+	// When set, the OIDC discovery document is fetched from IssuerURL+"/.well-known/openid-configuration"
+	// and the JWKS, authorize, and token endpoints are configured automatically.
+	// JWKSEndpoint, WebauthURL, and TenantID may be omitted when IssuerURL is set.
+	IssuerURL string
+
 	// WebauthURL is the base URL of the webauth server (e.g. https://auth.infodancer.net).
+	// If empty and IssuerURL is set, it is derived from the IssuerURL scheme+host.
+	// Used for logout URL construction.
 	WebauthURL string
-	// JWKSEndpoint is the JWKS discovery URL. Takes precedence over PEMKeyPath.
+	// JWKSEndpoint overrides the JWKS URL from autodiscovery. Takes precedence over PEMKeyPath.
 	JWKSEndpoint string
 	// PEMKeyPath is the path to an RSA public key PEM file, used when JWKS is not yet live.
 	PEMKeyPath string
-	// TenantID is the webauth tenant ID used for the OIDC authorize and token endpoints.
+	// TenantID is the webauth tenant ID used for constructing OIDC endpoints when
+	// IssuerURL is not set. Ignored when autodiscovery is active.
 	TenantID string
 	// ClientID is Herald's registered OIDC client ID.
 	ClientID string
@@ -56,14 +66,17 @@ type Validator struct {
 	keys          map[string]*rsa.PublicKey // kid → key ("" for PEM-loaded key without kid)
 	keysFetchedAt time.Time
 	keysTTL       time.Duration
+
+	// Populated by OIDC autodiscovery when IssuerURL is set.
+	discoveredAuthorizeURL string
+	discoveredTokenURL     string
 }
 
 // NewValidator creates a Validator and eagerly loads public keys.
 // Returns an error if the key source is misconfigured or unreachable.
+// If cfg.IssuerURL is set, the OIDC discovery document is fetched first to
+// populate the JWKS endpoint and OIDC endpoints automatically.
 func NewValidator(cfg ValidatorConfig) (*Validator, error) {
-	if cfg.JWKSEndpoint == "" && cfg.PEMKeyPath == "" {
-		return nil, fmt.Errorf("auth: one of JWKSEndpoint or PEMKeyPath must be set")
-	}
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
@@ -73,6 +86,14 @@ func NewValidator(cfg ValidatorConfig) (*Validator, error) {
 		httpClient: client,
 		keys:       make(map[string]*rsa.PublicKey),
 		keysTTL:    time.Hour,
+	}
+	if cfg.IssuerURL != "" {
+		if err := v.fetchDiscovery(); err != nil {
+			return nil, err
+		}
+	}
+	if v.cfg.JWKSEndpoint == "" && v.cfg.PEMKeyPath == "" {
+		return nil, fmt.Errorf("auth: one of JWKSEndpoint or PEMKeyPath must be set (or set IssuerURL for autodiscovery)")
 	}
 	if err := v.loadKeys(); err != nil {
 		return nil, err
@@ -85,13 +106,19 @@ func (v *Validator) CookieName() string { return v.cfg.CookieName }
 
 // OIDCConfigured reports whether the OIDC callback flow is configured.
 func (v *Validator) OIDCConfigured() bool {
-	return v.cfg.TenantID != "" && v.cfg.ClientID != "" && v.cfg.CallbackURL != ""
+	if v.cfg.ClientID == "" || v.cfg.CallbackURL == "" {
+		return false
+	}
+	return v.discoveredAuthorizeURL != "" || v.cfg.TenantID != ""
 }
 
 // AuthorizeURL builds the OIDC authorization URL with PKCE.
 // state is an opaque nonce; challenge is the base64url-encoded SHA-256 of the PKCE verifier.
 func (v *Validator) AuthorizeURL(state, challenge string) string {
-	base := fmt.Sprintf("%s/t/%s/authorize", v.cfg.WebauthURL, v.cfg.TenantID)
+	base := v.discoveredAuthorizeURL
+	if base == "" {
+		base = fmt.Sprintf("%s/t/%s/authorize", v.cfg.WebauthURL, v.cfg.TenantID)
+	}
 	u, _ := url.Parse(base)
 	q := u.Query()
 	q.Set("response_type", "code")
@@ -109,7 +136,10 @@ func (v *Validator) AuthorizeURL(state, challenge string) string {
 // verifier is the PKCE code_verifier that was used to derive the challenge.
 // Returns the access_token JWT string from the token endpoint response.
 func (v *Validator) ExchangeCode(ctx context.Context, code, verifier string) (string, error) {
-	tokenURL := fmt.Sprintf("%s/t/%s/token", v.cfg.WebauthURL, v.cfg.TenantID)
+	tokenURL := v.discoveredTokenURL
+	if tokenURL == "" {
+		tokenURL = fmt.Sprintf("%s/t/%s/token", v.cfg.WebauthURL, v.cfg.TenantID)
+	}
 
 	form := url.Values{
 		"grant_type":    {"authorization_code"},
@@ -255,6 +285,48 @@ func (v *Validator) findKey(kid string) (*rsa.PublicKey, bool) {
 		return key, true
 	}
 	return nil, false
+}
+
+// fetchDiscovery fetches the OIDC discovery document from IssuerURL and
+// populates discoveredAuthorizeURL, discoveredTokenURL, and cfg.JWKSEndpoint
+// (unless JWKSEndpoint was already set explicitly). Also derives cfg.WebauthURL
+// from the IssuerURL scheme+host when WebauthURL is not set.
+func (v *Validator) fetchDiscovery() error {
+	discoveryURL := strings.TrimRight(v.cfg.IssuerURL, "/") + "/.well-known/openid-configuration"
+	resp, err := v.httpClient.Get(discoveryURL) //nolint:noctx
+	if err != nil {
+		return fmt.Errorf("fetch OIDC discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("OIDC discovery returned %d", resp.StatusCode)
+	}
+
+	var doc struct {
+		JWKSURI      string `json:"jwks_uri"`
+		AuthorizeURL string `json:"authorization_endpoint"`
+		TokenURL     string `json:"token_endpoint"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return fmt.Errorf("parse OIDC discovery: %w", err)
+	}
+	if doc.JWKSURI == "" || doc.AuthorizeURL == "" || doc.TokenURL == "" {
+		return fmt.Errorf("OIDC discovery document missing required fields")
+	}
+
+	if v.cfg.JWKSEndpoint == "" {
+		v.cfg.JWKSEndpoint = doc.JWKSURI
+	}
+	v.discoveredAuthorizeURL = doc.AuthorizeURL
+	v.discoveredTokenURL = doc.TokenURL
+
+	if v.cfg.WebauthURL == "" {
+		u, err := url.Parse(v.cfg.IssuerURL)
+		if err == nil {
+			v.cfg.WebauthURL = u.Scheme + "://" + u.Host
+		}
+	}
+	return nil
 }
 
 // loadKeys loads keys from whichever source is configured.

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -192,6 +192,76 @@ func TestValidateCookie_Missing(t *testing.T) {
 	}
 }
 
+func TestNewValidator_Autodiscovery(t *testing.T) {
+	// Stand up a JWKS server (reuses the package-level testKey).
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := testKey.N.Bytes()
+		e := big.NewInt(int64(testKey.E)).Bytes()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"keys":[{"kty":"RSA","kid":"test","n":"%s","e":"%s"}]}`,
+			base64.RawURLEncoding.EncodeToString(n),
+			base64.RawURLEncoding.EncodeToString(e),
+		)
+	}))
+	defer jwksSrv.Close()
+
+	// Stand up a discovery server pointing at the JWKS server.
+	discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"jwks_uri": %q,
+			"authorization_endpoint": "https://auth.example.com/authorize",
+			"token_endpoint": "https://auth.example.com/token"
+		}`, jwksSrv.URL)
+	}))
+	defer discoverySrv.Close()
+
+	v, err := NewValidator(ValidatorConfig{
+		IssuerURL:   discoverySrv.URL,
+		CookieName:  "test_jwt",
+		ClientID:    "herald",
+		CallbackURL: "https://herald.example.com/auth/callback",
+	})
+	if err != nil {
+		t.Fatalf("NewValidator with autodiscovery: %v", err)
+	}
+
+	// JWKS endpoint should have been populated from the discovery document.
+	if v.cfg.JWKSEndpoint != jwksSrv.URL {
+		t.Errorf("JWKSEndpoint = %q, want %q", v.cfg.JWKSEndpoint, jwksSrv.URL)
+	}
+	// Authorize and token endpoints should be populated.
+	if v.discoveredAuthorizeURL != "https://auth.example.com/authorize" {
+		t.Errorf("discoveredAuthorizeURL = %q", v.discoveredAuthorizeURL)
+	}
+	if v.discoveredTokenURL != "https://auth.example.com/token" {
+		t.Errorf("discoveredTokenURL = %q", v.discoveredTokenURL)
+	}
+	// WebauthURL should be derived from the discovery server's scheme+host.
+	if v.cfg.WebauthURL == "" {
+		t.Error("WebauthURL not derived from IssuerURL")
+	}
+	// OIDCConfigured should report true.
+	if !v.OIDCConfigured() {
+		t.Error("OIDCConfigured() = false, want true")
+	}
+	// AuthorizeURL should use the discovered endpoint, not a TenantID construction.
+	authURL := v.AuthorizeURL("mystate", "mychallenge")
+	if !strings.HasPrefix(authURL, "https://auth.example.com/authorize") {
+		t.Errorf("AuthorizeURL = %q, want prefix https://auth.example.com/authorize", authURL)
+	}
+
+	// A valid token signed with testKey should validate.
+	token := makeToken(t, "sub-disco", "disco@example.com", "Disco User", "", time.Now().Add(time.Hour))
+	claims, err := v.Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.Sub != "sub-disco" {
+		t.Errorf("Sub = %q, want sub-disco", claims.Sub)
+	}
+}
+
 func TestWebauthLoginURL(t *testing.T) {
 	v := &Validator{cfg: ValidatorConfig{WebauthURL: "https://auth.example.com"}}
 


### PR DESCRIPTION
## Summary

- Add `IssuerURL` field to `ValidatorConfig`; when set, `NewValidator` fetches `/.well-known/openid-configuration` to populate the JWKS endpoint, authorize endpoint, and token endpoint automatically
- `WebauthURL` is derived from the issuer scheme+host when not provided explicitly
- Replace three required flags (`-webauth-url`, `-webauth-tenant`, `-jwks-url`) with a single `-webauth-issuer`; all manual-config flags are retained for overrides and dev fallback

## Motivation

The previous flag set required callers to know webauth's internal URL structure to construct OIDC endpoints manually. With autodiscovery, pointing Herald at the issuer URL is sufficient for a fully working OIDC flow.

## Test plan

- [ ] `TestNewValidator_Autodiscovery` — spins up a test discovery server + JWKS server, verifies endpoints are populated, `OIDCConfigured()` returns true, `AuthorizeURL` uses the discovered endpoint, and token validation works end-to-end
- [ ] All existing auth package tests still pass
- [ ] Full `./...` test suite green

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)