### PR TITLE
Skip-reason sentinel + fix early-return when no feeds are due

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with bounded parallelism (Ollama.MaxParallel), stores a sentinel
   on error / too-short content to prevent infinite retries.
 
+- **Summary backfill now distinguishes deterministic rejections.**
+  When the model returns a summary longer than the original content
+  (too-short content) or longer than `MaxSummaryLength + 15%` (model
+  rambling), the article is marked with a `skip_reason` and dropped
+  from the backfill set — no more retrying these every cycle.
+  Transient errors (Ollama timeout, garbled output that
+  `LooksLikeGarbage` matches) continue to retry as before.
+
 ### Changed
+
+- **`article_summaries` schema gains nullable `skip_reason TEXT`
+  column.** A non-null value with empty `ai_summary` marks a
+  sentinel row (deterministic rejection). A successful re-summary
+  via `UpdateArticleAISummary` clears the skip_reason. Migration is
+  idempotent ALTER TABLE — no data conversion needed.
 
 - **Embedding configuration moved from YAML to environment variables.**
   The embedder is now built from `EMBEDDING_BACKEND`, `EMBEDDING_BASE_URL`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Transient errors (Ollama timeout, garbled output that
   `LooksLikeGarbage` matches) continue to retry as before.
 
+### Fixed
+
+- **Daemon AI passes ran only on cycles with at least one feed due
+  to fetch.** With adaptive fetch scheduling, `next_fetch_at`
+  staggers across feeds, so it's common for an individual cycle to
+  have zero due. The early-return on `len(subscribedFeeds) == 0`
+  bypassed AI processing entirely on those cycles — the
+  unscored-articles loop, summary backfill, and embedding backfill
+  never ran. Removed the early return; the fetch loop is naturally
+  a no-op when no feeds are due, but the AI passes downstream now
+  drain pending work as designed.
+
 ### Changed
 
 - **`article_summaries` schema gains nullable `skip_reason TEXT`

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -269,19 +269,27 @@ func backfillSummariesForUser(ctx context.Context, store storage.Store, processo
 				maxLen := appCfg.Summarization.MaxSummaryLength
 				summary, err := processor.SummarizeArticle(ctx, userID, article.Title, content, maxLen)
 				if err != nil {
+					// Transient — leave unsummarized, retry next cycle.
 					formatter.Warning("backfill summarization failed for article %d: %v", article.ID, err)
 					return
 				}
 				if herald.LooksLikeGarbage(summary) {
+					// Mostly load-related, sometimes recovers under lower load — retry.
 					formatter.Warning("discarding garbled backfill summary for article %d", article.ID)
 					return
 				}
+				// Deterministic rejections: the model can't compress this content
+				// any more than its existing form. Mark skipped so we stop retrying.
 				if len(summary) > len(content) {
-					formatter.Warning("discarding backfill summary for article %d: longer than content (%d > %d)", article.ID, len(summary), len(content))
+					reason := fmt.Sprintf("summary longer than content (%d > %d)", len(summary), len(content))
+					formatter.Warning("marking article %d summarization skipped: %s", article.ID, reason)
+					store.MarkSummarizationSkipped(userID, article.ID, reason) //nolint:errcheck
 					return
 				}
 				if maxLen > 0 && len(summary) > maxLen+maxLen*15/100 {
-					formatter.Warning("discarding backfill summary for article %d: exceeds max length by >15%% (%d > %d)", article.ID, len(summary), maxLen)
+					reason := fmt.Sprintf("summary exceeds max length by >15%% (%d > %d)", len(summary), maxLen)
+					formatter.Warning("marking article %d summarization skipped: %s", article.ID, reason)
+					store.MarkSummarizationSkipped(userID, article.ID, reason) //nolint:errcheck
 					return
 				}
 				if err := store.UpdateArticleAISummary(userID, article.ID, summary); err != nil {

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -722,15 +722,13 @@ func doFetch(ctx context.Context) error {
 	}
 	defer store.Close()
 
-	// Get all feeds that ANY user is subscribed to
+	// Get all feeds due to fetch this cycle. Adaptive scheduling stages
+	// next_fetch_at across feeds, so it's normal for an individual cycle to
+	// have zero due — the AI passes downstream still need to run to drain
+	// pending work from prior cycles, so we don't early-return on this.
 	subscribedFeeds, err := store.GetAllSubscribedFeeds()
 	if err != nil {
 		return fmt.Errorf("failed to get subscribed feeds: %w", err)
-	}
-
-	if len(subscribedFeeds) == 0 {
-		formatter.Warning("no feeds subscribed by any user")
-		return formatter.OutputFetchResult(&output.FetchResult{})
 	}
 
 	// Fetch each feed once (efficient)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -59,6 +59,8 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		"ALTER TABLE group_summaries ADD COLUMN IF NOT EXISTS headline TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE article_groups ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE read_state ADD COLUMN IF NOT EXISTS ai_retries INTEGER NOT NULL DEFAULT 0",
+		// Sentinel marker for summarization rejections that shouldn't be retried.
+		"ALTER TABLE article_summaries ADD COLUMN IF NOT EXISTS skip_reason TEXT",
 		// Full-text search: tsvector column with GIN index.
 		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS search_vector tsvector",
 		"CREATE INDEX IF NOT EXISTS idx_articles_search_vector ON articles USING gin(search_vector)",
@@ -1224,15 +1226,31 @@ func (s *PostgresStore) HasFilterRules(userID int64) (bool, error) {
 
 func (s *PostgresStore) UpdateArticleAISummary(userID, articleID int64, aiSummary string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary)
-		 VALUES (?, ?, ?)
+		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, ?, NULL)
 		 ON CONFLICT(user_id, article_id) DO UPDATE SET
-		   ai_summary = excluded.ai_summary,
+		   ai_summary = EXCLUDED.ai_summary,
+		   skip_reason = NULL,
 		   generated_at = NOW()`,
 		userID, articleID, aiSummary,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update AI summary: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) MarkSummarizationSkipped(userID, articleID int64, reason string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, '', ?)
+		 ON CONFLICT (user_id, article_id) DO UPDATE SET
+		   skip_reason = EXCLUDED.skip_reason,
+		   generated_at = NOW()`,
+		userID, articleID, reason,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark summarization skipped: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS article_summaries (
     user_id INTEGER NOT NULL DEFAULT 1,
     article_id INTEGER NOT NULL,
     ai_summary TEXT NOT NULL,
+    skip_reason TEXT,
     generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (user_id, article_id),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS article_summaries (
     user_id      BIGINT NOT NULL DEFAULT 1,
     article_id   BIGINT NOT NULL,
     ai_summary   TEXT NOT NULL,
+    skip_reason  TEXT,
     generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (user_id, article_id),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -262,6 +262,10 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		"ALTER TABLE article_groups ADD COLUMN embedding_model TEXT NOT NULL DEFAULT ''",
 		// Retry counter for AI pipeline failures (prevents infinite retry loops).
 		"ALTER TABLE read_state ADD COLUMN ai_retries INTEGER NOT NULL DEFAULT 0",
+		// Sentinel marker for summarization rejections that shouldn't be retried
+		// (summary longer than content, summary exceeds maxLen+15%). Non-null
+		// reason + empty ai_summary = "we tried, it didn't fit, don't retry."
+		"ALTER TABLE article_summaries ADD COLUMN skip_reason TEXT",
 		// FTS5 full-text search index (external-content, synced via triggers).
 		`CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
 			title, content, summary, linked_content,
@@ -1109,18 +1113,40 @@ func (s *SQLiteStore) GetArticlesByInterestScore(userID int64, threshold float64
 	return articles, scores, rows.Err()
 }
 
-// UpdateArticleAISummary stores the AI-generated summary for an article (per-user)
+// UpdateArticleAISummary stores the AI-generated summary for an article (per-user).
+// Clears any prior skip_reason so a previously-skipped article that later
+// summarizes successfully transitions back to a normal cached row.
 func (s *SQLiteStore) UpdateArticleAISummary(userID, articleID int64, aiSummary string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary)
-		 VALUES (?, ?, ?)
+		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, ?, NULL)
 		 ON CONFLICT(user_id, article_id) DO UPDATE SET
 		   ai_summary = excluded.ai_summary,
+		   skip_reason = NULL,
 		   generated_at = CURRENT_TIMESTAMP`,
 		userID, articleID, aiSummary,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update AI summary: %w", err)
+	}
+	return nil
+}
+
+// MarkSummarizationSkipped records a deterministic summarization rejection
+// (e.g., the model can't compress content shorter than the input). Stores an
+// empty ai_summary plus a non-null skip_reason so the article drops out of the
+// backfill set and isn't retried each cycle.
+func (s *SQLiteStore) MarkSummarizationSkipped(userID, articleID int64, reason string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, '', ?)
+		 ON CONFLICT(user_id, article_id) DO UPDATE SET
+		   skip_reason = excluded.skip_reason,
+		   generated_at = CURRENT_TIMESTAMP`,
+		userID, articleID, reason,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark summarization skipped: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1710,6 +1710,16 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		URL: "https://example.com/4", PublishedDate: &now,
 	})
 
+	// Article 5: scored, passed security, summarization marked SKIPPED — excluded.
+	a5, _ := store.AddArticle(&Article{
+		FeedID: feedID, GUID: "a5", Title: "Skipped — too short to compress",
+		URL: "https://example.com/5", PublishedDate: &now,
+	})
+	store.UpdateReadState(1, a5, false, &score, &sec, nil)
+	if err := store.MarkSummarizationSkipped(1, a5, "summary longer than content"); err != nil {
+		t.Fatalf("MarkSummarizationSkipped: %v", err)
+	}
+
 	got, err := store.GetUnsummarizedScoredArticles(1, 7.0, 100)
 	if err != nil {
 		t.Fatalf("GetUnsummarizedScoredArticles: %v", err)
@@ -1719,6 +1729,18 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 	}
 	if got[0].ID != a2 {
 		t.Errorf("expected article %d, got %d", a2, got[0].ID)
+	}
+
+	// Sanity: skipped article (a5) shouldn't show in the unsummarized count.
+	// a1 has a summary row, a5 has a sentinel row — both are excluded.
+	// a2 (scored, no summary), a3 (security-failed, no summary row written),
+	// and a4 (never scored, no summary row) are all counted.
+	count, err := store.GetUnsummarizedArticleCount(1)
+	if err != nil {
+		t.Fatalf("GetUnsummarizedArticleCount: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected unsummarized count 3 (a2 + a3 + a4), got %d", count)
 	}
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -111,6 +111,7 @@ type Store interface {
 
 	// Article summaries
 	UpdateArticleAISummary(userID, articleID int64, aiSummary string) error
+	MarkSummarizationSkipped(userID, articleID int64, reason string) error
 	GetArticleSummary(userID, articleID int64) (*ArticleSummary, error)
 
 	// Feed stats


### PR DESCRIPTION
## Summary

Two related changes:

1. **Bug fix:** Daemon AI passes only ran when at least one feed was due to fetch this cycle. Adaptive fetch scheduling (`next_fetch_at`) staggers feeds across cycles, so individual cycles often have 0 due. The early-return on `len(subscribedFeeds) == 0` was skipping the unscored loop, summary backfill, and embedding backfill on those cycles. Discovered while watching PR #73's deployment — fresh container saw all 80 active feeds with `next_fetch_at > NOW()` and bailed in 50ms each cycle.

2. **Skip-reason sentinel:** Summary backfill now marks deterministic rejections (summary > content, summary > maxLen+15%) with a `skip_reason` so they drop out of the backfill set instead of being re-attempted every cycle. Transient errors (Ollama timeout, `LooksLikeGarbage` matches) continue to retry as designed. Schema migration is idempotent ALTER TABLE.

## Test plan
- [x] `go test -race -count=1 ./...` passes
- [x] `task lint` clean
- [x] `TestGetUnsummarizedScoredArticles` extended to cover sentinel exclusion + unsummarized-count exclusion
- [ ] Watch deployment: cycle should report "Backfilled N missing AI summaries" and "Backfilled N article embeddings" lines
- [ ] Verify `unsummarized_scored` and `missing_embeddings` counts drop in postgres
- [ ] Verify some articles get `skip_reason` set instead of retrying forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)