### PR TITLE
Distinguish transient embedding errors from deterministic skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Embedding sentinel rows now distinguish transient errors from
+  deterministic skips.** Earlier behavior: every failed embed wrote
+  the same `[]byte{0}` sentinel, and `GetArticlesWithoutEmbeddings`
+  treated all sentinels as "row exists, skip forever." A 2026-05-09
+  03:30/03:53 UTC backend-saturation burst sentineled ~15,062
+  articles that should have valid embeddings — those rows were then
+  permanent skip-records that no future cycle would retry.
+
+  Now: `article_embeddings` gains `status SMALLINT`, `attempts INTEGER`,
+  and `error_message TEXT` columns. Three terminal states:
+  - `EmbedStatusOK` (0) — real vector stored, normal case
+  - `EmbedStatusTooShort` (1) — content below minimum length, never retried
+  - `EmbedStatusError` (2) — transient failure, retried while
+    `attempts < EmbedMaxAttempts` (5)
+
+  New storage methods `MarkArticleEmbeddingSkipped` and
+  `MarkArticleEmbeddingFailed` write the appropriate state; the
+  failed-path's `ON CONFLICT DO UPDATE` increments attempts on each
+  retry. `GetArticlesWithoutEmbeddings` returns rows that are
+  missing OR in error state with retries remaining.
+
+  Migration is idempotent: `ALTER TABLE` adds the columns with safe
+  defaults, then two `UPDATE` statements reclassify existing 1-byte
+  legacy sentinels — articles whose body is genuinely too short land
+  in `status=1` (permanent skip), everything else lands in `status=2`
+  (eligible for retry on the next backfill cycle).
+
+  `error_message` is the bonus the original incident motivated. Had
+  this column existed during the 03:30/03:53 burst, we'd have known
+  exactly what the cube/quad backends were saying. Going forward,
+  every error sentinel carries a diagnostic trail.
+
 - **AI calls now send `max_tokens` so reasoning models can finish.**
   Reasoning-style chat models (Gemma 4, Qwen 3) burn 1500-2000
   output tokens on a chain-of-thought trace before emitting any

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -318,7 +318,6 @@ func backfillEmbeddingsInCycle(ctx context.Context, store storage.Store, groupMa
 		maxParallel = 1
 	}
 
-	sentinel := []byte{0}
 	model := groupMatcher.Model()
 
 	var (
@@ -350,12 +349,12 @@ func backfillEmbeddingsInCycle(ctx context.Context, store storage.Store, groupMa
 				emb, err := groupMatcher.EmbedRecord(ctx, fields, body)
 				if err != nil {
 					formatter.Warning("backfill embed article %d: %v", a.ID, err)
-					store.StoreArticleEmbedding(a.ID, sentinel, model) //nolint:errcheck
+					store.MarkArticleEmbeddingFailed(a.ID, model, err.Error()) //nolint:errcheck
 					return
 				}
 				if emb == nil {
-					// Body too short to embed meaningfully.
-					store.StoreArticleEmbedding(a.ID, sentinel, model) //nolint:errcheck
+					// Body too short to embed meaningfully — deterministic skip.
+					store.MarkArticleEmbeddingSkipped(a.ID, model) //nolint:errcheck
 					return
 				}
 				if err := store.StoreArticleEmbedding(a.ID, embedding.EncodeFloat32s(emb), model); err != nil {

--- a/engine.go
+++ b/engine.go
@@ -536,15 +536,11 @@ func (e *Engine) BackfillEmbeddings(ctx context.Context, batchSize int) (int, er
 	if e.groupMatcher == nil {
 		return 0, fmt.Errorf("embedding not configured (no Ollama URL)")
 	}
-	articles, err := e.store.GetArticlesWithoutEmbeddings(e.groupMatcher.Model(), batchSize)
+	model := e.groupMatcher.Model()
+	articles, err := e.store.GetArticlesWithoutEmbeddings(model, batchSize)
 	if err != nil {
 		return 0, err
 	}
-	// Sentinel stored for articles that cannot be embedded (too short, too long,
-	// or embedding error). Prevents infinite retry loops. The single zero byte
-	// is ignored by semantic search because DecodeFloat32s produces an empty
-	// vector, which gets cosine similarity 0.
-	sentinel := []byte{0}
 
 	count := 0
 	for _, a := range articles {
@@ -552,15 +548,15 @@ func (e *Engine) BackfillEmbeddings(ctx context.Context, batchSize int) (int, er
 		emb, err := e.groupMatcher.EmbedRecord(ctx, fields, body)
 		if err != nil {
 			log.Printf("backfill embed article %d: %v", a.ID, err)
-			e.store.StoreArticleEmbedding(a.ID, sentinel, e.groupMatcher.Model()) //nolint:errcheck
+			e.store.MarkArticleEmbeddingFailed(a.ID, model, err.Error()) //nolint:errcheck
 			continue
 		}
 		if emb == nil {
-			// Body too short to embed meaningfully.
-			e.store.StoreArticleEmbedding(a.ID, sentinel, e.groupMatcher.Model()) //nolint:errcheck
+			// Body too short to embed meaningfully — deterministic skip.
+			e.store.MarkArticleEmbeddingSkipped(a.ID, model) //nolint:errcheck
 			continue
 		}
-		if err := e.store.StoreArticleEmbedding(a.ID, embedding.EncodeFloat32s(emb), e.groupMatcher.Model()); err != nil {
+		if err := e.store.StoreArticleEmbedding(a.ID, embedding.EncodeFloat32s(emb), model); err != nil {
 			log.Printf("backfill store embedding %d: %v", a.ID, err)
 			continue
 		}

--- a/internal/storage/embedding_status.go
+++ b/internal/storage/embedding_status.go
@@ -1,0 +1,34 @@
+package storage
+
+// EmbedStatus is the lifecycle state of an article_embeddings row.
+//
+// Stored as a SMALLINT in the database — 1-2 bytes vs ~5 for an enum-like
+// TEXT, and integer comparisons are cheaper than text comparisons if the
+// column ever needs an index. The constants below are the only valid
+// values; storage methods are the only writers, so the value space stays
+// closed without a CHECK constraint.
+type EmbedStatus int16
+
+const (
+	// EmbedStatusOK marks a row whose `embedding` column contains a valid
+	// vector. attempts=0, error_message=NULL.
+	EmbedStatusOK EmbedStatus = 0
+
+	// EmbedStatusTooShort marks a row that was deterministically skipped
+	// because the article body fell below the minimum embedding length.
+	// `embedding` holds placeholder bytes that the application never reads.
+	// Never retried — content is persistently too short.
+	EmbedStatusTooShort EmbedStatus = 1
+
+	// EmbedStatusError marks a row whose embed call failed transiently
+	// (backend error, network blip, model not loaded, etc.). Eligible for
+	// retry while `attempts < EmbedMaxAttempts`. error_message holds the
+	// last failure text for diagnosis.
+	EmbedStatusError EmbedStatus = 2
+)
+
+// EmbedMaxAttempts caps retries on EmbedStatusError rows. After this many
+// failures the row stays in the error state but is no longer returned by
+// GetArticlesWithoutEmbeddings — operators can manually clear sentinels
+// (e.g. via a "herald backfill embeddings" CLI) to reset the budget.
+const EmbedMaxAttempts = 5

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -61,6 +61,22 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		"ALTER TABLE read_state ADD COLUMN IF NOT EXISTS ai_retries INTEGER NOT NULL DEFAULT 0",
 		// Sentinel marker for summarization rejections that shouldn't be retried.
 		"ALTER TABLE article_summaries ADD COLUMN IF NOT EXISTS skip_reason TEXT",
+		// Embedding lifecycle state — see EmbedStatus* constants.
+		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS status SMALLINT NOT NULL DEFAULT 0",
+		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS error_message TEXT",
+		// Reclassify legacy 1-byte sentinels (see SQLite migration for rationale).
+		`UPDATE article_embeddings
+		 SET status = 1
+		 WHERE octet_length(embedding) = 1 AND status = 0
+		   AND article_id IN (
+		     SELECT id FROM articles
+		     WHERE octet_length(COALESCE(NULLIF(content, ''), summary, '')) < 200
+		   )`,
+		`UPDATE article_embeddings
+		 SET status = 2,
+		     error_message = 'migrated from legacy 1-byte sentinel — original error not preserved'
+		 WHERE octet_length(embedding) = 1 AND status = 0`,
 		// Full-text search: tsvector column with GIN index.
 		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS search_vector tsvector",
 		"CREATE INDEX IF NOT EXISTS idx_articles_search_vector ON articles USING gin(search_vector)",
@@ -2207,14 +2223,50 @@ func (s *PostgresStore) SearchArticlesFTS(userID int64, query string, limit, off
 	return scanArticles(rows)
 }
 
-// StoreArticleEmbedding upserts a per-article embedding vector.
+// StoreArticleEmbedding upserts a successful embedding vector. Resets
+// status, attempts, and error_message — see SQLiteStore for rationale.
 func (s *PostgresStore) StoreArticleEmbedding(articleID int64, embedding []byte, model string) error {
 	_, err := s.db.Exec(s.db.prepare(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model)
-		VALUES (?, ?, ?)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 0, NULL)
 		ON CONFLICT (article_id) DO UPDATE
-		SET embedding = EXCLUDED.embedding, embedding_model = EXCLUDED.embedding_model, created_at = NOW()`),
-		articleID, embedding, model)
+		SET embedding = EXCLUDED.embedding,
+		    embedding_model = EXCLUDED.embedding_model,
+		    status = ?,
+		    attempts = 0,
+		    error_message = NULL,
+		    created_at = NOW()`),
+		articleID, embedding, model, EmbedStatusOK, EmbedStatusOK)
+	return err
+}
+
+// MarkArticleEmbeddingSkipped — see SQLiteStore for behaviour.
+func (s *PostgresStore) MarkArticleEmbeddingSkipped(articleID int64, model string) error {
+	_, err := s.db.Exec(s.db.prepare(`
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 0, NULL)
+		ON CONFLICT (article_id) DO UPDATE
+		SET embedding_model = EXCLUDED.embedding_model,
+		    status = ?,
+		    attempts = 0,
+		    error_message = NULL,
+		    created_at = NOW()`),
+		articleID, embedSentinelBytes, model, EmbedStatusTooShort, EmbedStatusTooShort)
+	return err
+}
+
+// MarkArticleEmbeddingFailed — see SQLiteStore for behaviour.
+func (s *PostgresStore) MarkArticleEmbeddingFailed(articleID int64, model, errMsg string) error {
+	_, err := s.db.Exec(s.db.prepare(`
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 1, ?)
+		ON CONFLICT (article_id) DO UPDATE
+		SET embedding_model = EXCLUDED.embedding_model,
+		    status = ?,
+		    attempts = article_embeddings.attempts + 1,
+		    error_message = EXCLUDED.error_message,
+		    created_at = NOW()`),
+		articleID, embedSentinelBytes, model, EmbedStatusError, errMsg, EmbedStatusError)
 	return err
 }
 
@@ -2263,8 +2315,8 @@ func (s *PostgresStore) ResetAllGroupEmbeddings() (int64, error) {
 	return r.RowsAffected()
 }
 
-// GetArticlesWithoutEmbeddings returns articles that have no embedding for the
-// specified model. Used for backfill.
+// GetArticlesWithoutEmbeddings returns articles eligible for an embedding
+// pass under the given model. See SQLiteStore for retry-eligibility rules.
 func (s *PostgresStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error) {
 	rows, err := s.db.Query(s.db.prepare(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
@@ -2272,8 +2324,9 @@ func (s *PostgresStore) GetArticlesWithoutEmbeddings(model string, limit int) ([
 		FROM articles a
 		LEFT JOIN article_embeddings ae ON a.id = ae.article_id AND ae.embedding_model = ?
 		WHERE ae.article_id IS NULL
+		   OR (ae.status = ? AND ae.attempts < ?)
 		ORDER BY a.published_date DESC
-		LIMIT ?`), model, limit)
+		LIMIT ?`), model, EmbedStatusError, EmbedMaxAttempts, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get articles without embeddings: %w", err)
 	}

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -201,10 +201,18 @@ CREATE TABLE IF NOT EXISTS feed_favicons (
     FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
 );
 
+-- See storage.EmbedStatus* constants for the meaning of status codes:
+-- 0 = ok (real vector stored), 1 = too_short (deterministic skip, no
+-- retry), 2 = error (transient failure, retryable while attempts < 5).
+-- error_message holds the last error text when status=2; NULL otherwise,
+-- and is critical for post-mortem diagnosis of backend failures.
 CREATE TABLE IF NOT EXISTS article_embeddings (
     article_id INTEGER PRIMARY KEY,
     embedding BLOB NOT NULL,
     embedding_model TEXT NOT NULL,
+    status SMALLINT NOT NULL DEFAULT 0,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -206,10 +206,15 @@ CREATE TABLE IF NOT EXISTS feed_favicons (
     FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
 );
 
+-- See storage.EmbedStatus* constants for status codes (0=ok, 1=too_short,
+-- 2=error). error_message holds the last failure text when status=2.
 CREATE TABLE IF NOT EXISTS article_embeddings (
     article_id BIGINT PRIMARY KEY,
     embedding  BYTEA NOT NULL,
     embedding_model TEXT NOT NULL,
+    status SMALLINT NOT NULL DEFAULT 0,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -266,6 +266,27 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		// (summary longer than content, summary exceeds maxLen+15%). Non-null
 		// reason + empty ai_summary = "we tried, it didn't fit, don't retry."
 		"ALTER TABLE article_summaries ADD COLUMN skip_reason TEXT",
+		// Embedding lifecycle state. Replaces the legacy single-byte
+		// sentinel encoding that conflated transient errors with permanent
+		// skips. See EmbedStatus* constants.
+		"ALTER TABLE article_embeddings ADD COLUMN status SMALLINT NOT NULL DEFAULT 0",
+		"ALTER TABLE article_embeddings ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE article_embeddings ADD COLUMN error_message TEXT",
+		// Reclassify legacy 1-byte sentinels:
+		//   articles whose body is genuinely too short → status=1 (no retry)
+		//   everything else with a 1-byte sentinel    → status=2 (retryable)
+		// Idempotent: each UPDATE narrows by status=0 so re-running is a no-op.
+		`UPDATE article_embeddings
+		 SET status = 1
+		 WHERE octet_length(embedding) = 1 AND status = 0
+		   AND article_id IN (
+		     SELECT id FROM articles
+		     WHERE octet_length(COALESCE(NULLIF(content, ''), summary, '')) < 200
+		   )`,
+		`UPDATE article_embeddings
+		 SET status = 2,
+		     error_message = 'migrated from legacy 1-byte sentinel — original error not preserved'
+		 WHERE octet_length(embedding) = 1 AND status = 0`,
 		// FTS5 full-text search index (external-content, synced via triggers).
 		`CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
 			title, content, summary, linked_content,
@@ -2493,11 +2514,63 @@ func (s *SQLiteStore) SearchArticlesFTS(userID int64, query string, limit, offse
 	return scanArticles(rows)
 }
 
-// StoreArticleEmbedding upserts a per-article embedding vector.
+// StoreArticleEmbedding upserts a successful embedding vector. Resets
+// status to ok, attempts to 0, and clears any prior error_message — the
+// success "wins" over any prior error/skip state for this article.
 func (s *SQLiteStore) StoreArticleEmbedding(articleID int64, embedding []byte, model string) error {
 	_, err := s.db.Exec(`
-		INSERT OR REPLACE INTO article_embeddings (article_id, embedding, embedding_model)
-		VALUES (?, ?, ?)`, articleID, embedding, model)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 0, NULL)
+		ON CONFLICT(article_id) DO UPDATE SET
+			embedding = excluded.embedding,
+			embedding_model = excluded.embedding_model,
+			status = ?,
+			attempts = 0,
+			error_message = NULL,
+			created_at = CURRENT_TIMESTAMP`,
+		articleID, embedding, model, EmbedStatusOK, EmbedStatusOK)
+	return err
+}
+
+// embedSentinelBytes is the placeholder written to the embedding column
+// for non-ok status rows. The schema declares embedding NOT NULL, so we
+// need some bytes to satisfy the constraint; one byte distinguishes
+// these rows from real vectors (≥ 4 bytes for any single float32) and
+// matches the legacy sentinel encoding for backward compatibility.
+var embedSentinelBytes = []byte{0}
+
+// MarkArticleEmbeddingSkipped records a deterministic skip (e.g. body
+// too short to embed). status=too_short, attempts=0, error_message=NULL.
+// Never returned by GetArticlesWithoutEmbeddings — permanent skip.
+func (s *SQLiteStore) MarkArticleEmbeddingSkipped(articleID int64, model string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 0, NULL)
+		ON CONFLICT(article_id) DO UPDATE SET
+			embedding_model = excluded.embedding_model,
+			status = ?,
+			attempts = 0,
+			error_message = NULL,
+			created_at = CURRENT_TIMESTAMP`,
+		articleID, embedSentinelBytes, model, EmbedStatusTooShort, EmbedStatusTooShort)
+	return err
+}
+
+// MarkArticleEmbeddingFailed records a transient failure. status=error,
+// attempts=attempts+1 on update (1 on first insert), error_message captures
+// the failure text. Eligible for retry by GetArticlesWithoutEmbeddings
+// while attempts < EmbedMaxAttempts.
+func (s *SQLiteStore) MarkArticleEmbeddingFailed(articleID int64, model, errMsg string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
+		VALUES (?, ?, ?, ?, 1, ?)
+		ON CONFLICT(article_id) DO UPDATE SET
+			embedding_model = excluded.embedding_model,
+			status = ?,
+			attempts = article_embeddings.attempts + 1,
+			error_message = excluded.error_message,
+			created_at = CURRENT_TIMESTAMP`,
+		articleID, embedSentinelBytes, model, EmbedStatusError, errMsg, EmbedStatusError)
 	return err
 }
 
@@ -2557,8 +2630,12 @@ func (s *SQLiteStore) ResetAllGroupEmbeddings() (int64, error) {
 	return r.RowsAffected()
 }
 
-// GetArticlesWithoutEmbeddings returns articles that have no embedding for the
-// specified model. Used for backfill.
+// GetArticlesWithoutEmbeddings returns articles eligible for an embedding
+// pass under the given model: either no row exists yet for this model,
+// or the row is in error state with retries remaining. status=too_short
+// rows are NEVER returned (permanent skip). status=error rows are
+// retried until attempts reaches EmbedMaxAttempts, at which point they
+// stay sentineled but stop consuming retry budget.
 func (s *SQLiteStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error) {
 	rows, err := s.db.Query(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
@@ -2566,8 +2643,9 @@ func (s *SQLiteStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]A
 		FROM articles a
 		LEFT JOIN article_embeddings ae ON a.id = ae.article_id AND ae.embedding_model = ?
 		WHERE ae.article_id IS NULL
+		   OR (ae.status = ? AND ae.attempts < ?)
 		ORDER BY a.published_date DESC
-		LIMIT ?`, model, limit)
+		LIMIT ?`, model, EmbedStatusError, EmbedMaxAttempts, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get articles without embeddings: %w", err)
 	}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1928,6 +1929,124 @@ func TestStoreAndGetArticleEmbeddings(t *testing.T) {
 	}
 	if string(embs[0].Embedding) != string(newEmb) {
 		t.Errorf("embedding not updated after upsert")
+	}
+}
+
+func TestEmbeddingStatusLifecycle(t *testing.T) {
+	// Walks the full lifecycle of an article_embeddings row across the
+	// three terminal states (ok, too_short, error) and verifies that
+	// GetArticlesWithoutEmbeddings honors retry eligibility correctly.
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	userID := int64(1)
+	store.CreateUser("u")
+	feedID, _ := store.AddFeed("https://example.com/feed", "F", "")
+	store.SubscribeUserToFeed(userID, feedID)
+	now := time.Now()
+	addArticle := func(guid string) int64 {
+		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: guid, Title: guid, URL: "u/" + guid, Content: "x", PublishedDate: &now})
+		return id
+	}
+	a1 := addArticle("a1") // will get a real embedding
+	a2 := addArticle("a2") // will be marked too-short (deterministic skip)
+	a3 := addArticle("a3") // will be marked failed; retried; eventually maxes out
+	a4 := addArticle("a4") // will be left untouched (no row → eligible)
+
+	const model = "nomic-embed-text"
+
+	// 1. Real embedding for a1 — status=ok, attempts=0, no error_message.
+	if err := store.StoreArticleEmbedding(a1, []byte{1, 2, 3, 4}, model); err != nil {
+		t.Fatalf("StoreArticleEmbedding a1: %v", err)
+	}
+
+	// 2. Too-short skip for a2 — permanent, never returned again.
+	if err := store.MarkArticleEmbeddingSkipped(a2, model); err != nil {
+		t.Fatalf("MarkArticleEmbeddingSkipped a2: %v", err)
+	}
+
+	// 3. Transient failure for a3 — should be retry-eligible immediately.
+	if err := store.MarkArticleEmbeddingFailed(a3, model, "first attempt failed"); err != nil {
+		t.Fatalf("MarkArticleEmbeddingFailed a3 (1): %v", err)
+	}
+
+	missing, err := store.GetArticlesWithoutEmbeddings(model, 100)
+	if err != nil {
+		t.Fatalf("GetArticlesWithoutEmbeddings: %v", err)
+	}
+	gotIDs := make(map[int64]bool)
+	for _, a := range missing {
+		gotIDs[a.ID] = true
+	}
+	if !gotIDs[a3] {
+		t.Errorf("a3 (status=error, attempts=1) should be retry-eligible, missing from result")
+	}
+	if !gotIDs[a4] {
+		t.Errorf("a4 (no row) should be eligible, missing from result")
+	}
+	if gotIDs[a1] {
+		t.Errorf("a1 (status=ok) should NOT be returned")
+	}
+	if gotIDs[a2] {
+		t.Errorf("a2 (status=too_short) should NOT be returned — deterministic skip")
+	}
+
+	// 4. Burn through retries on a3 until attempts hits EmbedMaxAttempts.
+	// First MarkFailed already counted as attempt=1, so we need MaxAttempts-1 more
+	// calls to exhaust the budget.
+	for i := 1; i < EmbedMaxAttempts; i++ {
+		if err := store.MarkArticleEmbeddingFailed(a3, model, "retry failed"); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed a3 (retry %d): %v", i, err)
+		}
+	}
+	missing, _ = store.GetArticlesWithoutEmbeddings(model, 100)
+	for _, a := range missing {
+		if a.ID == a3 {
+			t.Errorf("a3 should be exhausted after %d failures, but is still retry-eligible", EmbedMaxAttempts)
+		}
+	}
+
+	// 5. Success after failures resets the row — attempts=0, status=ok.
+	if err := store.StoreArticleEmbedding(a3, []byte{5, 6, 7, 8}, model); err != nil {
+		t.Fatalf("StoreArticleEmbedding a3 (recovery): %v", err)
+	}
+	missing, _ = store.GetArticlesWithoutEmbeddings(model, 100)
+	for _, a := range missing {
+		if a.ID == a3 {
+			t.Errorf("a3 should not appear after successful re-embed")
+		}
+	}
+}
+
+func TestEmbeddingFailedAttemptsIncrement(t *testing.T) {
+	// Verify MarkArticleEmbeddingFailed increments attempts via the
+	// ON CONFLICT path. Without this, every retry would start at 1
+	// and the EmbedMaxAttempts cap would never trigger.
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+	store.CreateUser("u")
+	feedID, _ := store.AddFeed("https://example.com/feed", "F", "")
+	now := time.Now()
+	id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "x", Title: "x", URL: "u", Content: "x", PublishedDate: &now})
+
+	const model = "nomic-embed-text"
+	for i := 1; i <= 3; i++ {
+		if err := store.MarkArticleEmbeddingFailed(id, model, fmt.Sprintf("attempt %d", i)); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed iter %d: %v", i, err)
+		}
+	}
+
+	// After 3 calls, attempts should be 3 and the row should still be
+	// retry-eligible (3 < EmbedMaxAttempts=5).
+	missing, _ := store.GetArticlesWithoutEmbeddings(model, 100)
+	found := false
+	for _, a := range missing {
+		if a.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("after 3 attempts (< %d cap) row should still be retry-eligible", EmbedMaxAttempts)
 	}
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -139,6 +139,8 @@ type Store interface {
 	// Search
 	SearchArticlesFTS(userID int64, query string, limit, offset int) ([]Article, error)
 	StoreArticleEmbedding(articleID int64, embedding []byte, model string) error
+	MarkArticleEmbeddingSkipped(articleID int64, model string) error
+	MarkArticleEmbeddingFailed(articleID int64, model, errMsg string) error
 	GetArticleEmbeddings(userID int64, model string) ([]ArticleEmbeddingRow, error)
 	GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error)
 	ResetAllArticleEmbeddings() (int64, error)


### PR DESCRIPTION
## Summary

- New `status` / `attempts` / `error_message` columns on `article_embeddings`
- Three terminal states: `EmbedStatusOK` (0), `EmbedStatusTooShort` (1), `EmbedStatusError` (2)
- New storage methods `MarkArticleEmbeddingSkipped` and `MarkArticleEmbeddingFailed`
- `GetArticlesWithoutEmbeddings` retries error-state rows while `attempts < 5`
- Idempotent migration reclassifies the existing ~17k legacy 1-byte sentinels
- Tests for the full lifecycle and attempts-increment-on-conflict

## Why

Earlier behavior: every failed embed wrote the same `[]byte{0}` sentinel, and the daemon's GetArticlesWithoutEmbeddings query treated all sentinels as "row exists, skip forever." A 2026-05-09 03:30/03:53 UTC backend-saturation burst on cube/quad turned ~15,062 articles with embedable content into permanent skip-records.

Now: transient errors stay transient. Three states make the lifecycle explicit; `error_message` captures the failure text for diagnosis (the column the original incident really wanted).

Fixes the underlying class of bug from memstore task 3491. Companion PR for the `herald backfill embeddings` CLI (memstore task 3492) can land later — ad-hoc cleanup is unblocked by this PR's idempotent migration.

## Migration data flow

After deploy, the migration runs two `UPDATE` statements (idempotent — narrow on `status = 0` so re-runs are no-ops):

| Existing state | Reclassified to | Count (prod) |
|---|---|---|
| 1-byte sentinel + body < 200 chars | `status = 1` (too_short, permanent) | ~2,377 |
| 1-byte sentinel + body ≥ 200 chars | `status = 2` (error, retryable, attempts=0) | ~15,062 |
| Real vector ≥ 4 bytes | unchanged at `status = 0` | ~1,649 |

After the migration, the daemon's next cycle picks up the ~15,062 retryable rows and re-embeds them under the stable cube+quad load balancing (with max_parallel=4 from the homelab change).

## Test plan

- [x] `task test` — all green (new tests in `internal/storage/storage_test.go`)
- [x] `task lint` — 0 issues
- [x] Manual: `TestEmbeddingStatusLifecycle` walks ok → too_short → error → exhausted → recovered, asserting GetArticlesWithoutEmbeddings eligibility at each step
- [x] Manual: `TestEmbeddingFailedAttemptsIncrement` confirms ON CONFLICT DO UPDATE increments attempts (without this, retries would loop forever at attempts=1)
- [ ] After merge + deploy: verify the migration reclassified existing rows correctly via `SELECT status, COUNT(*) FROM article_embeddings GROUP BY status`
- [ ] Watch daemon refill the ~15k retryable rows over the next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)