### PR TITLE
Cap Postgres connection pool to prevent ephemeral port exhaustion

### DIFF
--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -19,6 +19,18 @@ type PostgresStore struct {
 // Compile-time check that PostgresStore implements Store.
 var _ Store = (*PostgresStore)(nil)
 
+// Connection pool limits. Go's database/sql defaults (unlimited MaxOpen,
+// MaxIdle=2) churn connections under concurrent load: idle conns over 2 are
+// destroyed after each use, and the resulting TIME_WAIT sockets can exhaust
+// ephemeral ports during a failure storm. Holding more idle conns warm
+// eliminates the churn.
+const (
+	pgMaxOpenConns    = 25
+	pgMaxIdleConns    = 25
+	pgConnMaxLifetime = 30 * time.Minute
+	pgConnMaxIdleTime = 5 * time.Minute
+)
+
 // NewPostgresStore opens a PostgreSQL connection, verifies it, and initializes
 // the schema (all DDL statements are idempotent).
 func NewPostgresStore(dsn string) (*PostgresStore, error) {
@@ -26,6 +38,10 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open postgres: %w", err)
 	}
+	db.SetMaxOpenConns(pgMaxOpenConns)
+	db.SetMaxIdleConns(pgMaxIdleConns)
+	db.SetConnMaxLifetime(pgConnMaxLifetime)
+	db.SetConnMaxIdleTime(pgConnMaxIdleTime)
 	if err := db.Ping(); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to connect to postgres: %w", err)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -90,6 +90,21 @@ func TestNewSQLiteStore(t *testing.T) {
 	}
 }
 
+func TestNewPostgresStorePoolLimits(t *testing.T) {
+	store, cleanup := newPGTestStore(t)
+	defer cleanup()
+
+	pg, ok := store.(*PostgresStore)
+	if !ok {
+		t.Fatalf("expected *PostgresStore, got %T", store)
+	}
+
+	stats := pg.db.Stats()
+	if stats.MaxOpenConnections != pgMaxOpenConns {
+		t.Errorf("MaxOpenConnections = %d, want %d", stats.MaxOpenConnections, pgMaxOpenConns)
+	}
+}
+
 func TestAddAndGetFeeds(t *testing.T) {
 	store, cleanup := newTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- Set `MaxOpenConns=25`, `MaxIdleConns=25`, `ConnMaxLifetime=30m`, `ConnMaxIdleTime=5m` on the Postgres pool
- Prevents the ephemeral-port exhaustion that contributed to the 2026-04-15 fetcher outage

## Why

Herald's `sql.DB` pool was using Go's defaults: `MaxOpenConns=0` (unlimited) and `MaxIdleConns=2`. Under the `max_parallel: 8` AI worker load, 6 of every 8 conns get destroyed after each use (exceeds MaxIdle=2). Each teardown leaves a TIME_WAIT socket, and during a failure storm (AI breaker open, tight retry loop) the fetcher burned through the ephemeral port range, producing:

```
connect: cannot assign requested address
```

MaxIdle=MaxOpen keeps all conns warm so concurrent workers reuse rather than churn. Lifetime/IdleTime let conns rotate cleanly without holding them forever.

Investigation details in #65.

## What this does NOT fix

This bounds the damage but doesn't prevent the underlying hot loop. Deeper fixes tracked separately:

- #63 — circuit breaker requires process restart (no half-open recovery)
- #64 — fetcher hot-loops on articles that fail to score

## Test plan

- [x] `task test` (full suite) passes
- [x] `golangci-lint run ./internal/storage/...` clean
- [x] New `TestNewPostgresStorePoolLimits` verifies `MaxOpenConnections` via `DBStats` — passes locally against postgres:16
- [ ] Deployed in production; monitor for any pool-saturation waits (unlikely at 25)