### PR TITLE
Make config file mandatory; remove silent default fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI no longer silently falls back to a default config when the
+  config file is missing.** Earlier behavior: if `--config` pointed at
+  a nonexistent file (or the default `./config/config.yaml` didn't
+  exist), `loadConfig` quietly used `storage.DefaultConfig`. The result
+  was that an interactive `herald reset embeddings` invoked from `/`
+  inside the container — without the `--config /etc/herald/config.yaml`
+  flag the daemon passes — opened the default SQLite path instead of
+  the production Postgres, talked to an empty DB, and reported
+  nonsense like "no users with subscriptions" against a corpus of
+  19,000 articles.
+
+  Now: missing config is a hard error with a clear remediation hint
+  (run `herald init-config` or pass `--config <path>`). The
+  `init-config` subcommand carries a new `herald.skip-config-load`
+  cobra annotation so it can still bootstrap before any config exists.
+
 ### Added
 
 - **`herald reset embeddings` CLI.** Pure DB state mutator: clears

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -453,11 +453,19 @@ func updateGroupSummary(ctx context.Context, store storage.Store, processor *ai.
 	return nil
 }
 
+// annotationSkipConfigLoad marks a subcommand that bootstraps its own
+// config (e.g. init-config writes a fresh one). The persistent pre-run
+// skips loadConfig for these so they can run before any config exists.
+const annotationSkipConfigLoad = "herald.skip-config-load"
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "herald",
 		Short: "Your AI-powered news herald - intelligent RSS/Atom feed reader with AI curation",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Annotations[annotationSkipConfigLoad] == "true" {
+				return nil
+			}
 			return loadConfig()
 		},
 	}
@@ -485,16 +493,33 @@ func main() {
 	}
 }
 
+// defaultConfigPath is the search location for the config file when the
+// caller does not pass --config explicitly. Kept as a constant so tests
+// can refer to the same value without duplication.
+const defaultConfigPath = "./config/config.yaml"
+
+// loadConfig reads the YAML config from configPath into the package-level
+// cfg, layered over storage.DefaultConfig (so unset fields keep their
+// defaults).
+//
+// Missing-file is a hard error. Earlier versions silently fell back to a
+// pure-defaults config when the file didn't exist, which produced a
+// surprising "empty SQLite at the binary's CWD" when the running user
+// expected to be talking to their real database. Bootstrap commands that
+// need to run before any config exists (init-config) opt out via the
+// annotationSkipConfigLoad cobra annotation.
 func loadConfig() error {
 	if configPath == "" {
-		configPath = "./config/config.yaml"
+		configPath = defaultConfigPath
 	}
 
-	// Check if config exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		// Use default config
-		cfg = storage.DefaultConfig()
-		return nil
+		return fmt.Errorf("config file not found: %s\n"+
+			"  Create one with:  herald init-config [--config <path>]\n"+
+			"  Or point at an existing config:  --config <path>",
+			configPath)
+	} else if err != nil {
+		return fmt.Errorf("failed to stat config %s: %w", configPath, err)
 	}
 
 	data, err := os.ReadFile(configPath)
@@ -1008,9 +1033,12 @@ func initConfigCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init-config",
 		Short: "Create a default config file",
+		// init-config bootstraps the config file itself, so it must run
+		// before any config exists. Skip the persistent loadConfig.
+		Annotations: map[string]string{annotationSkipConfigLoad: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if configPath == "" {
-				configPath = "./config/config.yaml"
+				configPath = defaultConfigPath
 			}
 
 			// Create config directory

--- a/cmd/herald/main_test.go
+++ b/cmd/herald/main_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadConfig and the configPath/cfg globals are package-level state.
+// Each test saves and restores them so cases don't bleed into each other.
+func withGlobals(t *testing.T, fn func()) {
+	t.Helper()
+	savedPath := configPath
+	savedCfg := cfg
+	t.Cleanup(func() {
+		configPath = savedPath
+		cfg = savedCfg
+	})
+	fn()
+}
+
+func TestLoadConfig_MissingFileIsHardError(t *testing.T) {
+	withGlobals(t, func() {
+		configPath = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+		err := loadConfig()
+		if err == nil {
+			t.Fatalf("expected error for missing config, got nil")
+		}
+		// Error message should be actionable: mention init-config and --config.
+		msg := err.Error()
+		if !strings.Contains(msg, "init-config") {
+			t.Errorf("error missing init-config hint: %q", msg)
+		}
+		if !strings.Contains(msg, "--config") {
+			t.Errorf("error missing --config hint: %q", msg)
+		}
+		if !strings.Contains(msg, configPath) {
+			t.Errorf("error should include the missing path %q, got: %q", configPath, msg)
+		}
+	})
+}
+
+func TestLoadConfig_DefaultPathMissing(t *testing.T) {
+	// When --config is not passed AND the default path doesn't exist,
+	// we still error out (no silent fallback to defaults).
+	withGlobals(t, func() {
+		// Run from a temp dir so ./config/config.yaml is guaranteed missing.
+		dir := t.TempDir()
+		oldWd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+
+		configPath = "" // simulate no --config flag
+		err = loadConfig()
+		if err == nil {
+			t.Fatalf("expected error for missing default config, got nil")
+		}
+		if !strings.Contains(err.Error(), defaultConfigPath) {
+			t.Errorf("error should reference default path %q, got: %q", defaultConfigPath, err.Error())
+		}
+	})
+}
+
+func TestLoadConfig_ValidFile(t *testing.T) {
+	withGlobals(t, func() {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		// Minimal valid YAML — defaults fill in the rest.
+		body := []byte("database:\n  path: \"/tmp/test.db\"\n")
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			t.Fatalf("write tmp config: %v", err)
+		}
+		configPath = path
+		if err := loadConfig(); err != nil {
+			t.Fatalf("loadConfig on valid file: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("cfg should be non-nil after loadConfig")
+		}
+		if cfg.Database.Path != "/tmp/test.db" {
+			t.Errorf("Database.Path: got %q, want /tmp/test.db", cfg.Database.Path)
+		}
+	})
+}
+
+func TestInitConfigCmd_SkipsConfigLoad(t *testing.T) {
+	// init-config must be runnable before any config exists, so it
+	// carries the skip-config-load annotation. Without this annotation
+	// the bootstrap path would be impossible — loadConfig would error
+	// before init-config's RunE ever ran.
+	c := initConfigCmd()
+	if got := c.Annotations[annotationSkipConfigLoad]; got != "true" {
+		t.Errorf("init-config missing %q annotation: got %q, want \"true\"",
+			annotationSkipConfigLoad, got)
+	}
+}
+
+func TestPersistentPreRun_HonorsSkipAnnotation(t *testing.T) {
+	// Sanity check that the annotation actually wires into the rootCmd's
+	// PersistentPreRunE. We replicate the same logic the rootCmd uses
+	// (without spinning up cobra) and verify both branches.
+	withGlobals(t, func() {
+		configPath = filepath.Join(t.TempDir(), "missing.yaml")
+
+		// With the annotation: should be a no-op, no error.
+		annotated := map[string]string{annotationSkipConfigLoad: "true"}
+		if annotated[annotationSkipConfigLoad] != "true" {
+			t.Fatal("test setup wrong")
+		}
+		// Branch the same way main's PersistentPreRunE does.
+		var skipErr error
+		if annotated[annotationSkipConfigLoad] == "true" {
+			skipErr = nil
+		} else {
+			skipErr = loadConfig()
+		}
+		if skipErr != nil {
+			t.Errorf("annotated command should skip loadConfig, got: %v", skipErr)
+		}
+
+		// Without the annotation: loadConfig runs and errors on missing file.
+		unannotated := map[string]string{}
+		var loadErr error
+		if unannotated[annotationSkipConfigLoad] == "true" {
+			loadErr = nil
+		} else {
+			loadErr = loadConfig()
+		}
+		if loadErr == nil {
+			t.Errorf("unannotated command should error on missing config")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Missing config file is now a hard error with an actionable message (was: silent fallback to `storage.DefaultConfig`)
- `init-config` carries a new `herald.skip-config-load` cobra annotation so it can still bootstrap before any config exists
- Tests for: missing-file error wording, default-path-missing branch, valid-file happy path, init-config annotation contract

## Why

Caught this during the prod embedding-reset deploy yesterday. Running

```
docker exec herald-fetcher /usr/local/bin/herald reset embeddings -y
```

from `/` inside the container — without the `--config /etc/herald/config.yaml` flag the daemon already passes — silently opened the default SQLite path instead of the live Postgres, talked to an empty DB, and reported `"no users with subscriptions"` against a 19k-article corpus.

For a destructive command like `reset`, that's a footgun: the user thinks they're operating on prod data, the binary is happy to operate on whatever empty DB it finds at the default path. With this change you get a clear error and a hint at the right invocation.

## Test plan

- [x] `task test` — all green
- [x] `task lint` — 0 issues
- [x] Manual: `herald list` from a directory with no `./config/config.yaml` now errors cleanly; `herald init-config --config /tmp/test.yaml` still works (skip annotation honored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)