### PR TITLE
Apply modernize sweep across the module (#92)

### DIFF
--- a/cmd/herald-mcp/main.go
+++ b/cmd/herald-mcp/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	var kwList []string
 	if *keywords != "" {
-		for _, kw := range strings.Split(*keywords, ",") {
+		for kw := range strings.SplitSeq(*keywords, ",") {
 			if trimmed := strings.TrimSpace(kw); trimmed != "" {
 				kwList = append(kwList, trimmed)
 			}

--- a/cmd/herald-web/fever.go
+++ b/cmd/herald-web/fever.go
@@ -237,7 +237,7 @@ func (h *handlers) feverAddItems(userID int64, r *http.Request, resp map[string]
 
 	var withIDs []int64
 	if raw := r.FormValue("with_ids"); raw != "" {
-		for _, s := range strings.Split(raw, ",") {
+		for s := range strings.SplitSeq(raw, ",") {
 			if id, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64); err == nil {
 				withIDs = append(withIDs, id)
 			}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -40,18 +41,14 @@ func (h *handlers) isAdminCtx(ctx context.Context) bool {
 		role = "admin"
 	}
 	if claims := claimsFromContext(ctx); claims != nil {
-		for _, r := range claims.Roles {
-			if r == role {
-				return true
-			}
+		if slices.Contains(claims.Roles, role) {
+			return true
 		}
 	}
 	// Fallback: check the config email list.
 	if user := userFromContext(ctx); user != nil {
-		for _, email := range h.adminUsers {
-			if email == user.Email {
-				return true
-			}
+		if slices.Contains(h.adminUsers, user.Email) {
+			return true
 		}
 	}
 	return false

--- a/cmd/herald/embedding_drift.go
+++ b/cmd/herald/embedding_drift.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 
 	embedding "github.com/matthewjhunter/go-embedding"
 	herald "github.com/matthewjhunter/herald"
@@ -205,11 +206,11 @@ func printDriftSummary(rs []driftResult) {
 				count++
 			}
 		}
-		bar := ""
+		var bar strings.Builder
 		for i := 0; i < count; i++ {
-			bar += "#"
+			bar.WriteString("#")
 		}
-		fmt.Printf("  %-22s %3d  %s\n", b.label, count, bar)
+		fmt.Printf("  %-22s %3d  %s\n", b.label, count, bar.String())
 	}
 
 	sort.Slice(rs, func(i, j int) bool { return rs[i].Cosine < rs[j].Cosine })

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -54,10 +54,7 @@ func newGroupMatcher(store storage.Store, appCfg *storage.Config) (*ai.GroupMatc
 // Articles are processed in batches of 100 until the queue is empty.
 // Group summary updates are deferred until all batches complete.
 func processArticlesForUser(ctx context.Context, store storage.Store, processor *ai.AIProcessor, groupMatcher *ai.GroupMatcher, formatter *output.Formatter, appCfg *storage.Config, userID int64) (int, error) {
-	maxParallel := appCfg.Ollama.MaxParallel
-	if maxParallel < 1 {
-		maxParallel = 1
-	}
+	maxParallel := max(appCfg.Ollama.MaxParallel, 1)
 
 	var (
 		mu            sync.Mutex
@@ -249,10 +246,7 @@ func processArticlesForUser(ctx context.Context, store storage.Store, processor 
 // output) from previous cycles. Rejections (garbled, too-long) are logged but
 // not retry-bounded — systematic failures will be re-attempted each cycle.
 func backfillSummariesForUser(ctx context.Context, store storage.Store, processor *ai.AIProcessor, formatter *output.Formatter, appCfg *storage.Config, userID int64) (int, error) {
-	maxParallel := appCfg.Ollama.MaxParallel
-	if maxParallel < 1 {
-		maxParallel = 1
-	}
+	maxParallel := max(appCfg.Ollama.MaxParallel, 1)
 
 	var (
 		mu        sync.Mutex
@@ -334,10 +328,7 @@ func backfillSummariesForUser(ctx context.Context, store storage.Store, processo
 // for articles that error or are too short to embed, matching the engine
 // behavior — prevents infinite retries.
 func backfillEmbeddingsInCycle(ctx context.Context, store storage.Store, groupMatcher *ai.GroupMatcher, formatter *output.Formatter) (int, error) {
-	maxParallel := cfg.Ollama.MaxParallel
-	if maxParallel < 1 {
-		maxParallel = 1
-	}
+	maxParallel := max(cfg.Ollama.MaxParallel, 1)
 
 	model := groupMatcher.Model()
 

--- a/engine.go
+++ b/engine.go
@@ -87,10 +87,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		}
 	}
 
-	maxParallel := cfg.MaxParallel
-	if maxParallel < 1 {
-		maxParallel = 1
-	}
+	maxParallel := max(cfg.MaxParallel, 1)
 
 	var groupMatcher *ai.GroupMatcher
 	if !cfg.ReadOnly && cfg.OllamaBaseURL != "" {
@@ -468,10 +465,7 @@ func (e *Engine) Search(ctx context.Context, userID int64, query string, limit, 
 				})
 
 				// Take top N and merge.
-				n := limit
-				if n > len(candidates) {
-					n = len(candidates)
-				}
+				n := min(limit, len(candidates))
 				// Fetch full articles for semantic hits not already in FTS results.
 				for _, c := range candidates[:n] {
 					if existing, ok := resultMap[c.articleID]; ok {

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -302,7 +302,7 @@ func TestExtractJSON_StripsMarkdownFences(t *testing.T) {
 			}
 			// Verify the output is parseable — the whole point of
 			// extractJSON is to feed json.Unmarshal something valid.
-			var v map[string]interface{}
+			var v map[string]any
 			if err := json.Unmarshal([]byte(got), &v); err != nil {
 				t.Errorf("extracted JSON did not parse: %v (got %q)", err, got)
 			}

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -38,7 +38,7 @@ type CurationResult struct {
 
 // NewAIProcessor creates a new AI processor backed by an OpenAI-compatible
 // endpoint (LiteLLM, OpenAI, Ollama with --api-key, etc.).
-func NewAIProcessor(baseURL, securityModel, curationModel string, store interface{}, config interface{}) (*AIProcessor, error) {
+func NewAIProcessor(baseURL, securityModel, curationModel string, store any, config any) (*AIProcessor, error) {
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	}
@@ -66,7 +66,7 @@ func NewAIProcessor(baseURL, securityModel, curationModel string, store interfac
 }
 
 // newPromptLoaderSafe creates a PromptLoader with nil-safe type assertions.
-func newPromptLoaderSafe(store, config interface{}) *PromptLoader {
+func newPromptLoaderSafe(store, config any) *PromptLoader {
 	return &PromptLoader{
 		store:  store,
 		config: config,
@@ -81,7 +81,7 @@ func (p *AIProcessor) SecurityCheck(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("failed to load security prompt: %w", err)
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Title":   title,
 		"Content": truncateText(content, maxPromptContentLen),
 	}
@@ -140,7 +140,7 @@ func (p *AIProcessor) CurateArticle(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("failed to load curation prompt: %w", err)
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Title":    title,
 		"Content":  truncateText(content, maxPromptContentLen),
 		"Keywords": keywordStr,

--- a/internal/ai/prompts.go
+++ b/internal/ai/prompts.go
@@ -44,14 +44,14 @@ const (
 
 // PromptLoader handles 3-tier prompt loading: embedded -> config -> database
 type PromptLoader struct {
-	store  interface{}       // storage.Store
-	config interface{}       // *storage.Config
+	store  any               // storage.Store
+	config any               // *storage.Config
 	mu     sync.RWMutex      // protects cache
 	cache  map[string]string // cache of loaded prompts per user
 }
 
 // NewPromptLoader creates a new prompt loader
-func NewPromptLoader(store, config interface{}) *PromptLoader {
+func NewPromptLoader(store, config any) *PromptLoader {
 	return &PromptLoader{
 		store:  store,
 		config: config,
@@ -261,7 +261,7 @@ func (pl *PromptLoader) GetModel(userID int64, promptType PromptType) string {
 }
 
 // ExecutePrompt renders a prompt template with the given data
-func ExecutePrompt(promptTemplate string, data interface{}) (string, error) {
+func ExecutePrompt(promptTemplate string, data any) (string, error) {
 	tmpl, err := template.New("prompt").Parse(promptTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse prompt template: %w", err)

--- a/internal/ai/summarization.go
+++ b/internal/ai/summarization.go
@@ -17,7 +17,7 @@ func (p *AIProcessor) SummarizeArticle(ctx context.Context, userID int64, title,
 		return "", fmt.Errorf("failed to load summarization prompt: %w", err)
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Title":            title,
 		"Content":          truncateText(content, maxPromptContentLen),
 		"MaxSummaryLength": maxSummaryLength,
@@ -232,10 +232,7 @@ func (p *AIProcessor) FindRelatedGroups(ctx context.Context, userID int64, newAr
 			continue
 		}
 
-		sampleCount := len(articles)
-		if sampleCount > 3 {
-			sampleCount = 3
-		}
+		sampleCount := min(len(articles), 3)
 
 		var sampleTitles []string
 		for i := 0; i < sampleCount; i++ {

--- a/internal/feeds/favicon_test.go
+++ b/internal/feeds/favicon_test.go
@@ -267,8 +267,8 @@ func TestFetchFaviconsForFeeds_DoesNotRefetch(t *testing.T) {
 func makePNG(t *testing.T, w, h int) []byte {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			img.Set(x, y, color.RGBA{R: 100, G: 150, B: 200, A: 255})
 		}
 	}

--- a/internal/feeds/fulltext_test.go
+++ b/internal/feeds/fulltext_test.go
@@ -647,7 +647,7 @@ func newFullTextTestStore(t *testing.T) *storage.SQLiteStore {
 
 func repeatStr(s string, n int) string {
 	var b string
-	for i := 0; i < n; i++ {
+	for range n {
 		b += s
 	}
 	return b

--- a/internal/feeds/images.go
+++ b/internal/feeds/images.go
@@ -357,8 +357,8 @@ func drawNearest(dst *image.RGBA, src image.Image, srcBounds image.Rectangle) {
 	dh := dst.Bounds().Dy()
 	sw := srcBounds.Dx()
 	sh := srcBounds.Dy()
-	for y := 0; y < dh; y++ {
-		for x := 0; x < dw; x++ {
+	for y := range dh {
+		for x := range dw {
 			sx := x * sw / dw
 			sy := y * sh / dh
 			dst.Set(x, y, src.At(srcBounds.Min.X+sx, srcBounds.Min.Y+sy))

--- a/internal/feeds/images_test.go
+++ b/internal/feeds/images_test.go
@@ -55,7 +55,7 @@ func TestExtractImageURLs_Deduplicates(t *testing.T) {
 
 func TestExtractImageURLs_MaxCap(t *testing.T) {
 	var html string
-	for i := 0; i < maxImagesPerArticle+5; i++ {
+	for i := range maxImagesPerArticle + 5 {
 		html += fmt.Sprintf(`<img src="https://example.com/img%d.jpg">`, i)
 	}
 	urls := extractImageURLs(html, nil)
@@ -366,8 +366,8 @@ func TestResolveTwitterPics_ResolvesToImage(t *testing.T) {
 func makeJPEG(t *testing.T, w, h int) []byte {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			img.Set(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
 		}
 	}

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -215,7 +215,7 @@ func (f *Formatter) OutputHighInterestNotification(articles []storage.Article, s
 func (f *Formatter) OutputProcessingStatus(articleID int64, title string, interestScore, securityScore float64, safe bool) {
 	switch f.format {
 	case FormatJSON:
-		json.NewEncoder(f.out).Encode(map[string]interface{}{
+		json.NewEncoder(f.out).Encode(map[string]any{
 			"event":          "article_processed",
 			"article_id":     articleID,
 			"title":          title,
@@ -241,12 +241,12 @@ func (f *Formatter) OutputProcessingStatus(articleID int64, title string, intere
 }
 
 // Error outputs an error message to stderr
-func (f *Formatter) Error(format string, args ...interface{}) {
+func (f *Formatter) Error(format string, args ...any) {
 	fmt.Fprintf(f.err, format+"\n", args...)
 }
 
 // Warning outputs a warning message to stderr
-func (f *Formatter) Warning(format string, args ...interface{}) {
+func (f *Formatter) Warning(format string, args ...any) {
 	fmt.Fprintf(f.err, "Warning: "+format+"\n", args...)
 }
 

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -157,7 +157,7 @@ func TestOutputProcessingStatus_JSON(t *testing.T) {
 
 			f.OutputProcessingStatus(42, "Test Article", 7.5, 8.0, tt.safe)
 
-			var decoded map[string]interface{}
+			var decoded map[string]any
 			if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
 				t.Fatalf("failed to decode JSON: %v", err)
 			}
@@ -188,7 +188,7 @@ func TestOutputHighInterestNotification_JSON(t *testing.T) {
 		t.Fatalf("OutputHighInterestNotification failed: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
 		t.Fatalf("failed to decode JSON: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestOutputHighInterestNotification_JSON(t *testing.T) {
 	if decoded["type"] != "high_interest" {
 		t.Errorf("type = %v, want high_interest", decoded["type"])
 	}
-	decodedArticles, ok := decoded["articles"].([]interface{})
+	decodedArticles, ok := decoded["articles"].([]any)
 	if !ok || len(decodedArticles) != 1 {
 		t.Fatalf("expected 1 article in notification, got %v", decoded["articles"])
 	}

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -857,7 +857,7 @@ func migrateArticleImages(ctx context.Context, src *tracedDB, dst Store, article
 }
 
 // nullableTime converts a sql.NullTime to a *time.Time for use as a bind arg.
-func nullableTime(nt sql.NullTime) interface{} {
+func nullableTime(nt sql.NullTime) any {
 	if nt.Valid {
 		return nt.Time
 	}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -154,7 +154,7 @@ func (s *PostgresStore) computeFeedBaseInterval(feedID int64) time.Duration {
 	}
 	var medianGap time.Duration
 	if len(gaps) > 0 {
-		sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+		slices.Sort(gaps)
 		medianGap = gaps[len(gaps)/2]
 	}
 	return pickFetchIntervalPG(lastPostAge, medianGap)
@@ -453,7 +453,7 @@ func (s *PostgresStore) UpdateReadState(userID, articleID int64, read bool, inte
 	if interestScore != nil {
 		// AI pipeline: record scores, mark ai_scored=TRUE, do not overwrite user's read flag.
 		// security_flagged uses COALESCE so a nil caller arg preserves the existing value.
-		var flagVal interface{}
+		var flagVal any
 		if securityFlagged != nil {
 			flagVal = *securityFlagged
 		}
@@ -801,7 +801,7 @@ func (s *PostgresStore) GetArticlesByInterestScore(userID int64, threshold float
 		` + filterSQL + `
 		ORDER BY decayed_score DESC
 		LIMIT ? OFFSET ?`
-	args := []interface{}{userID, threshold}
+	args := []any{userID, threshold}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -843,7 +843,7 @@ func (s *PostgresStore) GetUnreadArticlesForUser(userID int64, limit, offset int
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?`
-	args := []interface{}{userID, userID, userID}
+	args := []any{userID, userID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -872,7 +872,7 @@ func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, off
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?`
-	args := []interface{}{userID, userID, feedID, userID}
+	args := []any{userID, userID, feedID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -1000,7 +1000,7 @@ func (s *PostgresStore) GetStarredArticles(userID int64, limit, offset int, filt
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?`
-	args := []interface{}{userID, userID}
+	args := []any{userID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -1221,16 +1221,16 @@ func (s *PostgresStore) AddFilterRule(rule *FilterRule) (int64, error) {
 
 func (s *PostgresStore) GetFilterRules(userID int64, feedID *int64) ([]FilterRule, error) {
 	var query string
-	var args []interface{}
+	var args []any
 	if feedID != nil {
 		query = `SELECT id, user_id, feed_id, axis, value, score, created_at
 				 FROM filter_rules WHERE user_id = ? AND (feed_id IS NULL OR feed_id = ?)
 				 ORDER BY axis, value`
-		args = []interface{}{userID, *feedID}
+		args = []any{userID, *feedID}
 	} else {
 		query = `SELECT id, user_id, feed_id, axis, value, score, created_at
 				 FROM filter_rules WHERE user_id = ? ORDER BY axis, value`
-		args = []interface{}{userID}
+		args = []any{userID}
 	}
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
@@ -1538,7 +1538,7 @@ func (s *PostgresStore) GetUnreadGroupArticles(userID, groupID int64, limit, off
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?`
-	args := []interface{}{userID, groupID, userID}
+	args := []any{userID, groupID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -2726,7 +2726,7 @@ func scanArticlesWithFlags(rows *sql.Rows) ([]Article, error) {
 
 // filterScoreClausePG is identical in logic to filterScoreClause but named
 // distinctly to avoid a duplicate-declaration collision with the SQLite version.
-func filterScoreClausePG(userID int64, threshold *int) (string, []interface{}) {
+func filterScoreClausePG(userID int64, threshold *int) (string, []any) {
 	if threshold == nil {
 		return "", nil
 	}
@@ -2749,5 +2749,5 @@ func filterScoreClausePG(userID int64, threshold *int) (string, []interface{}) {
 			  )
 		) >= ?
 	)`
-	return sql, []interface{}{userID, userID, *threshold}
+	return sql, []any{userID, userID, *threshold}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -433,7 +433,7 @@ func (s *SQLiteStore) computeFeedBaseInterval(feedID int64) time.Duration {
 	}
 	var medianGap time.Duration
 	if len(gaps) > 0 {
-		sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+		slices.Sort(gaps)
 		medianGap = gaps[len(gaps)/2]
 	}
 
@@ -475,10 +475,9 @@ func applyErrorBackoff(base time.Duration, consecutiveErrors int) time.Duration 
 	if consecutiveErrors <= 0 {
 		return base
 	}
-	n := consecutiveErrors
-	if n > 6 {
-		n = 6 // cap multiplier at 64×
-	}
+	n := min(consecutiveErrors,
+		// cap multiplier at 64×
+		6)
 	backoff := base * time.Duration(1<<n)
 	if max := 30 * 24 * time.Hour; backoff > max {
 		return max
@@ -1000,7 +999,7 @@ func (s *SQLiteStore) UpdateReadState(userID, articleID int64, read bool, intere
 	if interestScore != nil {
 		// AI pipeline: record scores, mark ai_scored=1, do not overwrite user's read flag.
 		// security_flagged uses COALESCE so a nil caller arg preserves the existing value.
-		var flagVal interface{}
+		var flagVal any
 		if securityFlagged != nil {
 			flagVal = *securityFlagged
 		}
@@ -1147,7 +1146,7 @@ func (s *SQLiteStore) GetArticlesByInterestScore(userID int64, threshold float64
 		ORDER BY decayed_score DESC
 		LIMIT ? OFFSET ?
 	`
-	args := []interface{}{userID, threshold}
+	args := []any{userID, threshold}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -1496,7 +1495,7 @@ func (s *SQLiteStore) GetUnreadGroupArticles(userID, groupID int64, limit, offse
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?
 	`
-	args := []interface{}{userID, groupID, userID}
+	args := []any{userID, groupID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -1939,7 +1938,7 @@ func (s *SQLiteStore) GetUnreadArticlesForUser(userID int64, limit, offset int, 
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?
 	`
-	args := []interface{}{userID, userID, userID}
+	args := []any{userID, userID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -1981,7 +1980,7 @@ func (s *SQLiteStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offse
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?
 	`
-	args := []interface{}{userID, userID, feedID, userID}
+	args := []any{userID, userID, feedID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -2091,7 +2090,7 @@ func (s *SQLiteStore) GetStarredArticles(userID int64, limit, offset int, filter
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?
 	`
-	args := []interface{}{userID, userID}
+	args := []any{userID, userID}
 	args = append(args, filterArgs...)
 	args = append(args, limit, offset)
 	rows, err := s.db.Query(query, args...)
@@ -2117,7 +2116,7 @@ func (s *SQLiteStore) GetStarredArticles(userID int64, limit, offset int, filter
 // filterScoreClause returns an SQL fragment and bind args that filter articles
 // by additive filter rule scoring. Returns ("", nil) when threshold is nil
 // (no filtering). The caller's query must alias the articles table as "a".
-func filterScoreClause(userID int64, threshold *int) (string, []interface{}) {
+func filterScoreClause(userID int64, threshold *int) (string, []any) {
 	if threshold == nil {
 		return "", nil
 	}
@@ -2140,7 +2139,7 @@ func filterScoreClause(userID int64, threshold *int) (string, []interface{}) {
 			  )
 		) >= ?
 	)`
-	return sql, []interface{}{userID, userID, *threshold}
+	return sql, []any{userID, userID, *threshold}
 }
 
 // --- Article metadata methods ---
@@ -2290,18 +2289,18 @@ func (s *SQLiteStore) AddFilterRule(rule *FilterRule) (int64, error) {
 // returns only rules scoped to that feed plus global rules. If nil, returns all.
 func (s *SQLiteStore) GetFilterRules(userID int64, feedID *int64) ([]FilterRule, error) {
 	var query string
-	var args []interface{}
+	var args []any
 
 	if feedID != nil {
 		query = `SELECT id, user_id, feed_id, axis, value, score, created_at
 				 FROM filter_rules WHERE user_id = ? AND (feed_id IS NULL OR feed_id = ?)
 				 ORDER BY axis, value`
-		args = []interface{}{userID, *feedID}
+		args = []any{userID, *feedID}
 	} else {
 		query = `SELECT id, user_id, feed_id, axis, value, score, created_at
 				 FROM filter_rules WHERE user_id = ?
 				 ORDER BY axis, value`
-		args = []interface{}{userID}
+		args = []any{userID}
 	}
 
 	rows, err := s.db.Query(query, args...)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -258,7 +258,7 @@ func TestGetArticlesByInterestScore(t *testing.T) {
 
 	// Add 3 articles with different interest scores: 6.0, 8.0, 9.0
 	scores := []float64{6.0, 8.0, 9.0}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		article := &Article{
 			FeedID:        feedID,
 			GUID:          string(rune('a' + i)),
@@ -1661,7 +1661,7 @@ func TestAIRetryLimit(t *testing.T) {
 	}
 
 	// Increment retries up to the limit (3).
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := store.IncrementAIRetries(1, articleID); err != nil {
 			t.Fatalf("IncrementAIRetries call %d: %v", i+1, err)
 		}


### PR DESCRIPTION
Closes #92.

Mechanical, behavior-preserving sweep from the gopls `modernize` analyzer (`-fix -test ./...`), applied module-wide:

- `interface{}` → `any`
- `min()` / `max()` builtins replacing manual clamp conditionals
- `slices.Contains` replacing membership-check loops
- range-over-int replacing index-only `for` loops
- `strings.Builder` replacing string concatenation in a loop

No `go.mod` change — all features are available at the module's Go version. 20 files, all small diffs.

`gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test -race -count=1 ./...`, and `golangci-lint run ./...` all pass (0 lint issues).

Deferred the issue's optional "wire modernize into CI" suggestion — keeping this PR to the sweep itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)