### PR TITLE
Fix silent AI false-positives caused by max_tokens exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AI calls now send `max_tokens` so reasoning models can finish.**
+  Reasoning-style chat models (Gemma 4, Qwen 3) burn 1500-2000
+  output tokens on a chain-of-thought trace before emitting any
+  response content. Without an explicit `max_tokens`, server-side
+  defaults (typically ~400) get fully consumed by reasoning, and
+  the JSON arrives empty. Herald previously labeled the empty
+  response `"Security response did not match expected JSON format
+  -- possible prompt injection"` and rejected the article — a
+  silent prompt-injection false alarm caused entirely by output
+  truncation. Now sends `max_tokens=2048` on every chat request,
+  which leaves room for reasoning plus a concise JSON object.
+  Empty-response is also given its own distinct error reason
+  (`"... returned no content (likely max_tokens exhausted by
+  model reasoning) -- not scored"`) so future regressions can be
+  diagnosed without conflating with injection signals.
+
+- **AI prompts updated to explicitly forbid markdown code fences
+  around JSON output.** Newer reasoning models tend to wrap their
+  JSON in ```` ```json ```` blocks even when the prompt asks for
+  raw JSON. herald's existing first-`{` to last-`}` extractor
+  tolerates the fences, but the explicit "do NOT wrap in code
+  fences" instruction reduces the failure surface and matches the
+  guidance already present in the newsletter and group_summary
+  prompts. Affected: security, curation, related_groups.
+
 - **CLI no longer silently falls back to a default config when the
   config file is missing.** Earlier behavior: if `--config` pointed at
   a nonexistent file (or the default `./config/config.yaml` didn't

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -116,10 +116,20 @@ func (c *openAIClient) isOpen() bool {
 	return true
 }
 
+// chatMaxTokens caps the model's response length. Sized for reasoning-style
+// models (Gemma 4, Qwen 3, etc.) that burn a substantial token budget on
+// chain-of-thought before producing output. With a tight cap, all tokens
+// are consumed by reasoning and the response content arrives empty —
+// herald then mis-labels the empty body as a malformed-JSON injection
+// attempt. 2048 leaves room for ~1500-2000 reasoning tokens plus a
+// concise JSON object (typically <100 tokens for our schemas).
+const chatMaxTokens = 2048
+
 type chatRequest struct {
 	Model       string        `json:"model"`
 	Messages    []chatMessage `json:"messages"`
 	Temperature float64       `json:"temperature,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
 	Stream      bool          `json:"stream"`
 }
 
@@ -163,6 +173,7 @@ func (c *openAIClient) generate(ctx context.Context, model, prompt string, tempe
 			{Role: "user", Content: prompt},
 		},
 		Temperature: temperature,
+		MaxTokens:   chatMaxTokens,
 		Stream:      false,
 	}
 

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -2,7 +2,9 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -233,5 +235,89 @@ func TestCircuitBreakerIgnores5xx(t *testing.T) {
 
 	if c.isOpen() {
 		t.Fatal("breaker should not trip on 5xx errors")
+	}
+}
+
+func TestGenerate_SendsMaxTokens(t *testing.T) {
+	// Reasoning-style models (Gemma 4, Qwen 3) burn most of their output
+	// budget on chain-of-thought before emitting JSON. Without an explicit
+	// max_tokens, the server-side default (often ~400) is consumed by the
+	// reasoning trace and the JSON arrives empty. herald must always send
+	// max_tokens so the budget is sized for both reasoning and output.
+	var captured chatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := newOpenAIClient(srv.URL, "")
+	if _, err := c.generate(context.Background(), "test-model", "hello", 0.1); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if captured.MaxTokens != chatMaxTokens {
+		t.Errorf("max_tokens: got %d, want %d", captured.MaxTokens, chatMaxTokens)
+	}
+}
+
+func TestExtractJSON_StripsMarkdownFences(t *testing.T) {
+	// Gemma 4 wraps JSON output in ```json ... ``` markdown fences even
+	// when the prompt asks for raw JSON. extractJSON's first-`{` to
+	// last-`}` scan is what makes this tolerable — it pulls the JSON
+	// out regardless of surrounding fences. A regression here would
+	// re-introduce the "Security response did not match expected JSON
+	// format" failure mode for every gemma4 article.
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			name: "fenced with language tag",
+			in:   "```json\n{\"safe\": true, \"score\": 10}\n```",
+			want: "{\"safe\": true, \"score\": 10}",
+		},
+		{
+			name: "fenced bare",
+			in:   "```\n{\"safe\": true}\n```",
+			want: "{\"safe\": true}",
+		},
+		{
+			name: "leading prose then fenced JSON",
+			in:   "Sure, here's my analysis:\n```json\n{\"score\": 7}\n```",
+			want: "{\"score\": 7}",
+		},
+		{
+			name: "raw JSON, no fence",
+			in:   "{\"safe\":false}",
+			want: "{\"safe\":false}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractJSON(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			// Verify the output is parseable — the whole point of
+			// extractJSON is to feed json.Unmarshal something valid.
+			var v map[string]interface{}
+			if err := json.Unmarshal([]byte(got), &v); err != nil {
+				t.Errorf("extracted JSON did not parse: %v (got %q)", err, got)
+			}
+		})
+	}
+}
+
+func TestExtractJSON_EmptyAndPlainText(t *testing.T) {
+	// extractJSON returns the input unchanged when there's no `{` to
+	// anchor on. The caller (SecurityCheck/CurateArticle) is then
+	// responsible for distinguishing empty from "JSON parse failed".
+	if got := extractJSON(""); got != "" {
+		t.Errorf("empty input: got %q, want empty", got)
+	}
+	if got := extractJSON("nothing useful here"); got != "nothing useful here" {
+		t.Errorf("no-brace input: got %q", got)
 	}
 }

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -104,8 +104,20 @@ func (p *AIProcessor) SecurityCheck(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("ollama security check failed: %w", err)
 	}
 
+	extracted := extractJSON(responseText)
+	if strings.TrimSpace(extracted) == "" {
+		// Empty content typically means the model burned its output budget
+		// on a reasoning trace before emitting JSON. Distinguish this from
+		// malformed-JSON so it isn't filed as a prompt-injection signal.
+		return &SecurityResult{
+			Safe:      false,
+			Score:     0,
+			Reasoning: "Security check returned no content (likely max_tokens exhausted by model reasoning) -- not scored",
+		}, nil
+	}
+
 	var result SecurityResult
-	if err := json.Unmarshal([]byte(extractJSON(responseText)), &result); err != nil {
+	if err := json.Unmarshal([]byte(extracted), &result); err != nil {
 		return &SecurityResult{
 			Safe:      false,
 			Score:     0,
@@ -152,8 +164,16 @@ func (p *AIProcessor) CurateArticle(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("ollama curation failed: %w", err)
 	}
 
+	extracted := extractJSON(responseText)
+	if strings.TrimSpace(extracted) == "" {
+		return &CurationResult{
+			InterestScore: 0,
+			Reasoning:     "Curation returned no content (likely max_tokens exhausted by model reasoning) -- not scored",
+		}, nil
+	}
+
 	var result CurationResult
-	if err := json.Unmarshal([]byte(extractJSON(responseText)), &result); err != nil {
+	if err := json.Unmarshal([]byte(extracted), &result); err != nil {
 		return &CurationResult{
 			InterestScore: 0,
 			Reasoning:     "Curation response did not match expected JSON format -- possible prompt injection",

--- a/internal/ai/prompts/curation.txt
+++ b/internal/ai/prompts/curation.txt
@@ -20,7 +20,10 @@ Score using the full range. High scores should be rare:
 
 Do not score follow-up articles, opinion pieces, or commentary about major events at 9-10 -- reserve those scores for first reports of genuinely breaking developments.
 
-Respond ONLY with valid JSON in this exact format:
+Respond ONLY with valid JSON in this exact format. Output the raw JSON
+object directly — do NOT wrap it in markdown code fences (no ```json
+or ``` blocks), do NOT prefix it with explanation or commentary, and
+keep your reasoning to a single sentence inside the JSON:
 {
   "interest_score": <0-10>,
   "reasoning": "<one sentence explanation>"

--- a/internal/ai/prompts/related_groups.txt
+++ b/internal/ai/prompts/related_groups.txt
@@ -38,7 +38,9 @@ Set create_group to false for:
 
 If create_group is true, include a display_name -- a 1-3 word sidebar label. Keep it very short: "Trade War", "AI Ethics", "Boeing Strike". No quotes, no articles (a/an/the), no punctuation.
 
-Respond ONLY with valid JSON:
+Respond ONLY with valid JSON in this exact format. Output the raw JSON
+object directly — do NOT wrap it in markdown code fences (no ```json
+or ``` blocks) and do NOT prefix it with explanation or commentary:
 {
   "is_related": true/false,
   "existing_groups": [<array of group IDs if is_related is true, empty array otherwise>],

--- a/internal/ai/prompts/security.txt
+++ b/internal/ai/prompts/security.txt
@@ -22,7 +22,10 @@ Title: {{.Title}}
 {{.Content}}
 </article>
 
-Respond ONLY with valid JSON in this exact format:
+Respond ONLY with valid JSON in this exact format. Output the raw JSON
+object directly — do NOT wrap it in markdown code fences (no ```json
+or ``` blocks), do NOT prefix it with explanation or commentary, and
+keep your reasoning to a single sentence inside the JSON:
 {
   "safe": true/false,
   "score": <0-10, where 10 is completely safe and 0 means confirmed malicious>,


### PR DESCRIPTION
## Summary

- `chatRequest` now sends `max_tokens=2048` (was: server default, ~400 on Lemonade)
- `SecurityCheck` and `CurateArticle` distinguish empty-response from malformed-JSON (so future failures diagnose cleanly)
- Security, curation, and related_groups prompts get an explicit "do NOT wrap in markdown code fences" instruction
- Tests for max_tokens being sent, `extractJSON` fence handling, empty-input behavior

## Why

Reasoning-style chat models (Gemma 4, Qwen 3) burn 1500-2000 output tokens on chain-of-thought before emitting JSON. With Lemonade's ~400-token default `max_tokens`, all output budget is consumed by reasoning and the response content arrives empty. herald then labeled the empty body `"Security response did not match expected JSON format -- possible prompt injection"` and rejected the article.

**~14% of production's 3,334 security failures (the 433 "JSON format" subset) trace to this single bug** — silent false-positive injection alarms caused by output truncation, not actual injection.

Reproduced empirically against gemma4:e4b on Lemonade with the live security prompt:

| max_tokens | finish_reason | content_len |
|---|---|---|
| 400 | `length` | **0** ← the broken state |
| 800 | `stop` | 92 |
| 2000 | `stop` | 113 |

## Test plan

- [x] `task test` — all green (new tests in `client_test.go`)
- [x] `task lint` — 0 issues
- [x] Manual: spot-checked the false-positive "Mid-Morning Art Thread" article — old gemma3:4b scored it 2 (false positive), new gemma4:e4b with this fix returns score 10 (correctly safe)
- [ ] After merge + deploy: run `herald reset-scores --security-only --below 7.0` and observe the failure rate. Expectation is the 433 "JSON format" failures evaporate; remaining ~2900 failures are real model judgments to be evaluated under gemma4:e4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)