### PR TITLE
Sanitize HTML at every rendering output path (#91)

### DIFF
--- a/cmd/herald-web/fever.go
+++ b/cmd/herald-web/fever.go
@@ -278,6 +278,7 @@ func (h *handlers) feverAddItems(userID int64, r *http.Request, resp map[string]
 		if html == "" {
 			html = row.Summary
 		}
+		html = sanitizeHTML(html)
 
 		items[i] = feverItem{
 			ID:            row.ID,

--- a/cmd/herald-web/fever_test.go
+++ b/cmd/herald-web/fever_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// feverRequest issues an unauthenticated-JWT Fever API POST (Fever auth is via
+// the api_key form field, not the JWT cookie) and returns the decoded response.
+func feverRequest(t *testing.T, tf *testFixtures, form url.Values) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/fever/?api", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	tf.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("fever status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fever response: %v\nbody: %s", err, rr.Body.String())
+	}
+	return resp
+}
+
+// TestFeverItems_SanitizesXSS verifies the Fever API never emits raw feed HTML:
+// a hostile <script>/onerror payload in stored content must be stripped before
+// it reaches a rendering Fever client, while safe markup survives.
+func TestFeverItems_SanitizesXSS(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	const apiKey = "test-fever-key"
+	if err := tf.store.SetFeverCredential(tf.userID, apiKey); err != nil {
+		t.Fatalf("SetFeverCredential: %v", err)
+	}
+
+	pub := time.Now()
+	if _, err := tf.store.AddArticle(&storage.Article{
+		FeedID:        tf.feedID,
+		GUID:          "fever-xss",
+		Title:         "Fever XSS",
+		URL:           "https://example.com/fever-xss",
+		Content:       `<p>Safe content</p><script>alert('xss')</script><img src=x onerror="alert(1)">`,
+		PublishedDate: &pub,
+	}); err != nil {
+		t.Fatalf("AddArticle: %v", err)
+	}
+
+	resp := feverRequest(t, tf, url.Values{
+		"api_key": {apiKey},
+		"items":   {""},
+	})
+
+	if auth, _ := resp["auth"].(float64); auth != 1 {
+		t.Fatalf("expected authenticated response, got auth=%v", resp["auth"])
+	}
+
+	items, ok := resp["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected items in response, got %v", resp["items"])
+	}
+
+	var found bool
+	for _, raw := range items {
+		item, _ := raw.(map[string]any)
+		html, _ := item["html"].(string)
+		if !strings.Contains(html, "Safe content") {
+			continue
+		}
+		found = true
+		if strings.Contains(html, "<script>") {
+			t.Error("Fever html must not contain <script> tags")
+		}
+		if strings.Contains(html, "onerror") {
+			t.Error("Fever html must not contain event-handler attributes")
+		}
+	}
+	if !found {
+		t.Fatal("did not find the test article in Fever items")
+	}
+}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/infodancer/oidclient"
 	herald "github.com/matthewjhunter/herald"
 	"github.com/matthewjhunter/herald/internal/storage"
-	"github.com/microcosm-cc/bluemonday"
 )
 
 // handlers holds dependencies for all HTTP handler methods.
@@ -28,9 +27,8 @@ type handlers struct {
 	engine     *herald.Engine
 	validator  *oidclient.Client
 	pages      map[string]*template.Template // per-page template sets
-	policy     *bluemonday.Policy
-	adminRole  string   // JWT role value that grants admin access (default: "admin")
-	adminUsers []string // fallback email list when the IdP does not issue role claims
+	adminRole  string                        // JWT role value that grants admin access (default: "admin")
+	adminUsers []string                      // fallback email list when the IdP does not issue role claims
 }
 
 // isAdminCtx reports whether the request context carries admin privileges.
@@ -163,8 +161,6 @@ func (h *handlers) init() {
 		t := template.Must(template.New("").Funcs(funcMap).ParseFS(tmplFS, files...))
 		h.pages[page] = t
 	}
-
-	h.policy = bluemonday.UGCPolicy()
 }
 
 // --- Template data types ---
@@ -758,7 +754,7 @@ func (h *handlers) handleArticleView(w http.ResponseWriter, r *http.Request) {
 	}
 	seenImages := make(map[string]bool)
 	imageMap, _ := h.engine.GetArticleImageMap(article.ID)
-	sanitized := normalizeContentWithSeen(h.policy.Sanitize(content), seenImages)
+	sanitized := normalizeContentWithSeen(sanitizeHTML(content), seenImages)
 	if len(imageMap) > 0 {
 		sanitized = rewriteImageURLs(sanitized, imageMap)
 	}
@@ -791,7 +787,7 @@ func (h *handlers) handleArticleView(w http.ResponseWriter, r *http.Request) {
 			data.LinkedDomain = u.Hostname()
 		}
 		if article.LinkedContent != "" {
-			sanitizedLinked := normalizeContentWithSeen(h.policy.Sanitize(article.LinkedContent), seenImages)
+			sanitizedLinked := normalizeContentWithSeen(sanitizeHTML(article.LinkedContent), seenImages)
 			if len(imageMap) > 0 {
 				sanitizedLinked = rewriteImageURLs(sanitizedLinked, imageMap)
 			}
@@ -992,7 +988,7 @@ func (h *handlers) handleNewsletterView(w http.ResponseWriter, r *http.Request) 
 
 	if issue, err := h.engine.GetLatestNewsletterIssue(newsletterID); err == nil {
 		data.LatestIssue = issue
-		data.SanitizedHTML = template.HTML(h.policy.Sanitize(issue.ContentHTML)) //nolint:gosec
+		data.SanitizedHTML = template.HTML(sanitizeHTML(issue.ContentHTML)) //nolint:gosec
 		data.GeneratedFmt = formatDate(&issue.GeneratedAt)
 		if issue.SentAt != nil {
 			data.SentFmt = formatDate(issue.SentAt)
@@ -1111,7 +1107,7 @@ func (h *handlers) handleNewsletterIssueView(w http.ResponseWriter, r *http.Requ
 			EmailRecipient: nl.EmailRecipient, Enabled: nl.Enabled,
 		},
 		LatestIssue:   issue,
-		SanitizedHTML: template.HTML(h.policy.Sanitize(issue.ContentHTML)), //nolint:gosec
+		SanitizedHTML: template.HTML(sanitizeHTML(issue.ContentHTML)), //nolint:gosec
 		GeneratedFmt:  formatDate(&issue.GeneratedAt),
 	}
 	if issue.SentAt != nil {

--- a/cmd/herald-web/sanitize.go
+++ b/cmd/herald-web/sanitize.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/microcosm-cc/bluemonday"
+
+// htmlSanitizer is the single HTML sanitization policy applied to every
+// feed-derived field served to a client that renders it as HTML — the web
+// article view and the Fever API. bluemonday policies are immutable after
+// construction and safe for concurrent use, so one package-level instance
+// serves all requests.
+var htmlSanitizer = bluemonday.UGCPolicy()
+
+// sanitizeHTML strips disallowed tags and attributes (script, event handlers,
+// etc.) from untrusted feed HTML. Every HTML output path MUST route content
+// through here before emitting it — never serve row.Content/Summary raw, or a
+// hostile feed's stored markup becomes a client-side XSS vector.
+func sanitizeHTML(s string) string {
+	return htmlSanitizer.Sanitize(s)
+}


### PR DESCRIPTION
Closes #91.

## Problem

The Fever API item handler emitted article content into the `html` field with **no HTML sanitization** — only the ingest-time `sanitizeText` (null-byte / invalid-UTF-8 strip), which is not HTML sanitization. Fever clients (Reeder, FreshRSS apps) render that field as HTML, so a hostile feed's stored `<script>`/event-handler markup was a client-side XSS vector delivered through Herald. The web article view sanitized with bluemonday, but that policy lived only on the web handler; the Fever path bypassed it.

## Fix

- New `sanitize.go`: a single package-level `sanitizeHTML()` chokepoint backed by one `bluemonday.UGCPolicy()` instance.
- The Fever `html` field now routes through it.
- The web article view and both newsletter views call the same helper (previously bare `h.policy.Sanitize`).
- Removed the lazily-initialized `policy` struct field. This also fixes a **latent nil-policy panic**: the Fever path never calls `init()`, so `h.policy` would have been nil for a Fever-only client that synced before any browser page was rendered.

## Test

`TestFeverItems_SanitizesXSS` provisions a Fever key, stores an article with a `<script>`/`onerror` payload, hits `/fever/?items`, and asserts the payload is stripped while safe markup survives. Red before the fix, green after.

## Out of scope (separate finding, filed separately)

The MCP server and CLI formatter emit feed-derived `Summary`/`Content` as **text**, not HTML — not an XSS vector, but a terminal/control-char (ANSI escape) injection vector, since `sanitizeText` leaves `0x1B` intact. That's a different vulnerability class on a different output path and gets its own issue rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)