### PR TITLE
Add TOML config file support to herald-web

### DIFF
--- a/cmd/herald-web/config.go
+++ b/cmd/herald-web/config.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config holds all herald-web configuration. Values are loaded from a TOML
+// file and may be overridden by CLI flags.
+type Config struct {
+	DB      string        `toml:"db"`
+	Addr    string        `toml:"addr"`
+	Webauth WebauthConfig `toml:"webauth"`
+}
+
+// WebauthConfig holds webauth OIDC and JWT settings.
+type WebauthConfig struct {
+	// IssuerURL enables OIDC autodiscovery. When set, WebauthURL, TenantID,
+	// and JWKSUrl may be omitted.
+	IssuerURL string `toml:"issuer_url"`
+	// WebauthURL is the webauth base URL for login/logout redirects.
+	// Derived from IssuerURL scheme+host when omitted.
+	WebauthURL string `toml:"webauth_url"`
+	// Cookie is the name of the JWT session cookie.
+	Cookie string `toml:"cookie"`
+	// JWKSUrl overrides the JWKS endpoint from autodiscovery.
+	JWKSUrl string `toml:"jwks_url"`
+	// PEMKeyPath is the path to an RSA public key PEM file (dev fallback).
+	PEMKeyPath string `toml:"pem_key_path"`
+	// JWTIssuer is the expected iss claim. Empty disables the check.
+	JWTIssuer string `toml:"jwt_issuer"`
+	// TenantID is used for manual OIDC endpoint construction without autodiscovery.
+	TenantID string `toml:"tenant_id"`
+	// ClientID is Herald's registered OIDC client ID.
+	ClientID string `toml:"client_id"`
+	// CallbackURL is Herald's registered OIDC redirect URI.
+	CallbackURL string `toml:"callback_url"`
+}
+
+// loadConfig reads a TOML config file and returns the populated Config.
+// Returns an empty Config (not an error) when path is empty.
+func loadConfig(path string) (Config, error) {
+	var cfg Config
+	if path == "" {
+		return cfg, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return cfg, fmt.Errorf("open config: %w", err)
+	}
+	defer f.Close()
+	if _, err := toml.NewDecoder(f).Decode(&cfg); err != nil {
+		return cfg, fmt.Errorf("parse config: %w", err)
+	}
+	return cfg, nil
+}
+
+// mergeString returns flag if non-empty, otherwise falls back to the config value.
+func mergeString(flag, cfgVal string) string {
+	if flag != "" {
+		return flag
+	}
+	return cfgVal
+}

--- a/cmd/herald-web/herald-web.toml.example
+++ b/cmd/herald-web/herald-web.toml.example
@@ -1,0 +1,39 @@
+# herald-web configuration
+# Copy to herald-web.toml and edit before running.
+
+# Path to the SQLite database written by the herald CLI/poller.
+db   = "/var/lib/herald/herald.db"
+
+# TCP address to listen on.
+addr = ":8080"
+
+[webauth]
+# OIDC issuer URL — enables autodiscovery of JWKS, authorize, and token
+# endpoints.  Set this and you can omit webauth_url, tenant_id, and jwks_url.
+issuer_url   = "https://webauth.example.com/t/mytenant"
+
+# Herald's registered OIDC client ID and redirect URI.
+client_id    = "herald"
+callback_url = "https://herald.example.com/auth/callback"
+
+# Name of the JWT session cookie issued by the auth server.
+# Defaults to "infodancer_jwt" if omitted.
+cookie = "infodancer_jwt"
+
+# Optional: expected iss claim value.  Leave empty to skip the check.
+# jwt_issuer = "https://webauth.example.com/t/mytenant"
+
+# ── Override / dev-fallback options ───────────────────────────────────────────
+
+# webauth_url overrides the base URL derived from issuer_url (login/logout).
+# webauth_url = "https://webauth.example.com"
+
+# jwks_url overrides the JWKS endpoint from autodiscovery.
+# jwks_url = "https://webauth.example.com/.well-known/jwks.json"
+
+# pem_key_path loads an RSA public key PEM directly (dev fallback).
+# pem_key_path = "/etc/herald/jwt-public.pem"
+
+# tenant_id enables manual OIDC endpoint construction without autodiscovery.
+# Not needed when issuer_url is set.
+# tenant_id = "mytenant"

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -19,13 +19,16 @@ import (
 var version = "dev"
 
 func main() {
-	dbPath := flag.String("db", "./herald.db", "path to SQLite database")
-	addr := flag.String("addr", ":8080", "listen address")
+	configPath := flag.String("config", "", "path to TOML config file")
+
+	// CLI flags — all default to \"\" so config file values take effect when flags are omitted.
+	dbPath := flag.String("db", "", "path to SQLite database (default ./herald.db)")
+	addr := flag.String("addr", "", "listen address (default :8080)")
 
 	// Auth flags.
 	webauthIssuer := flag.String("webauth-issuer", "", "OIDC issuer URL, e.g. https://auth.infodancer.net/t/infodancer (enables autodiscovery)")
 	webauthURL := flag.String("webauth-url", "", "base URL of webauth server; derived from -webauth-issuer when omitted")
-	jwtCookie := flag.String("jwt-cookie", "infodancer_jwt", "name of the JWT cookie set by webauth")
+	jwtCookie := flag.String("jwt-cookie", "", "name of the JWT cookie set by webauth (default infodancer_jwt)")
 	jwksURL := flag.String("jwks-url", "", "JWKS endpoint URL; overrides autodiscovery when set")
 	pemKeyPath := flag.String("jwt-public-key", "", "path to RSA public key PEM file (dev fallback when JWKS not yet live)")
 	jwtIssuer := flag.String("jwt-issuer", "", "expected JWT issuer claim (empty = skip validation)")
@@ -35,25 +38,45 @@ func main() {
 
 	flag.Parse()
 
-	if *webauthIssuer == "" && *webauthURL == "" {
-		fmt.Fprintln(os.Stderr, "herald-web: -webauth-issuer or -webauth-url is required")
+	// Load config file (empty path is a no-op).
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "herald-web: %v\n", err)
 		os.Exit(1)
 	}
-	if *webauthIssuer == "" && *jwksURL == "" && *pemKeyPath == "" {
-		fmt.Fprintln(os.Stderr, "herald-web: one of -jwks-url or -jwt-public-key is required (or use -webauth-issuer for autodiscovery)")
+
+	// Merge: CLI flag wins over config file, config file wins over hardcoded default.
+	db := mergeString(*dbPath, mergeString(cfg.DB, "./herald.db"))
+	listenAddr := mergeString(*addr, mergeString(cfg.Addr, ":8080"))
+	issuerURL := mergeString(*webauthIssuer, cfg.Webauth.IssuerURL)
+	webauthBaseURL := mergeString(*webauthURL, cfg.Webauth.WebauthURL)
+	cookie := mergeString(*jwtCookie, mergeString(cfg.Webauth.Cookie, "infodancer_jwt"))
+	jwks := mergeString(*jwksURL, cfg.Webauth.JWKSUrl)
+	pem := mergeString(*pemKeyPath, cfg.Webauth.PEMKeyPath)
+	jwtIss := mergeString(*jwtIssuer, cfg.Webauth.JWTIssuer)
+	tenantID := mergeString(*webauthTenant, cfg.Webauth.TenantID)
+	clientID := mergeString(*webauthClientID, cfg.Webauth.ClientID)
+	callbackURL := mergeString(*webauthCallbackURL, cfg.Webauth.CallbackURL)
+
+	if issuerURL == "" && webauthBaseURL == "" {
+		fmt.Fprintln(os.Stderr, "herald-web: auth.issuer_url (or -webauth-issuer) is required")
+		os.Exit(1)
+	}
+	if issuerURL == "" && jwks == "" && pem == "" {
+		fmt.Fprintln(os.Stderr, "herald-web: auth.jwks_url or auth.pem_key_path required when issuer_url is not set")
 		os.Exit(1)
 	}
 
 	validator, err := auth.NewValidator(auth.ValidatorConfig{
-		Issuer:       *jwtIssuer,
-		CookieName:   *jwtCookie,
-		IssuerURL:    *webauthIssuer,
-		WebauthURL:   *webauthURL,
-		JWKSEndpoint: *jwksURL,
-		PEMKeyPath:   *pemKeyPath,
-		TenantID:     *webauthTenant,
-		ClientID:     *webauthClientID,
-		CallbackURL:  *webauthCallbackURL,
+		Issuer:       jwtIss,
+		CookieName:   cookie,
+		IssuerURL:    issuerURL,
+		WebauthURL:   webauthBaseURL,
+		JWKSEndpoint: jwks,
+		PEMKeyPath:   pem,
+		TenantID:     tenantID,
+		ClientID:     clientID,
+		CallbackURL:  callbackURL,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "herald-web: %v\n", err)
@@ -61,7 +84,7 @@ func main() {
 	}
 
 	engine, err := herald.NewEngine(herald.EngineConfig{
-		DBPath:   *dbPath,
+		DBPath:   db,
 		ReadOnly: true,
 	})
 	if err != nil {
@@ -73,7 +96,7 @@ func main() {
 	mux := newRouter(engine, validator)
 
 	srv := &http.Server{
-		Addr:         *addr,
+		Addr:         listenAddr,
 		Handler:      logging(recovery(mux)),
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -85,7 +108,7 @@ func main() {
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		log.Printf("herald-web: listening on %s", *addr)
+		log.Printf("herald-web: listening on %s", listenAddr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("herald-web: %v", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=


### PR DESCRIPTION
## Summary

- Add a \`-config\` flag accepting a path to a TOML config file
- New \`config.go\` defines \`Config\`/\`AuthConfig\` structs (BurntSushi/toml v1.6.0) and a \`mergeString\` helper
- Priority: CLI flag > config file value > hardcoded default — existing flag-only invocations continue to work unchanged
- \`herald-web.toml.example\` provides a documented template for all settings

## Motivation

With autodiscovery adding even more knobs, managing herald-web via a long flag string became unwieldy. A config file is the natural home for stable per-deployment settings; flags remain available for one-off overrides.

## Test plan

- [ ] All existing tests pass (\`go test ./...\`)
- [ ] \`-config\` with a valid TOML file starts the server correctly
- [ ] CLI flag overrides a value set in the config file
- [ ] Missing required fields in the config file (no issuer, no JWKS) produce a clear error

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)