### PR TITLE
Add vertical resize handle between article list and reading pane

### DIFF
--- a/cmd/herald-web/static/herald.css
+++ b/cmd/herald-web/static/herald.css
@@ -59,8 +59,20 @@
 }
 
 .article-list-pane {
-    flex: 0 0 calc(40% - 36px);
+    flex: 0 0 calc(var(--article-list-height, 40%) - 36px);
     overflow-y: auto;
+}
+
+.vertical-resize-handle {
+    flex: 0 0 4px;
+    cursor: row-resize;
+    background: var(--pico-muted-border-color);
+    transition: background 0.15s;
+}
+
+.vertical-resize-handle:hover,
+.vertical-resize-handle.dragging {
+    background: var(--pico-primary);
 }
 
 .article-list-footer {
@@ -206,6 +218,6 @@
         flex-direction: column;
     }
     .article-list-pane {
-        flex: 0 0 50%;
+        flex: 0 0 calc(var(--article-list-height, 50%) - 36px);
     }
 }

--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -93,6 +93,42 @@
         });
     })();
 
+    // Vertical drag-to-resize (article list height)
+    (function() {
+        var handle = document.getElementById('vertical-resize-handle');
+        var split = handle && handle.closest('.content-split');
+        if (!handle || !split) return;
+
+        var saved = localStorage.getItem('herald-list-height');
+        if (saved) split.style.setProperty('--article-list-height', saved);
+
+        var dragging = false;
+        var lastPct = null;
+
+        handle.addEventListener('mousedown', function(e) {
+            dragging = true;
+            handle.classList.add('dragging');
+            e.preventDefault();
+        });
+
+        document.addEventListener('mousemove', function(e) {
+            if (!dragging) return;
+            var rect = split.getBoundingClientRect();
+            var pct = (e.clientY - rect.top) / rect.height;
+            lastPct = Math.min(Math.max(pct, 0.2), 0.75);
+            split.style.setProperty('--article-list-height', (lastPct * 100) + '%');
+        });
+
+        document.addEventListener('mouseup', function() {
+            if (!dragging) return;
+            dragging = false;
+            handle.classList.remove('dragging');
+            if (lastPct !== null) {
+                localStorage.setItem('herald-list-height', (lastPct * 100) + '%');
+            }
+        });
+    })();
+
     // Unsubscribe feed button — show when a specific feed is selected
     document.addEventListener('click', function(e) {
         var link = e.target.closest('a[data-feed-id]');

--- a/cmd/herald-web/templates/home.html
+++ b/cmd/herald-web/templates/home.html
@@ -26,6 +26,7 @@
                 Unsubscribe
             </button>
         </div>
+        <div class="vertical-resize-handle" id="vertical-resize-handle"></div>
         <div class="reading-pane" id="reading-pane">
             <div class="empty-state">Select an article to read</div>
         </div>


### PR DESCRIPTION
## Summary

- Adds a 4px horizontal drag handle between the article list footer and the reading pane
- Dragging adjusts `--article-list-height` on `.content-split`, clamped to 20%–75%
- Position persists across page loads via `localStorage` (`herald-list-height`)
- Mirrors the existing sidebar horizontal resize implementation

## Test plan

- [ ] Drag the handle up and down — list and reading pane resize accordingly
- [ ] Reload the page — height is restored from localStorage
- [ ] Handle highlights on hover and while dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)