### PR TITLE
Add per-user AI prompt editing and admin global prompts

### DIFF
--- a/cmd/herald-web/config.go
+++ b/cmd/herald-web/config.go
@@ -7,12 +7,21 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// AdminConfig holds admin access configuration.
+type AdminConfig struct {
+	// Role is the JWT role claim value that grants admin access (default: "admin").
+	Role string `toml:"role"`
+	// Users is a fallback list of email addresses for when the IdP does not issue role claims.
+	Users []string `toml:"users"`
+}
+
 // Config holds all herald-web configuration. Values are loaded from a TOML
 // file and may be overridden by CLI flags.
 type Config struct {
 	DB      string        `toml:"db"`
 	Addr    string        `toml:"addr"`
 	Webauth WebauthConfig `toml:"webauth"`
+	Admin   AdminConfig   `toml:"admin"`
 }
 
 // WebauthConfig holds webauth OIDC and JWT settings.

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -18,10 +19,84 @@ import (
 
 // handlers holds dependencies for all HTTP handler methods.
 type handlers struct {
-	engine    *herald.Engine
-	validator *auth.Validator
-	pages     map[string]*template.Template // per-page template sets
-	policy    *bluemonday.Policy
+	engine     *herald.Engine
+	validator  *auth.Validator
+	pages      map[string]*template.Template // per-page template sets
+	policy     *bluemonday.Policy
+	adminRole  string   // JWT role value that grants admin access (default: "admin")
+	adminUsers []string // fallback email list when the IdP does not issue role claims
+}
+
+// isAdminCtx reports whether the request context carries admin privileges.
+// Checks JWT roles first; falls back to the config email list.
+func (h *handlers) isAdminCtx(ctx context.Context) bool {
+	role := h.adminRole
+	if role == "" {
+		role = "admin"
+	}
+	if claims := claimsFromContext(ctx); claims != nil {
+		for _, r := range claims.Roles {
+			if r == role {
+				return true
+			}
+		}
+	}
+	// Fallback: check the config email list.
+	if user := userFromContext(ctx); user != nil {
+		for _, email := range h.adminUsers {
+			if email == user.Email {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// requireAdmin is middleware that returns 403 for non-admin users.
+func (h *handlers) requireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !h.isAdminCtx(r.Context()) {
+			h.renderError(w, http.StatusForbidden, "Admin access required")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// promptUIEntry holds display data for a single prompt type in the settings UI.
+type promptUIEntry struct {
+	Type     string
+	Label    string
+	Template string
+	IsCustom bool
+}
+
+// promptTypeOrder defines the display order for prompt types in the UI.
+var promptTypeOrder = []string{"curation", "summarization", "group_summary", "related_groups"}
+
+var promptLabels = map[string]string{
+	"curation":       "Article Curation",
+	"summarization":  "Article Summarization",
+	"group_summary":  "Group Summary",
+	"related_groups": "Related Groups",
+}
+
+// loadPromptEntries builds the UI entry list for a given userID.
+func (h *handlers) loadPromptEntries(userID int64) []promptUIEntry {
+	var entries []promptUIEntry
+	for _, pt := range promptTypeOrder {
+		detail, err := h.engine.GetPrompt(userID, pt)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, promptUIEntry{
+			Type:     pt,
+			Label:    promptLabels[pt],
+			Template: detail.Template,
+			IsCustom: detail.IsCustom,
+		})
+	}
+	return entries
 }
 
 // init parses templates and creates the sanitizer policy on first use.
@@ -46,7 +121,7 @@ func (h *handlers) init() {
 	shared := []string{"base.html", "feed_sidebar.html", "article_list.html", "article_row.html", "article_view.html", "error.html"}
 
 	// Pages that get their own template tree.
-	pages := []string{"home.html", "feeds_manage.html", "groups.html", "group_detail.html", "settings.html", "filters.html"}
+	pages := []string{"home.html", "feeds_manage.html", "groups.html", "group_detail.html", "settings.html", "filters.html", "admin_prompts.html"}
 
 	h.pages = make(map[string]*template.Template, len(pages))
 	for _, page := range pages {
@@ -133,6 +208,8 @@ type settingsData struct {
 	InterestThreshold float64
 	NotifyWhen        string
 	NotifyMinScore    float64
+	Prompts           []promptUIEntry
+	IsAdmin           bool
 }
 
 type filtersData struct {
@@ -425,7 +502,8 @@ func (h *handlers) handleGroupDetail(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handlers) handleSettings(w http.ResponseWriter, r *http.Request) {
-	uid := userFromContext(r.Context()).ID
+	user := userFromContext(r.Context())
+	uid := user.ID
 
 	prefs, err := h.engine.GetPreferences(uid)
 	if err != nil {
@@ -439,6 +517,8 @@ func (h *handlers) handleSettings(w http.ResponseWriter, r *http.Request) {
 		InterestThreshold: prefs.InterestThreshold,
 		NotifyWhen:        prefs.NotifyWhen,
 		NotifyMinScore:    prefs.NotifyMinScore,
+		Prompts:           h.loadPromptEntries(uid),
+		IsAdmin:           h.isAdminCtx(r.Context()),
 	}
 
 	h.renderPage(w, r, "settings.html", data)
@@ -734,6 +814,95 @@ func (h *handlers) handleSettingsSave(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("HX-Trigger", "settings-saved")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "Settings saved.")
+}
+
+// --- AI prompt handlers ---
+
+func (h *handlers) handleUserPromptSave(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	promptType := r.PathValue("promptType")
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid form data")
+		return
+	}
+
+	tmpl := strings.TrimSpace(r.FormValue("template"))
+	if tmpl == "" {
+		h.renderError(w, http.StatusBadRequest, "Prompt template cannot be empty")
+		return
+	}
+
+	if err := h.engine.SetPrompt(uid, promptType, tmpl, nil); err != nil {
+		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to save prompt: %v", err))
+		return
+	}
+
+	w.Header().Set("HX-Trigger", "prompt-saved")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "Prompt saved.")
+}
+
+func (h *handlers) handleUserPromptReset(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	promptType := r.PathValue("promptType")
+
+	if err := h.engine.ResetPrompt(uid, promptType); err != nil {
+		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to reset prompt: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/u/%d/settings", uid), http.StatusSeeOther)
+}
+
+// adminPromptsData is the template data for the admin prompts page.
+type adminPromptsData struct {
+	UserID  int64
+	Prompts []promptUIEntry
+}
+
+func (h *handlers) handleAdminPrompts(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	data := adminPromptsData{
+		UserID:  uid,
+		Prompts: h.loadPromptEntries(0),
+	}
+	h.renderPage(w, r, "admin_prompts.html", data)
+}
+
+func (h *handlers) handleAdminPromptSave(w http.ResponseWriter, r *http.Request) {
+	promptType := r.PathValue("promptType")
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid form data")
+		return
+	}
+
+	tmpl := strings.TrimSpace(r.FormValue("template"))
+	if tmpl == "" {
+		h.renderError(w, http.StatusBadRequest, "Prompt template cannot be empty")
+		return
+	}
+
+	if err := h.engine.SetPrompt(0, promptType, tmpl, nil); err != nil {
+		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to save global prompt: %v", err))
+		return
+	}
+
+	w.Header().Set("HX-Trigger", "prompt-saved")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "Global prompt saved.")
+}
+
+func (h *handlers) handleAdminPromptReset(w http.ResponseWriter, r *http.Request) {
+	promptType := r.PathValue("promptType")
+
+	if err := h.engine.ResetPrompt(0, promptType); err != nil {
+		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to reset global prompt: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, "/admin/prompts", http.StatusSeeOther)
 }
 
 // --- Filter rules handlers ---

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -136,7 +136,7 @@ func newTestFixtures(t *testing.T) *testFixtures {
 	}
 
 	validator, jwtToken := newTestValidator(t)
-	router := newRouter(engine, validator)
+	router := newRouter(engine, validator, "", nil)
 
 	t.Cleanup(func() {
 		engine.Close()
@@ -609,7 +609,7 @@ func TestHandleCallback_SetsJWTCookie(t *testing.T) {
 	defer mockWebauth.Close()
 
 	validator := newTestValidatorWithOIDC(t, mockWebauth.URL)
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	state := "test-state-nonce"
 	verifier := "test-pkce-verifier"
@@ -653,7 +653,7 @@ func TestHandleCallback_DefaultRedirect(t *testing.T) {
 	defer mockWebauth.Close()
 
 	validator := newTestValidatorWithOIDC(t, mockWebauth.URL)
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state="+state, nil)
@@ -676,7 +676,7 @@ func TestHandleCallback_InvalidState(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, "https://auth.example.com")
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state=WRONG", nil)
 	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "correct-state"})
@@ -694,7 +694,7 @@ func TestHandleCallback_MissingVerifier(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, "https://auth.example.com")
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state="+state, nil)
@@ -719,7 +719,7 @@ func TestHandleCallback_TokenExchangeError(t *testing.T) {
 	defer mockWebauth.Close()
 
 	validator := newTestValidatorWithOIDC(t, mockWebauth.URL)
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=bad-code&state="+state, nil)
@@ -738,7 +738,7 @@ func TestHandleCallback_UpstreamAuthError(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, "https://auth.example.com")
-	router := newRouter(tf.engine, validator)
+	router := newRouter(tf.engine, validator, "", nil)
 
 	// Webauth redirects with ?error=access_denied when the user denies.
 	req := httptest.NewRequest("GET", "/auth/callback?error=access_denied&error_description=User+denied+access", nil)

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 	defer engine.Close()
 
-	mux := newRouter(engine, validator)
+	mux := newRouter(engine, validator, cfg.Admin.Role, cfg.Admin.Users)
 
 	srv := &http.Server{
 		Addr:         listenAddr,

--- a/cmd/herald-web/middleware.go
+++ b/cmd/herald-web/middleware.go
@@ -11,10 +11,14 @@ import (
 	"time"
 
 	herald "github.com/matthewjhunter/herald"
+	"github.com/matthewjhunter/herald/internal/auth"
 )
 
 // contextKey is an unexported type for context values set by this package.
 type contextKey struct{}
+
+// claimsContextKey stores the validated JWT claims in the request context.
+type claimsContextKey struct{}
 
 // withUser stores the authenticated Herald user in the request context.
 func withUser(ctx context.Context, u *herald.User) context.Context {
@@ -26,6 +30,17 @@ func withUser(ctx context.Context, u *herald.User) context.Context {
 func userFromContext(ctx context.Context) *herald.User {
 	u, _ := ctx.Value(contextKey{}).(*herald.User)
 	return u
+}
+
+// withClaims stores the validated JWT claims in the request context.
+func withClaims(ctx context.Context, c *auth.Claims) context.Context {
+	return context.WithValue(ctx, claimsContextKey{}, c)
+}
+
+// claimsFromContext retrieves the JWT claims from the context.
+func claimsFromContext(ctx context.Context) *auth.Claims {
+	c, _ := ctx.Value(claimsContextKey{}).(*auth.Claims)
+	return c
 }
 
 // generateVerifier returns a random base64url-encoded PKCE code verifier.
@@ -110,7 +125,9 @@ func (h *handlers) requireAuth(next http.Handler) http.Handler {
 			}
 		}
 
-		next.ServeHTTP(w, r.WithContext(withUser(r.Context(), user)))
+		ctx := withUser(r.Context(), user)
+		ctx = withClaims(ctx, claims)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -13,14 +13,14 @@ import (
 var embedded embed.FS
 
 // newRouter sets up all routes using Go 1.22+ enhanced routing.
-func newRouter(engine *herald.Engine, validator *auth.Validator) http.Handler {
+func newRouter(engine *herald.Engine, validator *auth.Validator, adminRole string, adminUsers []string) http.Handler {
 	mux := http.NewServeMux()
 
 	// Static files — no auth required.
 	staticFS, _ := fs.Sub(embedded, "static")
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticFS)))
 
-	h := &handlers{engine: engine, validator: validator}
+	h := &handlers{engine: engine, validator: validator, adminRole: adminRole, adminUsers: adminUsers}
 	auth := h.requireAuth
 
 	// Root: redirect to home page if authenticated, else webauth handles it via requireAuth.
@@ -56,6 +56,16 @@ func newRouter(engine *herald.Engine, validator *auth.Validator) http.Handler {
 	mux.Handle("GET /u/{userID}/feeds/{feedID}/metadata", auth(http.HandlerFunc(h.handleFeedMetadata)))
 	mux.Handle("GET /u/{userID}/feeds/metadata", auth(http.HandlerFunc(h.handleFeedMetadataByQuery)))
 	mux.Handle("GET /u/{userID}/filters/values", auth(http.HandlerFunc(h.handleFilterValues)))
+
+	// Per-user AI prompt customization.
+	mux.Handle("POST /u/{userID}/settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)))
+	mux.Handle("DELETE /u/{userID}/settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)))
+
+	// Admin-only global prompt management.
+	adminAuth := h.requireAdmin
+	mux.Handle("GET /admin/prompts", auth(adminAuth(http.HandlerFunc(h.handleAdminPrompts))))
+	mux.Handle("POST /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptSave))))
+	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))))
 
 	return mux
 }

--- a/cmd/herald-web/templates/admin_prompts.html
+++ b/cmd/herald-web/templates/admin_prompts.html
@@ -1,0 +1,38 @@
+{{define "title"}}Herald - Global AI Prompts{{end}}
+{{define "nav"}}
+<nav style="display:flex;gap:1rem;align-items:center;">
+    <a href="/u/{{.UserID}}">Articles</a>
+    <a href="/u/{{.UserID}}/settings">Settings</a>
+    <span aria-current="page">Admin: Global Prompts</span>
+</nav>
+{{end}}
+{{define "content"}}
+<main class="container" style="max-width:800px;">
+    <h2>Global AI Prompts</h2>
+    <p class="secondary">These prompts are used as defaults for all users who have not set their own. Changes take effect on the next AI processing cycle.</p>
+
+    {{range .Prompts}}
+    <article>
+        <header>
+            <strong>{{.Label}}</strong>
+            {{if .IsCustom}}<small style="color:var(--pico-primary);">&nbsp;(global override active)</small>{{else}}<small class="secondary">&nbsp;(using embedded default)</small>{{end}}
+        </header>
+        <form hx-post="/admin/prompts/{{.Type}}" hx-swap="none"
+              hx-on::after-request="if(event.detail.successful){var b=this.querySelector('[data-save-btn]');b.textContent='Saved!';setTimeout(()=>b.textContent='Save',2000);}">
+            <textarea name="template" rows="8" style="font-family:monospace;font-size:0.85em;">{{.Template}}</textarea>
+            <div style="display:flex;gap:0.5rem;margin-top:0.5rem;">
+                <button type="submit" data-save-btn style="margin:0;">Save</button>
+                {{if .IsCustom}}
+                <button type="button" class="outline secondary" style="margin:0;"
+                        hx-delete="/admin/prompts/{{.Type}}"
+                        hx-confirm="Reset '{{.Label}}' to embedded default?"
+                        hx-on::after-request="if(event.detail.successful) window.location.reload();">
+                    Reset to Embedded Default
+                </button>
+                {{end}}
+            </div>
+        </form>
+    </article>
+    {{end}}
+</main>
+{{end}}

--- a/cmd/herald-web/templates/settings.html
+++ b/cmd/herald-web/templates/settings.html
@@ -38,5 +38,40 @@
 
     <hr>
     <p><a href="/u/{{.UserID}}/filters">Manage Filter Rules</a> &mdash; score articles by author, category, or tag.</p>
+
+    {{if .Prompts}}
+    <hr>
+    <h3>AI Prompts</h3>
+    <p class="secondary">Customize how AI evaluates and summarizes your articles. Each prompt is pre-filled with the current effective default.</p>
+
+    {{range .Prompts}}
+    <article>
+        <header>
+            <strong>{{.Label}}</strong>
+            {{if .IsCustom}}<small style="color:var(--pico-primary);">&nbsp;(customized)</small>{{end}}
+        </header>
+        <form hx-post="/u/{{$.UserID}}/settings/prompts/{{.Type}}" hx-swap="none"
+              hx-on::after-request="if(event.detail.successful){var b=this.querySelector('[data-save-btn]');b.textContent='Saved!';setTimeout(()=>b.textContent='Save',2000);}">
+            <textarea name="template" rows="6" style="font-family:monospace;font-size:0.85em;">{{.Template}}</textarea>
+            <div style="display:flex;gap:0.5rem;margin-top:0.5rem;">
+                <button type="submit" data-save-btn style="margin:0;">Save</button>
+                {{if .IsCustom}}
+                <button type="button" class="outline secondary" style="margin:0;"
+                        hx-delete="/u/{{$.UserID}}/settings/prompts/{{.Type}}"
+                        hx-confirm="Reset '{{.Label}}' to default?"
+                        hx-on::after-request="if(event.detail.successful) window.location.reload();">
+                    Reset to Default
+                </button>
+                {{end}}
+            </div>
+        </form>
+    </article>
+    {{end}}
+    {{end}}
+
+    {{if .IsAdmin}}
+    <hr>
+    <p><a href="/admin/prompts">Manage Global AI Prompts</a> &mdash; set the defaults all users inherit.</p>
+    {{end}}
 </main>
 {{end}}

--- a/engine.go
+++ b/engine.go
@@ -708,6 +708,14 @@ func (e *Engine) ResetPrompt(userID int64, promptType string) error {
 	return e.store.DeleteUserPrompt(userID, promptType)
 }
 
+// DefaultPrompt returns the embedded default prompt template for a type.
+func (e *Engine) DefaultPrompt(promptType string) (string, error) {
+	if !allowedPromptTypes[promptType] {
+		return "", fmt.Errorf("unknown or restricted prompt type: %q", promptType)
+	}
+	return ai.DefaultPrompt(ai.PromptType(promptType))
+}
+
 // StarArticle sets or clears the starred flag on an article.
 func (e *Engine) StarArticle(userID, articleID int64, starred bool) error {
 	return e.store.UpdateStarred(userID, articleID, starred)

--- a/internal/ai/prompts.go
+++ b/internal/ai/prompts.go
@@ -53,8 +53,26 @@ func NewPromptLoader(store, config interface{}) *PromptLoader {
 	}
 }
 
-// GetPrompt loads a prompt with 3-tier fallback
-// Priority: user database -> config file -> embedded default
+// DefaultPrompt returns the embedded default prompt for the given type.
+func DefaultPrompt(pt PromptType) (string, error) {
+	switch pt {
+	case PromptTypeSecurity:
+		return defaultSecurityPrompt, nil
+	case PromptTypeCuration:
+		return defaultCurationPrompt, nil
+	case PromptTypeSummarization:
+		return defaultSummarizationPrompt, nil
+	case PromptTypeGroupSummary:
+		return defaultGroupSummaryPrompt, nil
+	case PromptTypeRelatedGroups:
+		return defaultRelatedGroupsPrompt, nil
+	default:
+		return "", fmt.Errorf("unknown prompt type: %s", pt)
+	}
+}
+
+// GetPrompt loads a prompt with 4-tier fallback
+// Priority: user database -> global admin (user_id=0) -> config file -> embedded default
 func (pl *PromptLoader) GetPrompt(userID int64, promptType PromptType) (string, error) {
 	cacheKey := fmt.Sprintf("%d:%s", userID, promptType)
 
@@ -63,13 +81,22 @@ func (pl *PromptLoader) GetPrompt(userID int64, promptType PromptType) (string, 
 		return cached, nil
 	}
 
-	// Tier 3: Check user database (highest priority)
+	// Tier 4: Check user-specific database entry (highest priority)
 	if pl.store != nil {
 		if store, ok := pl.store.(*storage.SQLiteStore); ok {
 			userPrompt, err := store.GetUserPrompt(userID, string(promptType))
 			if err == nil && userPrompt != "" {
 				pl.cache[cacheKey] = userPrompt
 				return userPrompt, nil
+			}
+
+			// Tier 3: Global admin override (user_id=0), only when fetching for a real user
+			if userID != 0 {
+				globalPrompt, err := store.GetUserPrompt(0, string(promptType))
+				if err == nil && globalPrompt != "" {
+					pl.cache[cacheKey] = globalPrompt
+					return globalPrompt, nil
+				}
 			}
 		}
 	}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -22,6 +22,7 @@ type Claims struct {
 	Sub   string
 	Email string
 	Name  string
+	Roles []string // from the "roles" claim (may be absent)
 }
 
 // ValidatorConfig configures JWT validation.
@@ -209,6 +210,7 @@ func (v *Validator) Validate(tokenStr string) (*Claims, error) {
 		Sub:   stringClaim(mapClaims, "sub"),
 		Email: stringClaim(mapClaims, "email"),
 		Name:  stringClaim(mapClaims, "name"),
+		Roles: stringSliceClaim(mapClaims, "roles"),
 	}
 	if claims.Sub == "" {
 		return nil, fmt.Errorf("token missing sub claim")
@@ -411,4 +413,26 @@ func rsaKeyFromJWK(nB64, eB64 string) (*rsa.PublicKey, error) {
 func stringClaim(claims jwt.MapClaims, key string) string {
 	v, _ := claims[key].(string)
 	return v
+}
+
+// stringSliceClaim extracts a []string from a JWT claim that may be encoded
+// as []interface{} (standard JSON decode) or []string.
+func stringSliceClaim(claims jwt.MapClaims, key string) []string {
+	raw, ok := claims[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Users can view and edit AI prompts directly from Settings, with each prompt pre-filled with the current effective value (their custom one, admin global, or embedded default)
- Save and Reset buttons per prompt type; Reset reverts to the next tier (global admin override if set, otherwise embedded default)
- New `/admin/prompts` page (403 for non-admins) for setting global prompt defaults stored as `user_id=0` in the `user_prompts` table
- Admin access controlled by email list in `[admin] users = [...]` in the TOML config
- Extended `PromptLoader` with a 4th tier: user-specific → global admin (user_id=0) → config file → embedded default

## Test plan

- [ ] Visit Settings — AI Prompts section appears with four prompt types pre-filled
- [ ] Edit a prompt and Save — textarea retains new text, badge shows "(customized)"
- [ ] Click Reset to Default — prompt reverts and page reloads showing the default text
- [ ] Visit `/admin/prompts` as non-admin — 403 Forbidden
- [ ] Add email to `[admin] users` in config, restart, visit `/admin/prompts` — page loads with global prompt editors
- [ ] Save a global prompt as admin — regular user settings page reflects the global override for users without their own customization
- [ ] Reset global prompt as admin — reverts to embedded default

🤖 Generated with [Claude Code](https://claude.com/claude-code)