### PR TITLE
Add OPML import via web UI

### DIFF
--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -674,6 +674,29 @@ func (h *handlers) handleFeedUnsubscribe(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("HX-Redirect", fmt.Sprintf("/u/%d/feeds", uid))
 }
 
+func (h *handlers) handleOPMLImport(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+
+	if err := r.ParseMultipartForm(4 << 20); err != nil {
+		h.renderError(w, http.StatusBadRequest, "Failed to parse upload")
+		return
+	}
+
+	f, _, err := r.FormFile("opml")
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "No OPML file provided")
+		return
+	}
+	defer f.Close()
+
+	if err := h.engine.ImportOPMLReader(f, uid); err != nil {
+		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to import OPML: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/u/%d/feeds", uid), http.StatusSeeOther)
+}
+
 func (h *handlers) handleSettingsSave(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
 

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -47,6 +47,7 @@ func newRouter(engine *herald.Engine, validator *auth.Validator) http.Handler {
 	mux.Handle("POST /u/{userID}/articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)))
 	mux.Handle("POST /u/{userID}/articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)))
 	mux.Handle("POST /u/{userID}/feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)))
+	mux.Handle("POST /u/{userID}/feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)))
 	mux.Handle("DELETE /u/{userID}/feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)))
 	mux.Handle("POST /u/{userID}/settings", auth(http.HandlerFunc(h.handleSettingsSave)))
 	mux.Handle("POST /u/{userID}/filters", auth(http.HandlerFunc(h.handleFilterAdd)))

--- a/cmd/herald-web/templates/feeds_manage.html
+++ b/cmd/herald-web/templates/feeds_manage.html
@@ -23,6 +23,16 @@
         </form>
     </article>
 
+    <article>
+        <header><h3>Import OPML</h3></header>
+        <form method="post" action="/u/{{.UserID}}/feeds/import" enctype="multipart/form-data">
+            <div class="grid">
+                <input type="file" name="opml" accept=".opml,.xml" required>
+                <button type="submit">Import</button>
+            </div>
+        </form>
+    </article>
+
     <div id="feed-list">
         {{if .Feeds}}
         <table id="feeds-table">

--- a/engine.go
+++ b/engine.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"strconv"
 	"strings"
@@ -280,6 +281,11 @@ func (e *Engine) MarkArticlesRead(userID int64, articleIDs []int64) error {
 // ImportOPML imports feeds from an OPML file and subscribes the user.
 func (e *Engine) ImportOPML(path string, userID int64) error {
 	return e.fetcher.ImportOPML(path, userID)
+}
+
+// ImportOPMLReader imports feeds from an OPML reader and subscribes the user.
+func (e *Engine) ImportOPMLReader(r io.Reader, userID int64) error {
+	return e.fetcher.ImportOPMLReader(r, userID)
 }
 
 // GetUserFeeds returns all feeds a user is subscribed to.

--- a/internal/feeds/fetcher.go
+++ b/internal/feeds/fetcher.go
@@ -105,13 +105,25 @@ func (f *Fetcher) FetchFeed(ctx context.Context, feed storage.Feed) (*FetchResul
 	}, nil
 }
 
+// ImportOPMLReader imports feeds from an OPML reader and subscribes user to them.
+func (f *Fetcher) ImportOPMLReader(r io.Reader, userID int64) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read OPML: %w", err)
+	}
+	return f.importOPMLBytes(data, userID)
+}
+
 // ImportOPML imports feeds from an OPML file and subscribes user to them
 func (f *Fetcher) ImportOPML(opmlPath string, userID int64) error {
 	data, err := os.ReadFile(opmlPath)
 	if err != nil {
 		return fmt.Errorf("failed to read OPML file: %w", err)
 	}
+	return f.importOPMLBytes(data, userID)
+}
 
+func (f *Fetcher) importOPMLBytes(data []byte, userID int64) error {
 	var opml OPML
 	if err := xml.Unmarshal(data, &opml); err != nil {
 		return fmt.Errorf("failed to parse OPML: %w", err)


### PR DESCRIPTION
## Summary

- Adds an **Import OPML** card to the Manage Feeds page with a file picker accepting `.opml`/`.xml`
- Refactors `fetcher.ImportOPML` to extract `importOPMLBytes` so the new `ImportOPMLReader(io.Reader)` can share the same logic without touching the filesystem
- New route `POST /u/{userID}/feeds/import` handles the multipart upload (4 MB limit) and redirects to `/feeds` on success

## Test plan

- [ ] `go test ./...` passes
- [ ] Upload a real OPML export from Feedly/Inoreader and verify feeds appear on the feeds page

🤖 Generated with [Claude Code](https://claude.com/claude-code)