### PR TITLE
Add --reset-errors flag to backfill-embeddings for stuck-row recovery

### DIFF
--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -1178,7 +1178,11 @@ Examples:
 }
 
 func backfillEmbeddingsCmd() *cobra.Command {
-	var batchSize int
+	var (
+		batchSize    int
+		resetErrors  bool
+		resetPattern string
+	)
 	cmd := &cobra.Command{
 		Use:   "backfill-embeddings",
 		Short: "Generate embeddings for articles that don't have them (for semantic search)",
@@ -1186,7 +1190,13 @@ func backfillEmbeddingsCmd() *cobra.Command {
 configured Ollama embedding model. Processes articles in batches until all
 articles have embeddings. Required for semantic search to return results.
 
-Existing embeddings are not regenerated unless the embedding model has changed.`,
+Existing embeddings are not regenerated unless the embedding model has changed.
+
+Use --reset-errors to clear the retry budget on rows that hit
+EmbedMaxAttempts (e.g. after a sustained backend outage). Combine with
+--reset-pattern to narrow the reset to a specific error class — for
+example, "%HTTP 403%" to retry only rate-limited rows after fixing the
+limiter, leaving rows stuck on other errors untouched.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
@@ -1199,6 +1209,18 @@ Existing embeddings are not regenerated unless the embedding model has changed.`
 				return fmt.Errorf("failed to create engine: %w", err)
 			}
 			defer engine.Close()
+
+			if resetErrors {
+				n, err := engine.ResetStuckEmbeddings(resetPattern)
+				if err != nil {
+					return fmt.Errorf("reset stuck embeddings: %w", err)
+				}
+				if resetPattern == "" {
+					fmt.Printf("Reset %d stuck embedding rows\n", n)
+				} else {
+					fmt.Printf("Reset %d stuck embedding rows matching %q\n", n, resetPattern)
+				}
+			}
 
 			total := 0
 			for {
@@ -1218,5 +1240,7 @@ Existing embeddings are not regenerated unless the embedding model has changed.`
 		},
 	}
 	cmd.Flags().IntVar(&batchSize, "batch", 50, "number of articles to process per batch")
+	cmd.Flags().BoolVar(&resetErrors, "reset-errors", false, "before backfill, clear retry budget on rows stuck at EmbedMaxAttempts so they get re-tried")
+	cmd.Flags().StringVar(&resetPattern, "reset-pattern", "", "optional SQL LIKE pattern narrowing --reset-errors to matching error_message values (e.g. '%HTTP 403%')")
 	return cmd
 }

--- a/engine.go
+++ b/engine.go
@@ -530,6 +530,23 @@ func BuildArticleEmbedInput(store storage.Store, a storage.Article) ([]embedding
 	return fields, body
 }
 
+// ResetStuckEmbeddings clears the retry budget on rows stuck at
+// EmbedMaxAttempts for the configured embedding model. errorPattern is
+// an optional SQL LIKE pattern (use "" for unfiltered) that narrows
+// the reset to matching error_message values. Returns the number of
+// rows reset.
+//
+// Pairs with the next BackfillEmbeddings call: reset rows have
+// last_attempted_at=NULL, so they're picked up immediately under the
+// retry-cooldown logic without waiting for the cooldown window.
+func (e *Engine) ResetStuckEmbeddings(errorPattern string) (int64, error) {
+	if e.groupMatcher == nil {
+		return 0, fmt.Errorf("embedding not configured (no Ollama URL)")
+	}
+	model := e.groupMatcher.Model()
+	return e.store.ResetStuckEmbeddings(model, errorPattern)
+}
+
 // BackfillEmbeddings generates embeddings for articles that don't have them yet.
 // Processes up to batchSize articles per call. Returns the count processed.
 func (e *Engine) BackfillEmbeddings(ctx context.Context, batchSize int) (int, error) {

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -2321,6 +2321,32 @@ func (s *PostgresStore) ResetAllGroupEmbeddings() (int64, error) {
 	return r.RowsAffected()
 }
 
+// ResetStuckEmbeddings — see SQLiteStore for behaviour.
+func (s *PostgresStore) ResetStuckEmbeddings(model, errorPattern string) (int64, error) {
+	var (
+		r   sql.Result
+		err error
+	)
+	if errorPattern == "" {
+		r, err = s.db.Exec(s.db.prepare(`
+			UPDATE article_embeddings
+			SET attempts = 0, last_attempted_at = NULL, error_message = NULL
+			WHERE embedding_model = ? AND status = ? AND attempts >= ?`),
+			model, EmbedStatusError, EmbedMaxAttempts)
+	} else {
+		r, err = s.db.Exec(s.db.prepare(`
+			UPDATE article_embeddings
+			SET attempts = 0, last_attempted_at = NULL, error_message = NULL
+			WHERE embedding_model = ? AND status = ? AND attempts >= ?
+			  AND error_message LIKE ?`),
+			model, EmbedStatusError, EmbedMaxAttempts, errorPattern)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reset stuck embeddings: %w", err)
+	}
+	return r.RowsAffected()
+}
+
 // GetArticlesWithoutEmbeddings returns articles eligible for an embedding
 // pass under the given model. See SQLiteStore for retry-eligibility rules.
 func (s *PostgresStore) GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2646,6 +2646,46 @@ func (s *SQLiteStore) ResetAllGroupEmbeddings() (int64, error) {
 	return r.RowsAffected()
 }
 
+// ResetStuckEmbeddings clears the retry budget on rows that exhausted
+// EmbedMaxAttempts. Sets attempts=0, last_attempted_at=NULL,
+// error_message=NULL on rows where status=error AND attempts >=
+// EmbedMaxAttempts AND embedding_model = model. The next backfill cycle
+// then picks them up again with a fresh budget.
+//
+// errorPattern is an optional SQL LIKE pattern (use "" for unfiltered).
+// Useful for narrowing the reset to a specific cause — e.g. resetting
+// only "%HTTP 403%" rows after fixing a rate-limit misconfiguration,
+// without touching rows stuck on a different error class.
+//
+// Status stays at EmbedStatusError so reset rows stay distinguishable
+// from never-attempted rows; the (status, attempts<5, last_attempted_at
+// IS NULL) shape is what GetArticlesWithoutEmbeddings looks for. Returns
+// the number of rows updated.
+func (s *SQLiteStore) ResetStuckEmbeddings(model, errorPattern string) (int64, error) {
+	var (
+		r   sql.Result
+		err error
+	)
+	if errorPattern == "" {
+		r, err = s.db.Exec(`
+			UPDATE article_embeddings
+			SET attempts = 0, last_attempted_at = NULL, error_message = NULL
+			WHERE embedding_model = ? AND status = ? AND attempts >= ?`,
+			model, EmbedStatusError, EmbedMaxAttempts)
+	} else {
+		r, err = s.db.Exec(`
+			UPDATE article_embeddings
+			SET attempts = 0, last_attempted_at = NULL, error_message = NULL
+			WHERE embedding_model = ? AND status = ? AND attempts >= ?
+			  AND error_message LIKE ?`,
+			model, EmbedStatusError, EmbedMaxAttempts, errorPattern)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reset stuck embeddings: %w", err)
+	}
+	return r.RowsAffected()
+}
+
 // GetArticlesWithoutEmbeddings returns articles eligible for an embedding
 // pass under the given model: either no row exists yet for this model,
 // or the row is in error state with retries remaining AND the

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2063,6 +2063,113 @@ func TestEmbeddingFailedAttemptsIncrement(t *testing.T) {
 	}
 }
 
+func TestResetStuckEmbeddings(t *testing.T) {
+	// Verify ResetStuckEmbeddings clears the retry budget on rows stuck
+	// at EmbedMaxAttempts, scopes to embedding_model, supports an
+	// optional error_message LIKE filter, and leaves non-stuck rows
+	// (status=ok, status=too_short, status=error with attempts<max)
+	// untouched.
+	disableEmbedRetryCooldown(t)
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	store.CreateUser("u")
+	feedID, _ := store.AddFeed("https://example.com/feed", "F", "")
+	now := time.Now()
+	addArticle := func(guid string) int64 {
+		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: guid, Title: guid, URL: "u/" + guid, Content: "x", PublishedDate: &now})
+		return id
+	}
+	stuck403 := addArticle("stuck403")     // status=error, attempts=max, "HTTP 403"
+	stuck400 := addArticle("stuck400")     // status=error, attempts=max, "HTTP 400 ctx"
+	progress := addArticle("progress")     // status=error, attempts=2, retryable
+	ok := addArticle("ok")                 // status=ok
+	tooShort := addArticle("tooShort")     // status=too_short
+	otherModel := addArticle("otherModel") // status=error, attempts=max, but different model
+
+	const model = "nomic-embed-text"
+	const otherModelName = "other-model"
+
+	// Set up: stuck403 hits max with HTTP 403 error.
+	for range EmbedMaxAttempts {
+		if err := store.MarkArticleEmbeddingFailed(stuck403, model, "openai embed: HTTP 403 Forbidden"); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed stuck403: %v", err)
+		}
+	}
+	// stuck400 hits max with a different error.
+	for range EmbedMaxAttempts {
+		if err := store.MarkArticleEmbeddingFailed(stuck400, model, "input length exceeds context length"); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed stuck400: %v", err)
+		}
+	}
+	// progress: only 2 attempts, still has retry budget.
+	for range 2 {
+		if err := store.MarkArticleEmbeddingFailed(progress, model, "transient"); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed progress: %v", err)
+		}
+	}
+	// ok: real embedding.
+	if err := store.StoreArticleEmbedding(ok, []byte{1, 2, 3, 4}, model); err != nil {
+		t.Fatalf("StoreArticleEmbedding ok: %v", err)
+	}
+	// tooShort: deterministic skip.
+	if err := store.MarkArticleEmbeddingSkipped(tooShort, model); err != nil {
+		t.Fatalf("MarkArticleEmbeddingSkipped tooShort: %v", err)
+	}
+	// otherModel: stuck under a different embedding_model.
+	for range EmbedMaxAttempts {
+		if err := store.MarkArticleEmbeddingFailed(otherModel, otherModelName, "HTTP 403 Forbidden"); err != nil {
+			t.Fatalf("MarkArticleEmbeddingFailed otherModel: %v", err)
+		}
+	}
+
+	// Pattern-narrowed reset: only HTTP 403 rows for the active model.
+	n, err := store.ResetStuckEmbeddings(model, "%HTTP 403%")
+	if err != nil {
+		t.Fatalf("ResetStuckEmbeddings(403): %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected to reset 1 row (stuck403), got %d", n)
+	}
+
+	missing, _ := store.GetArticlesWithoutEmbeddings(model, 100)
+	gotIDs := make(map[int64]bool)
+	for _, a := range missing {
+		gotIDs[a.ID] = true
+	}
+	if !gotIDs[stuck403] {
+		t.Errorf("stuck403 should be retry-eligible after reset")
+	}
+	if gotIDs[stuck400] {
+		t.Errorf("stuck400 should NOT be eligible — pattern excluded it")
+	}
+	if !gotIDs[progress] {
+		t.Errorf("progress (attempts<max, untouched) should still be retry-eligible")
+	}
+	if gotIDs[ok] || gotIDs[tooShort] {
+		t.Errorf("ok/tooShort should NOT be retry-eligible")
+	}
+
+	// Unfiltered reset: clears stuck400 too. otherModel stays stuck
+	// (different embedding_model).
+	n, err = store.ResetStuckEmbeddings(model, "")
+	if err != nil {
+		t.Fatalf("ResetStuckEmbeddings(all): %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected to reset 1 remaining row (stuck400), got %d", n)
+	}
+
+	// otherModel should still be stuck under its own model.
+	missingOther, _ := store.GetArticlesWithoutEmbeddings(otherModelName, 100)
+	for _, a := range missingOther {
+		if a.ID == otherModel {
+			// Should NOT be eligible — still attempts=max for its own model.
+			t.Errorf("otherModel reset leaked across embedding_model — should still be stuck")
+		}
+	}
+}
+
 func TestEmbeddingRetryCooldown(t *testing.T) {
 	// Verify that an article that just failed is NOT immediately retry-
 	// eligible while EmbedRetryCooldown is in effect. This is the fix

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -145,6 +145,7 @@ type Store interface {
 	GetArticlesWithoutEmbeddings(model string, limit int) ([]Article, error)
 	ResetAllArticleEmbeddings() (int64, error)
 	ResetAllGroupEmbeddings() (int64, error)
+	ResetStuckEmbeddings(model, errorPattern string) (int64, error)
 
 	// Newsletters
 	CreateNewsletter(n *Newsletter) (int64, error)


### PR DESCRIPTION
## Summary

Companion to PR #81. The retry-cooldown fix prevents future budget burnout but doesn't recover the ~4,792 rows already at `attempts=EmbedMaxAttempts` (3,988 HTTP 403 rate-limited before the olla bump, 773 HTTP 400 context-overflow, 31 other).

Adds an opt-in reset path on the existing subcommand:

```
herald backfill-embeddings --reset-errors
  # clear retry budget on all rows stuck at EmbedMaxAttempts, then backfill

herald backfill-embeddings --reset-errors --reset-pattern '%HTTP 403%'
  # narrow to a specific error class — useful when only some causes are remediable
```

The reset is a SQL UPDATE setting `attempts=0`, `last_attempted_at=NULL`, `error_message=NULL`. Status stays at `EmbedStatusError` so reset rows remain distinguishable from never-attempted rows. `GetArticlesWithoutEmbeddings` picks them up under the existing `(status=2 AND attempts<5 AND last_attempted_at IS NULL)` shape with no cooldown gating.

Scope:
- Filtered by `embedding_model` — an old-model reset can't accidentally re-process rows that wouldn't be retryable under the current model
- Pattern is parameterized (driver-level binding) — `%HTTP 403%`-style operator input flows through `?` placeholder, not string interpolation
- New `Engine.ResetStuckEmbeddings(errorPattern string)` wraps the store call with the engine's model resolution

Closes memstore task 3492.

## Operational plan

After merge + auto-deploy:

```bash
# Step 1: drain only the rate-limit rows under the new olla limits
docker exec herald-fetcher /usr/local/bin/herald backfill-embeddings \
    --reset-errors --reset-pattern '%HTTP 403%'
# Expected: ~3,988 reset, then re-embed under the post-bump rate limits

# Step 2 (later): the 773 HTTP 400 rows are context-overflow — those need
# the separate metadata-payload truncation work (memstore task 3496) before
# resetting them is useful. Leave them stuck until that lands.
```

## Test plan

- [x] `go test -race -count=1 ./...` — passes
- [x] `task lint` — 0 issues
- [x] New `TestResetStuckEmbeddings` covers: pattern-narrowed reset, unfiltered reset, model-scope isolation, non-stuck rows untouched
- [ ] Post-deploy: dry-run via prod psql/pg-mcp first to confirm the row count, then run the reset on docker-web

🤖 Generated with [Claude Code](https://claude.com/claude-code)