### PR TITLE
Spread embedding retries across cycles via time-based eligibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ config/config.yaml
 # Claude Code / OMC state
 .omc/
 
+# direnv environment (contains DSNs and secrets for MCP servers)
+.envrc
+.envrc.local
+
 # Build output
 dist/
 

--- a/internal/storage/embedding_status.go
+++ b/internal/storage/embedding_status.go
@@ -1,5 +1,7 @@
 package storage
 
+import "time"
+
 // EmbedStatus is the lifecycle state of an article_embeddings row.
 //
 // Stored as a SMALLINT in the database — 1-2 bytes vs ~5 for an enum-like
@@ -32,3 +34,16 @@ const (
 // GetArticlesWithoutEmbeddings — operators can manually clear sentinels
 // (e.g. via a "herald backfill embeddings" CLI) to reset the budget.
 const EmbedMaxAttempts = 5
+
+// EmbedRetryCooldown is the minimum interval between retries on a
+// status=error row. The daemon's intra-cycle outer loop in
+// backfillEmbeddingsInCycle (and the equivalent CLI loop) repeatedly
+// calls GetArticlesWithoutEmbeddings until no work remains; without a
+// cooldown, a transient backend issue burns the full EmbedMaxAttempts
+// budget in seconds and the row becomes terminally errored. With this
+// cooldown, an article gets at most one retry per cooldown interval —
+// roughly one retry per daemon cycle at the default 30-minute pacing.
+//
+// Declared as var (not const) so tests can override to 0 for immediate
+// retry eligibility.
+var EmbedRetryCooldown = 30 * time.Minute

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -65,6 +65,8 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS status SMALLINT NOT NULL DEFAULT 0",
 		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS error_message TEXT",
+		// Time-based retry eligibility — see EmbedRetryCooldown.
+		"ALTER TABLE article_embeddings ADD COLUMN IF NOT EXISTS last_attempted_at TIMESTAMPTZ",
 		// Reclassify legacy 1-byte sentinels (see SQLite migration for rationale).
 		`UPDATE article_embeddings
 		 SET status = 1
@@ -2224,17 +2226,19 @@ func (s *PostgresStore) SearchArticlesFTS(userID int64, query string, limit, off
 }
 
 // StoreArticleEmbedding upserts a successful embedding vector. Resets
-// status, attempts, and error_message — see SQLiteStore for rationale.
+// status, attempts, error_message, and last_attempted_at —
+// see SQLiteStore for rationale.
 func (s *PostgresStore) StoreArticleEmbedding(articleID int64, embedding []byte, model string) error {
 	_, err := s.db.Exec(s.db.prepare(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 0, NULL)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 0, NULL, NULL)
 		ON CONFLICT (article_id) DO UPDATE
 		SET embedding = EXCLUDED.embedding,
 		    embedding_model = EXCLUDED.embedding_model,
 		    status = ?,
 		    attempts = 0,
 		    error_message = NULL,
+		    last_attempted_at = NULL,
 		    created_at = NOW()`),
 		articleID, embedding, model, EmbedStatusOK, EmbedStatusOK)
 	return err
@@ -2243,13 +2247,14 @@ func (s *PostgresStore) StoreArticleEmbedding(articleID int64, embedding []byte,
 // MarkArticleEmbeddingSkipped — see SQLiteStore for behaviour.
 func (s *PostgresStore) MarkArticleEmbeddingSkipped(articleID int64, model string) error {
 	_, err := s.db.Exec(s.db.prepare(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 0, NULL)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 0, NULL, NULL)
 		ON CONFLICT (article_id) DO UPDATE
 		SET embedding_model = EXCLUDED.embedding_model,
 		    status = ?,
 		    attempts = 0,
 		    error_message = NULL,
+		    last_attempted_at = NULL,
 		    created_at = NOW()`),
 		articleID, embedSentinelBytes, model, EmbedStatusTooShort, EmbedStatusTooShort)
 	return err
@@ -2258,13 +2263,14 @@ func (s *PostgresStore) MarkArticleEmbeddingSkipped(articleID int64, model strin
 // MarkArticleEmbeddingFailed — see SQLiteStore for behaviour.
 func (s *PostgresStore) MarkArticleEmbeddingFailed(articleID int64, model, errMsg string) error {
 	_, err := s.db.Exec(s.db.prepare(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 1, ?)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 1, ?, NOW())
 		ON CONFLICT (article_id) DO UPDATE
 		SET embedding_model = EXCLUDED.embedding_model,
 		    status = ?,
 		    attempts = article_embeddings.attempts + 1,
 		    error_message = EXCLUDED.error_message,
+		    last_attempted_at = NOW(),
 		    created_at = NOW()`),
 		articleID, embedSentinelBytes, model, EmbedStatusError, errMsg, EmbedStatusError)
 	return err
@@ -2318,15 +2324,17 @@ func (s *PostgresStore) ResetAllGroupEmbeddings() (int64, error) {
 // GetArticlesWithoutEmbeddings returns articles eligible for an embedding
 // pass under the given model. See SQLiteStore for retry-eligibility rules.
 func (s *PostgresStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error) {
+	cutoff := time.Now().UTC().Add(-EmbedRetryCooldown)
 	rows, err := s.db.Query(s.db.prepare(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		LEFT JOIN article_embeddings ae ON a.id = ae.article_id AND ae.embedding_model = ?
 		WHERE ae.article_id IS NULL
-		   OR (ae.status = ? AND ae.attempts < ?)
+		   OR (ae.status = ? AND ae.attempts < ?
+		       AND (ae.last_attempted_at IS NULL OR ae.last_attempted_at < ?))
 		ORDER BY a.published_date DESC
-		LIMIT ?`), model, EmbedStatusError, EmbedMaxAttempts, limit)
+		LIMIT ?`), model, EmbedStatusError, EmbedMaxAttempts, cutoff, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get articles without embeddings: %w", err)
 	}

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -213,6 +213,7 @@ CREATE TABLE IF NOT EXISTS article_embeddings (
     status SMALLINT NOT NULL DEFAULT 0,
     attempts INTEGER NOT NULL DEFAULT 0,
     error_message TEXT,
+    last_attempted_at DATETIME,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -215,6 +215,7 @@ CREATE TABLE IF NOT EXISTS article_embeddings (
     status SMALLINT NOT NULL DEFAULT 0,
     attempts INTEGER NOT NULL DEFAULT 0,
     error_message TEXT,
+    last_attempted_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -272,6 +272,10 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		"ALTER TABLE article_embeddings ADD COLUMN status SMALLINT NOT NULL DEFAULT 0",
 		"ALTER TABLE article_embeddings ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE article_embeddings ADD COLUMN error_message TEXT",
+		// Time-based retry eligibility — see EmbedRetryCooldown. Existing
+		// rows have NULL here, which the GetArticlesWithoutEmbeddings query
+		// treats as "no recorded attempt, eligible immediately."
+		"ALTER TABLE article_embeddings ADD COLUMN last_attempted_at DATETIME",
 		// Reclassify legacy 1-byte sentinels:
 		//   articles whose body is genuinely too short → status=1 (no retry)
 		//   everything else with a 1-byte sentinel    → status=2 (retryable)
@@ -2515,18 +2519,20 @@ func (s *SQLiteStore) SearchArticlesFTS(userID int64, query string, limit, offse
 }
 
 // StoreArticleEmbedding upserts a successful embedding vector. Resets
-// status to ok, attempts to 0, and clears any prior error_message — the
-// success "wins" over any prior error/skip state for this article.
+// status to ok, attempts to 0, and clears any prior error_message and
+// last_attempted_at — the success "wins" over any prior error/skip
+// state for this article.
 func (s *SQLiteStore) StoreArticleEmbedding(articleID int64, embedding []byte, model string) error {
 	_, err := s.db.Exec(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 0, NULL)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 0, NULL, NULL)
 		ON CONFLICT(article_id) DO UPDATE SET
 			embedding = excluded.embedding,
 			embedding_model = excluded.embedding_model,
 			status = ?,
 			attempts = 0,
 			error_message = NULL,
+			last_attempted_at = NULL,
 			created_at = CURRENT_TIMESTAMP`,
 		articleID, embedding, model, EmbedStatusOK, EmbedStatusOK)
 	return err
@@ -2544,13 +2550,14 @@ var embedSentinelBytes = []byte{0}
 // Never returned by GetArticlesWithoutEmbeddings — permanent skip.
 func (s *SQLiteStore) MarkArticleEmbeddingSkipped(articleID int64, model string) error {
 	_, err := s.db.Exec(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 0, NULL)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 0, NULL, NULL)
 		ON CONFLICT(article_id) DO UPDATE SET
 			embedding_model = excluded.embedding_model,
 			status = ?,
 			attempts = 0,
 			error_message = NULL,
+			last_attempted_at = NULL,
 			created_at = CURRENT_TIMESTAMP`,
 		articleID, embedSentinelBytes, model, EmbedStatusTooShort, EmbedStatusTooShort)
 	return err
@@ -2558,19 +2565,28 @@ func (s *SQLiteStore) MarkArticleEmbeddingSkipped(articleID int64, model string)
 
 // MarkArticleEmbeddingFailed records a transient failure. status=error,
 // attempts=attempts+1 on update (1 on first insert), error_message captures
-// the failure text. Eligible for retry by GetArticlesWithoutEmbeddings
-// while attempts < EmbedMaxAttempts.
+// the failure text, last_attempted_at = now() to gate the next retry by
+// EmbedRetryCooldown. Eligible for retry by GetArticlesWithoutEmbeddings
+// while attempts < EmbedMaxAttempts AND the cooldown has elapsed.
+//
+// last_attempted_at is bound as a Go time.Time (not CURRENT_TIMESTAMP)
+// so writes and the cutoff comparison in GetArticlesWithoutEmbeddings
+// share a single string format under the SQLite driver — mixing
+// CURRENT_TIMESTAMP ("YYYY-MM-DD HH:MM:SS") with driver-formatted
+// time.Time values broke the comparison subtly during cooldown checks.
 func (s *SQLiteStore) MarkArticleEmbeddingFailed(articleID int64, model, errMsg string) error {
+	now := time.Now().UTC()
 	_, err := s.db.Exec(`
-		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message)
-		VALUES (?, ?, ?, ?, 1, ?)
+		INSERT INTO article_embeddings (article_id, embedding, embedding_model, status, attempts, error_message, last_attempted_at)
+		VALUES (?, ?, ?, ?, 1, ?, ?)
 		ON CONFLICT(article_id) DO UPDATE SET
 			embedding_model = excluded.embedding_model,
 			status = ?,
 			attempts = article_embeddings.attempts + 1,
 			error_message = excluded.error_message,
-			created_at = CURRENT_TIMESTAMP`,
-		articleID, embedSentinelBytes, model, EmbedStatusError, errMsg, EmbedStatusError)
+			last_attempted_at = excluded.last_attempted_at,
+			created_at = excluded.last_attempted_at`,
+		articleID, embedSentinelBytes, model, EmbedStatusError, errMsg, now, EmbedStatusError)
 	return err
 }
 
@@ -2632,20 +2648,31 @@ func (s *SQLiteStore) ResetAllGroupEmbeddings() (int64, error) {
 
 // GetArticlesWithoutEmbeddings returns articles eligible for an embedding
 // pass under the given model: either no row exists yet for this model,
-// or the row is in error state with retries remaining. status=too_short
+// or the row is in error state with retries remaining AND the
+// EmbedRetryCooldown has elapsed since the last attempt. status=too_short
 // rows are NEVER returned (permanent skip). status=error rows are
 // retried until attempts reaches EmbedMaxAttempts, at which point they
 // stay sentineled but stop consuming retry budget.
+//
+// Rows migrated from before the cooldown column existed have
+// last_attempted_at IS NULL; those are eligible immediately, which is
+// the right behavior — we have no record of when they last failed.
 func (s *SQLiteStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error) {
+	// UTC matches the format used by MarkArticleEmbeddingFailed when
+	// writing last_attempted_at. Mixing local-time and UTC produces
+	// driver-formatted strings ("...-05:00" vs "...Z") that don't
+	// compare correctly under SQLite's string-based DATETIME compare.
+	cutoff := time.Now().UTC().Add(-EmbedRetryCooldown)
 	rows, err := s.db.Query(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		LEFT JOIN article_embeddings ae ON a.id = ae.article_id AND ae.embedding_model = ?
 		WHERE ae.article_id IS NULL
-		   OR (ae.status = ? AND ae.attempts < ?)
+		   OR (ae.status = ? AND ae.attempts < ?
+		       AND (ae.last_attempted_at IS NULL OR ae.last_attempted_at < ?))
 		ORDER BY a.published_date DESC
-		LIMIT ?`, model, EmbedStatusError, EmbedMaxAttempts, limit)
+		LIMIT ?`, model, EmbedStatusError, EmbedMaxAttempts, cutoff, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get articles without embeddings: %w", err)
 	}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1932,10 +1932,22 @@ func TestStoreAndGetArticleEmbeddings(t *testing.T) {
 	}
 }
 
+// disableEmbedRetryCooldown sets EmbedRetryCooldown to 0 for the duration
+// of the test. Required by tests that assert retry eligibility immediately
+// after MarkArticleEmbeddingFailed, which the production 30-minute cooldown
+// would otherwise block.
+func disableEmbedRetryCooldown(t *testing.T) {
+	t.Helper()
+	saved := EmbedRetryCooldown
+	EmbedRetryCooldown = 0
+	t.Cleanup(func() { EmbedRetryCooldown = saved })
+}
+
 func TestEmbeddingStatusLifecycle(t *testing.T) {
 	// Walks the full lifecycle of an article_embeddings row across the
 	// three terminal states (ok, too_short, error) and verifies that
 	// GetArticlesWithoutEmbeddings honors retry eligibility correctly.
+	disableEmbedRetryCooldown(t)
 	store, cleanup := newTestStore(t)
 	defer cleanup()
 
@@ -2022,6 +2034,7 @@ func TestEmbeddingFailedAttemptsIncrement(t *testing.T) {
 	// Verify MarkArticleEmbeddingFailed increments attempts via the
 	// ON CONFLICT path. Without this, every retry would start at 1
 	// and the EmbedMaxAttempts cap would never trigger.
+	disableEmbedRetryCooldown(t)
 	store, cleanup := newTestStore(t)
 	defer cleanup()
 	store.CreateUser("u")
@@ -2047,6 +2060,57 @@ func TestEmbeddingFailedAttemptsIncrement(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("after 3 attempts (< %d cap) row should still be retry-eligible", EmbedMaxAttempts)
+	}
+}
+
+func TestEmbeddingRetryCooldown(t *testing.T) {
+	// Verify that an article that just failed is NOT immediately retry-
+	// eligible while EmbedRetryCooldown is in effect. This is the fix
+	// for the 2026-05-09 burnout pathology where the daemon's intra-
+	// cycle outer loop would refetch a freshly-failed article and
+	// exhaust all 5 attempts within seconds during a transient backend
+	// outage.
+	saved := EmbedRetryCooldown
+	EmbedRetryCooldown = 30 * time.Minute
+	t.Cleanup(func() { EmbedRetryCooldown = saved })
+
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+	store.CreateUser("u")
+	feedID, _ := store.AddFeed("https://example.com/feed", "F", "")
+	now := time.Now()
+	id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "x", Title: "x", URL: "u", Content: "x", PublishedDate: &now})
+
+	const model = "nomic-embed-text"
+	if err := store.MarkArticleEmbeddingFailed(id, model, "transient"); err != nil {
+		t.Fatalf("MarkArticleEmbeddingFailed: %v", err)
+	}
+
+	// Cooldown active: row must NOT be returned even though attempts<5.
+	missing, err := store.GetArticlesWithoutEmbeddings(model, 100)
+	if err != nil {
+		t.Fatalf("GetArticlesWithoutEmbeddings during cooldown: %v", err)
+	}
+	for _, a := range missing {
+		if a.ID == id {
+			t.Errorf("article %d returned during cooldown — expected to be filtered out", id)
+		}
+	}
+
+	// Simulate cooldown elapsed by zeroing it; row should now be eligible.
+	EmbedRetryCooldown = 0
+	missing, err = store.GetArticlesWithoutEmbeddings(model, 100)
+	if err != nil {
+		t.Fatalf("GetArticlesWithoutEmbeddings after cooldown: %v", err)
+	}
+	found := false
+	for _, a := range missing {
+		if a.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("article %d not retry-eligible after cooldown elapsed", id)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the burnout pathology exposed by the 2026-05-09 incident: the daemon's intra-cycle outer loop in `backfillEmbeddingsInCycle` (and the equivalent CLI loop) refetches just-failed articles on the next iteration, exhausting the full `EmbedMaxAttempts=5` budget in seconds during a transient backend issue. Adds `last_attempted_at` to `article_embeddings` and gates retry eligibility by elapsed wall-clock time since the last attempt.

- `EmbedRetryCooldown = 30 * time.Minute` (var, so tests can disable)
- Row at status=2 only re-fetched if `last_attempted_at IS NULL OR last_attempted_at < now() - cooldown`
- Migration is idempotent `ALTER TABLE ADD COLUMN` for both SQLite and Postgres
- Existing rows (NULL `last_attempted_at`) eligible immediately — the right behavior since we have no record of when they last failed
- UTC matters: bind UTC time on both write and read so the modernc.org/sqlite driver produces matching `...Z` suffixes (mixing local `-05:00` and UTC `Z` compared as strings, not as times — caught during test development)

In prod this would have prevented the 2,742 articles that transitioned from migration-placeholder to terminal HTTP 403 during cycle 2 alone (after the olla rate-limit raise gave headroom but before the budget burnout was fixed).

Existing 4,792 terminal rows (all `attempts=5`) stay terminal — this prevents future burnout but doesn't recover past casualties. That recovery is the separate `herald backfill embeddings` CLI work (memstore task 3492).

Closes memstore task 3494.

## Test plan

- [x] `go test -race -count=1 ./...` — passes
- [x] `task lint` — 0 issues
- [x] `task vulncheck` — clean for this change (pre-existing stdlib vulns unrelated)
- [x] New `TestEmbeddingRetryCooldown` — row not eligible during cooldown, eligible after
- [x] Updated `TestEmbeddingStatusLifecycle` and `TestEmbeddingFailedAttemptsIncrement` to use the new `disableEmbedRetryCooldown` helper
- [ ] Post-deploy: monitor that newly-erroring articles spread retries across cycles instead of exhausting in one

🤖 Generated with [Claude Code](https://claude.com/claude-code)