### PR TITLE
Fix crash-loop: oidc_sub index in schema fails on existing DBs

### DIFF
--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -39,7 +39,6 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc_sub ON users(oidc_sub) WHERE oidc_sub IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS read_state (
     user_id INTEGER NOT NULL DEFAULT 1,

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,9 +1,12 @@
 package storage
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func newTestStore(t *testing.T) (*SQLiteStore, func()) {
@@ -1033,5 +1036,54 @@ func TestFilteredQueriesNoRulesPassthrough(t *testing.T) {
 	}
 	if len(articles) != 1 {
 		t.Errorf("expected 1 article (no rules passthrough), got %d", len(articles))
+	}
+}
+
+// TestMigrationFromPreOIDCSchema verifies that NewSQLiteStore successfully opens
+// an existing database that was created before the oidc_sub/email columns were
+// added to the users table.  This is a regression test for the crash-loop
+// caused by the schema init trying to CREATE UNIQUE INDEX on a column that
+// didn't yet exist.
+func TestMigrationFromPreOIDCSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pre-oidc.db")
+
+	// Bootstrap an old-style database with the users table missing oidc_sub and email.
+	legacyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	_, err = legacyDB.Exec(`
+		CREATE TABLE users (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			name       TEXT NOT NULL UNIQUE COLLATE NOCASE,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create legacy users table: %v", err)
+	}
+	_, err = legacyDB.Exec(`INSERT INTO users (name) VALUES ('alice')`)
+	if err != nil {
+		t.Fatalf("insert legacy user: %v", err)
+	}
+	legacyDB.Close()
+
+	// NewSQLiteStore must not crash-loop on this database.
+	store, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore on pre-oidc schema: %v", err)
+	}
+	defer store.Close()
+
+	// The migrated users table must expose oidc_sub and email via the normal API.
+	users, err := store.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers after migration: %v", err)
+	}
+	if len(users) != 1 || users[0].Name != "alice" {
+		t.Errorf("unexpected users after migration: %+v", users)
+	}
+	if users[0].OIDCSub != nil {
+		t.Errorf("expected nil OIDCSub for legacy user, got %v", users[0].OIDCSub)
 	}
 }


### PR DESCRIPTION
## Summary

- The `CREATE UNIQUE INDEX idx_users_oidc_sub` line in `schema.go` was executing during schema init before the `ALTER TABLE users ADD COLUMN oidc_sub` migration had a chance to run.
- On fresh databases this was harmless (column came from `CREATE TABLE`). On existing databases without the column, SQLite rejected the DDL with _"SQL logic error: no such column: oidc_sub"_, causing herald-web to crash-loop on startup.
- Fix: remove the index DDL from `Schema`. The migration in `NewSQLiteStore` already creates it idempotently with `CREATE UNIQUE INDEX IF NOT EXISTS`, covering both code paths.

## Test plan

- [ ] `go test ./internal/storage/...` — all 30 tests pass, including new `TestMigrationFromPreOIDCSchema`
- [ ] Deploy to docker-jellyfin and verify herald-web starts cleanly against existing `herald.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)