### PR TITLE
Gate summarization and curation behind the security check (#90)

### DIFF
--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/matthewjhunter/herald/internal/output"
 	"github.com/matthewjhunter/herald/internal/storage"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -105,7 +104,7 @@ func processArticlesForUser(ctx context.Context, store storage.Store, processor 
 				// Skip entire AI pipeline for articles too short to process meaningfully.
 				// Mark as scored with NULL security score — not a security failure, just
 				// insufficient content.
-				minLen := cfg.Summarization.MinArticleLength
+				minLen := appCfg.Summarization.MinArticleLength
 				if minLen > 0 && len(content) < minLen {
 					formatter.Warning("skipping article %d: content too short (%d < %d)", article.ID, len(content), minLen)
 					zeroInterest := 0.0
@@ -114,93 +113,14 @@ func processArticlesForUser(ctx context.Context, store storage.Store, processor 
 					return
 				}
 
-				// 1+2. Summarize and security check concurrently — they are independent.
-				var (
-					aiSummary string
-					secResult *ai.SecurityResult
-					secErr    error
-				)
-				g, gctx := errgroup.WithContext(ctx)
-
-				g.Go(func() error {
-					existing, err := store.GetArticleSummary(userID, article.ID)
-					if err != nil {
-						formatter.Warning("failed to check article summary for %d: %v", article.ID, err)
-						return nil // non-fatal
-					}
-					if existing != nil {
-						aiSummary = existing.AISummary
-						return nil
-					}
-					aiSummary, err = processor.SummarizeArticle(gctx, userID, article.Title, content, cfg.Summarization.MaxSummaryLength)
-					if err != nil {
-						formatter.Warning("summarization failed for article %d: %v", article.ID, err)
-						return nil // non-fatal: scoring can proceed without summary
-					}
-					if herald.LooksLikeGarbage(aiSummary) {
-						formatter.Warning("discarding garbled summary for article %d", article.ID)
-						aiSummary = ""
-					} else if err := store.UpdateArticleAISummary(userID, article.ID, aiSummary); err != nil {
-						formatter.Warning("failed to cache AI summary for %d: %v", article.ID, err)
-					}
-					return nil
-				})
-
-				g.Go(func() error {
-					secResult, secErr = processor.SecurityCheck(gctx, userID, article.Title, content)
-					return nil
-				})
-
-				g.Wait() //nolint:errcheck
-
-				if secErr != nil {
-					formatter.Warning("security check failed for article %d: %v", article.ID, secErr)
-					// Increment retry counter so the article is re-queued on the next
-					// cycle. After 3 failures it falls out of GetUnscoredArticlesForUser
-					// and won't be retried further.
-					store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+				// 1-3. Security screen gates summarization and interest scoring.
+				outcome := screenAndScoreArticle(ctx, processor, store, formatter, appCfg, userID, article, content)
+				if !outcome.scored {
 					return
 				}
-
-				mediumScore := appCfg.Thresholds.SecurityMediumScore
-				if mediumScore == 0 {
-					mediumScore = 4.0
-				}
-
-				if !secResult.Safe || secResult.Score < mediumScore {
-					// Hard block: below the lower threshold entirely.
-					secScore := secResult.Score
-					interestScore := 0.0
-					store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, nil) //nolint:errcheck
-					formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
-					return
-				}
-
-				if secResult.Score < appCfg.Thresholds.SecurityScore {
-					// Medium path: passes lower threshold but not full threshold.
-					// Let through without AI processing; flag for audit.
-					secScore := secResult.Score
-					interestScore := 0.0
-					flagged := true
-					store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, &flagged) //nolint:errcheck
-					formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
-					return
-				}
-
-				// 3. Interest scoring
-				curResult, err := processor.CurateArticle(ctx, userID, article.Title, content, appCfg.Preferences.Keywords)
-				if err != nil {
-					formatter.Warning("curation failed for article %d: %v", article.ID, err)
-					return
-				}
-
-				secScore := secResult.Score
-				interestScore := curResult.InterestScore
-				store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, nil) //nolint:errcheck
-				formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, true)
 
 				// 4. Vector-based group matching
-				matchedGroupID, articleEmb, err := groupMatcher.MatchArticleToGroup(ctx, userID, article.Title, aiSummary)
+				matchedGroupID, articleEmb, err := groupMatcher.MatchArticleToGroup(ctx, userID, article.Title, outcome.aiSummary)
 				if err != nil {
 					formatter.Warning("vector group match failed: %v", err)
 				}

--- a/cmd/herald/screen.go
+++ b/cmd/herald/screen.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+
+	herald "github.com/matthewjhunter/herald"
+	"github.com/matthewjhunter/herald/internal/ai"
+	"github.com/matthewjhunter/herald/internal/output"
+	"github.com/matthewjhunter/herald/internal/storage"
+	"golang.org/x/sync/errgroup"
+)
+
+// articleAI is the subset of *ai.AIProcessor used to screen and score a single
+// article. It is declared on the consumer side so the screening pipeline can be
+// unit-tested with a fake that records which model calls happen, and in what
+// order.
+type articleAI interface {
+	SecurityCheck(ctx context.Context, userID int64, title, content string) (*ai.SecurityResult, error)
+	SummarizeArticle(ctx context.Context, userID int64, title, content string, maxSummaryLength int) (string, error)
+	CurateArticle(ctx context.Context, userID int64, title, content string, keywords []string) (*ai.CurationResult, error)
+}
+
+// articleScoreStore is the subset of storage.Store that screenAndScoreArticle
+// persists through. Narrowed so tests need only a tiny fake.
+type articleScoreStore interface {
+	GetArticleSummary(userID, articleID int64) (*storage.ArticleSummary, error)
+	UpdateArticleAISummary(userID, articleID int64, aiSummary string) error
+	UpdateReadState(userID, articleID int64, read bool, interestScore, securityScore *float64, securityReason *string, securityFlagged *bool) error
+	IncrementAIRetries(userID, articleID int64) error
+}
+
+// screenOutcome reports what happened to one article so the caller can decide
+// whether to proceed to group matching.
+type screenOutcome struct {
+	scored    bool   // article passed security screening and was interest-scored
+	aiSummary string // summary for group matching (empty unless scored with a usable summary)
+}
+
+// screenAndScoreArticle runs the security screen for one article and, only if it
+// passes, summarizes and interest-scores it.
+//
+// The security check GATES every downstream model call: an article that fails
+// the screen, is hard-blocked, or is flagged at the medium threshold never
+// reaches the summarizer or curator, and no summary is generated or cached for
+// it. This fixes the prior structure, where summarization ran concurrently with
+// the security check and cached a summary regardless of the verdict (#90).
+func screenAndScoreArticle(ctx context.Context, aiProc articleAI, store articleScoreStore, formatter *output.Formatter, appCfg *storage.Config, userID int64, article storage.Article, content string) screenOutcome {
+	// 1. Security check first — it gates all downstream model calls.
+	secResult, err := aiProc.SecurityCheck(ctx, userID, article.Title, content)
+	if err != nil {
+		formatter.Warning("security check failed for article %d: %v", article.ID, err)
+		// Re-queue; after 3 failures the article falls out of the unscored query
+		// and is not retried further.
+		store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+		return screenOutcome{}
+	}
+
+	mediumScore := appCfg.Thresholds.SecurityMediumScore
+	if mediumScore == 0 {
+		mediumScore = 4.0
+	}
+
+	if !secResult.Safe || secResult.Score < mediumScore {
+		// Hard block: below the lower threshold entirely.
+		secScore := secResult.Score
+		interestScore := 0.0
+		store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, nil) //nolint:errcheck
+		formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
+		return screenOutcome{}
+	}
+
+	if secResult.Score < appCfg.Thresholds.SecurityScore {
+		// Medium: clears the lower threshold but not the full one. Let through
+		// without AI processing; flag for audit.
+		secScore := secResult.Score
+		interestScore := 0.0
+		flagged := true
+		store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, &flagged) //nolint:errcheck
+		formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
+		return screenOutcome{}
+	}
+
+	// Passed security screening. Summarize and curate concurrently — both
+	// operate only on screened content and are independent of each other.
+	var (
+		aiSummary string
+		curResult *ai.CurationResult
+		curErr    error
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		aiSummary = summarizeArticle(gctx, aiProc, store, formatter, appCfg, userID, article, content)
+		return nil
+	})
+	g.Go(func() error {
+		curResult, curErr = aiProc.CurateArticle(gctx, userID, article.Title, content, appCfg.Preferences.Keywords)
+		return nil
+	})
+	g.Wait() //nolint:errcheck
+
+	if curErr != nil {
+		formatter.Warning("curation failed for article %d: %v", article.ID, curErr)
+		return screenOutcome{}
+	}
+
+	secScore := secResult.Score
+	interestScore := curResult.InterestScore
+	store.UpdateReadState(userID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, nil) //nolint:errcheck
+	formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, true)
+	return screenOutcome{scored: true, aiSummary: aiSummary}
+}
+
+// summarizeArticle returns the cached summary if present, otherwise generates,
+// validates, and caches one. All failures are non-fatal (logged); it returns ""
+// when no usable summary is available.
+func summarizeArticle(ctx context.Context, aiProc articleAI, store articleScoreStore, formatter *output.Formatter, appCfg *storage.Config, userID int64, article storage.Article, content string) string {
+	existing, err := store.GetArticleSummary(userID, article.ID)
+	if err != nil {
+		formatter.Warning("failed to check article summary for %d: %v", article.ID, err)
+		return ""
+	}
+	if existing != nil {
+		return existing.AISummary
+	}
+	summary, err := aiProc.SummarizeArticle(ctx, userID, article.Title, content, appCfg.Summarization.MaxSummaryLength)
+	if err != nil {
+		formatter.Warning("summarization failed for article %d: %v", article.ID, err)
+		return ""
+	}
+	if herald.LooksLikeGarbage(summary) {
+		formatter.Warning("discarding garbled summary for article %d", article.ID)
+		return ""
+	}
+	if err := store.UpdateArticleAISummary(userID, article.ID, summary); err != nil {
+		formatter.Warning("failed to cache AI summary for %d: %v", article.ID, err)
+	}
+	return summary
+}

--- a/cmd/herald/screen_test.go
+++ b/cmd/herald/screen_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/matthewjhunter/herald/internal/ai"
+	"github.com/matthewjhunter/herald/internal/output"
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// fakeAI records which model calls happen, and in what order, so tests can
+// assert the security check gates the downstream summarizer and curator.
+type fakeAI struct {
+	mu    sync.Mutex
+	calls []string
+
+	sec    *ai.SecurityResult
+	secErr error
+	sum    string
+	sumErr error
+	cur    *ai.CurationResult
+	curErr error
+}
+
+func (f *fakeAI) record(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, name)
+}
+
+func (f *fakeAI) called(name string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Contains(f.calls, name)
+}
+
+func (f *fakeAI) firstCall() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return ""
+	}
+	return f.calls[0]
+}
+
+func (f *fakeAI) SecurityCheck(_ context.Context, _ int64, _, _ string) (*ai.SecurityResult, error) {
+	f.record("SecurityCheck")
+	return f.sec, f.secErr
+}
+
+func (f *fakeAI) SummarizeArticle(_ context.Context, _ int64, _, _ string, _ int) (string, error) {
+	f.record("SummarizeArticle")
+	return f.sum, f.sumErr
+}
+
+func (f *fakeAI) CurateArticle(_ context.Context, _ int64, _, _ string, _ []string) (*ai.CurationResult, error) {
+	f.record("CurateArticle")
+	return f.cur, f.curErr
+}
+
+type readStateCall struct {
+	interest *float64
+	security *float64
+	reason   *string
+	flagged  *bool
+}
+
+// fakeStore records the persistence calls screenAndScoreArticle makes.
+type fakeStore struct {
+	mu sync.Mutex
+
+	summary    *storage.ArticleSummary // returned by GetArticleSummary
+	summaryErr error
+
+	cacheCalled   bool
+	cachedSummary string
+	readStates    []readStateCall
+	retries       int
+}
+
+func (f *fakeStore) GetArticleSummary(_, _ int64) (*storage.ArticleSummary, error) {
+	return f.summary, f.summaryErr
+}
+
+func (f *fakeStore) UpdateArticleAISummary(_, _ int64, summary string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cacheCalled = true
+	f.cachedSummary = summary
+	return nil
+}
+
+func (f *fakeStore) UpdateReadState(_, _ int64, _ bool, interest, security *float64, reason *string, flagged *bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.readStates = append(f.readStates, readStateCall{interest, security, reason, flagged})
+	return nil
+}
+
+func (f *fakeStore) IncrementAIRetries(_, _ int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.retries++
+	return nil
+}
+
+func testConfig() *storage.Config {
+	cfg := &storage.Config{}
+	cfg.Thresholds.SecurityMediumScore = 4
+	cfg.Thresholds.SecurityScore = 7
+	cfg.Summarization.MaxSummaryLength = 200
+	cfg.Preferences.Keywords = []string{"go"}
+	return cfg
+}
+
+func discardFormatter() *output.Formatter {
+	return output.NewFormatterWithWriters(output.FormatText, io.Discard, io.Discard)
+}
+
+func runScreen(aiProc articleAI, store articleScoreStore) screenOutcome {
+	return screenAndScoreArticle(
+		context.Background(), aiProc, store, discardFormatter(),
+		testConfig(), 1, storage.Article{ID: 1, Title: "T", Content: "body"}, "body content",
+	)
+}
+
+// The core #90 regression: a passing article is screened BEFORE any downstream
+// model call, then summarized and curated.
+func TestScreenAndScore_PassRunsSecurityFirstThenScores(t *testing.T) {
+	f := &fakeAI{
+		sec: &ai.SecurityResult{Safe: true, Score: 9},
+		sum: "a usable summary",
+		cur: &ai.CurationResult{InterestScore: 8},
+	}
+	s := &fakeStore{}
+
+	out := runScreen(f, s)
+
+	if !out.scored {
+		t.Fatal("expected scored=true for a passing article")
+	}
+	if out.aiSummary != "a usable summary" {
+		t.Errorf("aiSummary = %q, want %q", out.aiSummary, "a usable summary")
+	}
+	if got := f.firstCall(); got != "SecurityCheck" {
+		t.Errorf("first AI call = %q, want SecurityCheck to gate the pipeline", got)
+	}
+	if !f.called("SummarizeArticle") || !f.called("CurateArticle") {
+		t.Errorf("passing article should be summarized and curated; calls=%v", f.calls)
+	}
+	if !s.cacheCalled || s.cachedSummary != "a usable summary" {
+		t.Errorf("expected summary to be cached; cacheCalled=%v cached=%q", s.cacheCalled, s.cachedSummary)
+	}
+	if len(s.readStates) != 1 || s.readStates[0].interest == nil || *s.readStates[0].interest != 8 {
+		t.Errorf("expected one read-state write with interest 8; got %+v", s.readStates)
+	}
+}
+
+// A hard-blocked article must never reach the summarizer or curator, and no
+// summary may be cached for it.
+func TestScreenAndScore_HardBlockSkipsDownstream(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sec  *ai.SecurityResult
+	}{
+		{"unsafe", &ai.SecurityResult{Safe: false, Score: 9}},
+		{"below medium threshold", &ai.SecurityResult{Safe: true, Score: 2}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeAI{sec: tc.sec}
+			s := &fakeStore{}
+
+			out := runScreen(f, s)
+
+			if out.scored {
+				t.Error("hard-blocked article must not be scored")
+			}
+			if f.called("SummarizeArticle") {
+				t.Error("hard-blocked article must NOT be summarized")
+			}
+			if f.called("CurateArticle") {
+				t.Error("hard-blocked article must NOT be curated")
+			}
+			if s.cacheCalled {
+				t.Error("no summary may be cached for a blocked article")
+			}
+			if len(s.readStates) != 1 || s.readStates[0].flagged != nil {
+				t.Errorf("expected one read-state write with flagged=nil; got %+v", s.readStates)
+			}
+		})
+	}
+}
+
+// A medium-flagged article (passes lower but not full threshold) is flagged for
+// audit and must NOT be summarized or curated.
+func TestScreenAndScore_MediumFlagSkipsDownstream(t *testing.T) {
+	f := &fakeAI{sec: &ai.SecurityResult{Safe: true, Score: 5}}
+	s := &fakeStore{}
+
+	out := runScreen(f, s)
+
+	if out.scored {
+		t.Error("medium-flagged article must not be scored")
+	}
+	if f.called("SummarizeArticle") || f.called("CurateArticle") {
+		t.Errorf("medium-flagged article must skip downstream models; calls=%v", f.calls)
+	}
+	if len(s.readStates) != 1 || s.readStates[0].flagged == nil || !*s.readStates[0].flagged {
+		t.Errorf("expected one read-state write with flagged=true; got %+v", s.readStates)
+	}
+}
+
+// A failed security check re-queues the article and runs nothing downstream.
+func TestScreenAndScore_SecurityErrorRetriesAndSkips(t *testing.T) {
+	f := &fakeAI{secErr: errors.New("model unreachable")}
+	s := &fakeStore{}
+
+	out := runScreen(f, s)
+
+	if out.scored {
+		t.Error("article must not be scored when the security check errors")
+	}
+	if f.called("SummarizeArticle") || f.called("CurateArticle") {
+		t.Errorf("no downstream model calls on security error; calls=%v", f.calls)
+	}
+	if s.retries != 1 {
+		t.Errorf("expected one retry increment, got %d", s.retries)
+	}
+	if len(s.readStates) != 0 {
+		t.Errorf("no read-state write on transient security error; got %+v", s.readStates)
+	}
+}
+
+// A passing article whose summary is already cached must not be re-summarized,
+// but is still curated and scored.
+func TestScreenAndScore_UsesCachedSummary(t *testing.T) {
+	f := &fakeAI{
+		sec: &ai.SecurityResult{Safe: true, Score: 9},
+		cur: &ai.CurationResult{InterestScore: 6},
+	}
+	s := &fakeStore{summary: &storage.ArticleSummary{AISummary: "cached summary"}}
+
+	out := runScreen(f, s)
+
+	if !out.scored {
+		t.Fatal("expected scored=true")
+	}
+	if out.aiSummary != "cached summary" {
+		t.Errorf("aiSummary = %q, want cached summary", out.aiSummary)
+	}
+	if f.called("SummarizeArticle") {
+		t.Error("should reuse the cached summary, not call SummarizeArticle")
+	}
+	if s.cacheCalled {
+		t.Error("should not re-cache an existing summary")
+	}
+}

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -191,8 +191,9 @@ func (p *AIProcessor) ListModels(ctx context.Context) ([]string, error) {
 // truncateText truncates text to maxLen characters.
 // maxPromptContentLen is the maximum number of characters of article content
 // sent to any AI model. All prompt stages (security, summarization, curation)
-// must use the same limit so the security check screens everything downstream
-// models will see.
+// use the same limit, and the article-processing pipeline runs the security
+// check before the summarizer and curator (see screenAndScoreArticle), so the
+// security screen always sees everything those downstream models will see.
 const maxPromptContentLen = 3000
 
 func truncateText(text string, maxLen int) string {


### PR DESCRIPTION
Closes #90.

## Problem

`processArticlesForUser` ran the security check **concurrently** with summarization in the same `errgroup`. So:
- the summarizer was exposed to unscreened content regardless of the security verdict;
- a summary was generated and **cached unconditionally** before the block/flag decision — even for articles the screen then hard-blocked or flagged (flagged articles are surfaced in the web UI per `c0e71bd`);
- the `maxPromptContentLen` comment claimed the shared limit meant "the security check screens everything downstream models will see," but the concurrent structure meant the screen did not gate the summarizer at all.

## Fix

Extract the per-article screen/score logic into `screenAndScoreArticle` (`cmd/herald/screen.go`), behind two narrow **consumer interfaces** (`articleAI`, `articleScoreStore`) so the ordering is unit-testable without a live LLM or the full `storage.Store`.

- The security check runs **first and alone**.
- A screen failure (retry), hard block, or medium flag returns **before** any summarizer or curator call — no summary is generated or cached for those articles.
- Only an article that clears the full security threshold is summarized and curated, now concurrently with each other (both operate on screened content).
- All prior behavior preserved: retry-on-error, hard-block/medium-flag persistence, curation-error return, cached-summary reuse, garbled-summary discard.

This also sets up the queued batch-by-model refactor, which can build on the extracted seam.

## Tests

`cmd/herald/screen_test.go` — fakes record AI call order and store writes:
- pass path: `SecurityCheck` runs first, then `SummarizeArticle` + `CurateArticle`; summary cached; interest score persisted;
- hard block (unsafe / below medium): downstream models **never called**, no summary cached;
- medium flag: downstream models **never called**, `flagged=true` persisted;
- security error: retry incremented, no downstream calls, no read-state write;
- cached summary: `SummarizeArticle` not re-called, still scored.

`go test -race -count=1 ./...` passes; `golangci-lint run ./cmd/herald/... ./internal/ai/...` reports 0 issues; `go build ./...` clean.

## Note

Branched off `main` (independent of #89). Both touch `internal/ai/ollama.go` in different regions; trivial to reconcile at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)