### PR TITLE
Fix JS fetch URLs missed in URL refactor

### DIFF
--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -148,13 +148,12 @@
     document.addEventListener('click', function(e) {
         var btn = e.target.closest('#unsubscribe-feed-btn');
         if (!btn || !btn.dataset.feedId) return;
-        var userID = btn.dataset.userId;
         var feedID = btn.dataset.feedId;
         if (!confirm('Unsubscribe from this feed?')) return;
-        fetch('/u/' + userID + '/feeds/' + feedID, {method: 'DELETE'})
+        fetch('/feeds/' + feedID, {method: 'DELETE'})
             .then(function(res) {
                 if (res.ok) {
-                    window.location.href = '/u/' + userID;
+                    window.location.href = '/';
                 }
             });
     });
@@ -164,7 +163,6 @@
         var btn = e.target.closest('.mark-all-read-btn');
         if (!btn) return;
 
-        var userID = btn.dataset.userId;
         var ids = Array.from(document.querySelectorAll('#article-list .article-row[data-article-id]'))
             .map(function(el) { return el.dataset.articleId; })
             .filter(Boolean)
@@ -172,7 +170,7 @@
 
         if (!ids) return;
 
-        fetch('/u/' + userID + '/articles/mark-all-read', {
+        fetch('/articles/mark-all-read', {
             method: 'POST',
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
             body: 'ids=' + encodeURIComponent(ids)


### PR DESCRIPTION
## Summary

- `herald.js` still used `/u/{userID}/feeds/{feedID}` and `/u/{userID}/articles/mark-all-read` after the URL refactor merged
- Updated both to flat paths (`/feeds/{feedID}`, `/articles/mark-all-read`) and removed now-unused `userID` dataset reads

## Test plan

- [ ] Mark all articles as read — button should work
- [ ] Unsubscribe from a feed via the sidebar button — should work and redirect to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)