### PR TITLE
Drop unnecessary approve step from dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: dependabot/fetch-metadata@v3
         id: metadata
-      - run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Removes \`gh pr review --approve\` step from \`dependabot-auto-merge.yml\`
- Step always failed: GITHUB_TOKEN cannot approve PRs by default

## Why
Branch protection on this repo does not require reviews — only required status checks. The approve step was unnecessary and was blocking the subsequent auto-merge step from running, so every dependabot PR had to be merged manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)