### PR TITLE
Strip control characters from feed text at ingest (#98)

### DIFF
--- a/internal/feeds/fetcher.go
+++ b/internal/feeds/fetcher.go
@@ -14,12 +14,32 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-// sanitizeText strips null bytes and invalid UTF-8 sequences from feed/web
-// content. PostgreSQL rejects text containing 0x00 even though it is a valid
-// UTF-8 byte; SQLite accepts it silently, so the problem only surfaces on PG.
+// sanitizeText normalizes feed/web content at the ingest trust boundary:
+// it drops invalid UTF-8 and all C0/C1 control characters (including DEL),
+// keeping only tab, newline, and carriage return.
+//
+// Two reasons this lives here rather than at each output path:
+//   - PostgreSQL rejects text containing 0x00 even though it is a valid UTF-8
+//     byte; SQLite accepts it silently, so the storage problem only surfaces
+//     on PG.
+//   - An embedded ESC (0x1B) or other control byte lets a hostile feed inject
+//     ANSI terminal sequences that execute when the text is later printed to a
+//     terminal or handed to a downstream text consumer (CLI output, the MCP
+//     server). Article text has no legitimate use for these characters, so
+//     stripping once at ingest protects every consumer — including any added
+//     later — without the lossiness that makes HTML sanitization output-time.
 func sanitizeText(s string) string {
 	s = strings.ToValidUTF8(s, "")
-	return strings.ReplaceAll(s, "\x00", "")
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\t', '\n', '\r':
+			return r
+		}
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return -1 // drop control character
+		}
+		return r
+	}, s)
 }
 
 type Fetcher struct {

--- a/internal/feeds/sanitize_test.go
+++ b/internal/feeds/sanitize_test.go
@@ -1,0 +1,59 @@
+package feeds
+
+import "testing"
+
+func TestSanitizeText_StripsControlChars(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "ANSI escape sequence stripped, visible text kept",
+			in:   "before\x1b[31mRED\x1b[0mafter",
+			want: "before[31mRED[0mafter",
+		},
+		{
+			name: "preserves tab, newline, carriage return",
+			in:   "a\tb\nc\rd",
+			want: "a\tb\nc\rd",
+		},
+		{
+			name: "strips NUL (PostgreSQL rejects it)",
+			in:   "a\x00b",
+			want: "ab",
+		},
+		{
+			name: "strips other C0 controls (bell, backspace, vertical tab)",
+			in:   "a\x07b\x08c\x0bd",
+			want: "abcd",
+		},
+		{
+			name: "strips DEL",
+			in:   "a\x7fb",
+			want: "ab",
+		},
+		{
+			name: "strips C1 controls (NEL, CSI)",
+			in:   "a\u0085b\u009bc",
+			want: "abc",
+		},
+		{
+			name: "preserves printable unicode",
+			in:   "café 日本語 🔔 — ok",
+			want: "café 日本語 🔔 — ok",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeText(tt.in); got != tt.want {
+				t.Errorf("sanitizeText(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #98.

## Problem

`sanitizeText` runs on every feed-derived field at ingest (title, summary, author, content, full-text/linked content) but only stripped NUL and invalid UTF-8. The ESC byte (`0x1B`) and other C0/C1 controls are valid UTF-8 and sailed through, so a hostile feed could embed ANSI escape sequences that execute when the text is later printed to a terminal or handed to a text consumer — the CLI formatter (`internal/output/formatter.go`) and the MCP server (`articles_get`, `articles_unread`). That's a terminal-injection vector, distinct from the HTML XSS fixed in #91.

## Fix

Extend `sanitizeText` to drop all C0 (0x00–0x1F) and C1 (0x80–0x9F) control characters plus DEL (0x7F), keeping only `\t`, `\n`, `\r`.

### Why ingest, not output (contrast with #91)

HTML sanitization is lossy and context-specific, so it must happen at the render path (#91). Control characters are different: they have no legitimate place in article text in *any* context (HTML, terminal, JSON, TTS). Normalizing once at the ingest trust boundary protects every consumer — web, Fever, CLI, MCP, and anything added later — and can't be silently forgotten by a new output path. This also subsumes the existing NUL-for-PostgreSQL strip.

Caveat: this normalizes content fetched/refreshed after the change; already-stored rows keep their control chars until re-fetched. Acceptable given the low severity (the affected sinks are the local terminal and a lightly-used MCP path, and modern terminals neuter the genuinely dangerous escapes).

## Test

`TestSanitizeText_StripsControlChars` (table): ESC/ANSI stripped while visible text survives, C0/DEL/C1 stripped, NUL still stripped, and `\t`/`\n`/`\r` plus printable Unicode (accents, CJK, emoji, em-dash) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)