### PR TITLE
Don't burn the AI retry budget on backend-unavailable errors (#100)

### DIFF
--- a/cmd/herald/screen.go
+++ b/cmd/herald/screen.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	herald "github.com/matthewjhunter/herald"
 	"github.com/matthewjhunter/herald/internal/ai"
@@ -49,9 +50,14 @@ func screenAndScoreArticle(ctx context.Context, aiProc articleAI, store articleS
 	secResult, err := aiProc.SecurityCheck(ctx, userID, article.Title, content)
 	if err != nil {
 		formatter.Warning("security check failed for article %d: %v", article.ID, err)
-		// Re-queue; after 3 failures the article falls out of the unscored query
-		// and is not retried further.
-		store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+		// Only a genuine model-response failure (unparseable verdict) counts
+		// against the retry budget; after 3 the article falls out of the unscored
+		// query and is not retried. A backend-unavailable error means we never got
+		// a verdict — re-queue without incrementing so a later cycle retries once
+		// the backend recovers, rather than orphaning it on a transient outage (#100).
+		if !errors.Is(err, ai.ErrBackendUnavailable) {
+			store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+		}
 		return screenOutcome{}
 	}
 

--- a/cmd/herald/screen_test.go
+++ b/cmd/herald/screen_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"slices"
 	"sync"
@@ -217,7 +218,9 @@ func TestScreenAndScore_MediumFlagSkipsDownstream(t *testing.T) {
 
 // A failed security check re-queues the article and runs nothing downstream.
 func TestScreenAndScore_SecurityErrorRetriesAndSkips(t *testing.T) {
-	f := &fakeAI{secErr: errors.New("model unreachable")}
+	// A genuine model-response failure (the model answered but the verdict was
+	// unparseable) counts against the retry budget.
+	f := &fakeAI{secErr: errors.New("security check returned malformed JSON")}
 	s := &fakeStore{}
 
 	out := runScreen(f, s)
@@ -233,6 +236,31 @@ func TestScreenAndScore_SecurityErrorRetriesAndSkips(t *testing.T) {
 	}
 	if len(s.readStates) != 0 {
 		t.Errorf("no read-state write on transient security error; got %+v", s.readStates)
+	}
+}
+
+// A backend-unavailable error (circuit breaker open, transport failure, non-200)
+// means no verdict was produced for this article, so it must NOT consume the
+// retry budget — otherwise a transient backend outage permanently orphans
+// whatever was in flight (#100).
+func TestScreenAndScore_BackendUnavailableDoesNotBurnRetries(t *testing.T) {
+	// Wrapped exactly as ollama.go propagates a client error.
+	f := &fakeAI{secErr: fmt.Errorf("ollama security check failed: %w", ai.ErrBackendUnavailable)}
+	s := &fakeStore{}
+
+	out := runScreen(f, s)
+
+	if out.scored {
+		t.Error("article must not be scored when the security check errors")
+	}
+	if f.called("SummarizeArticle") || f.called("CurateArticle") {
+		t.Errorf("no downstream model calls on security error; calls=%v", f.calls)
+	}
+	if s.retries != 0 {
+		t.Errorf("backend-unavailable error must not increment retries, got %d", s.retries)
+	}
+	if len(s.readStates) != 0 {
+		t.Errorf("no read-state write on backend-unavailable error; got %+v", s.readStates)
 	}
 }
 

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,6 +18,14 @@ import (
 // debugAI enables verbose logging of all model calls when HERALD_DEBUG_AI=1.
 var debugAI = os.Getenv("HERALD_DEBUG_AI") == "1"
 
+// ErrBackendUnavailable marks errors where the AI backend never produced a
+// verdict: the circuit breaker was open, the request never connected, or the
+// server returned a non-200 status. These failures are infrastructure-transient
+// and not specific to the content being scored, so callers must not count them
+// against a per-article retry budget — doing so lets a brief backend outage
+// permanently orphan whatever was in flight (#100).
+var ErrBackendUnavailable = errors.New("ai backend unavailable")
+
 const (
 	// clientBreakerThreshold is the number of consecutive 4xx errors before the
 	// circuit breaker trips.
@@ -29,6 +38,8 @@ const (
 )
 
 // ClientError represents an HTTP client error (4xx) that should not be retried.
+// StatusCode 0 is the synthetic status used for a circuit-breaker-open
+// rejection, where no request was sent at all.
 type ClientError struct {
 	StatusCode int
 	Body       string
@@ -36,6 +47,14 @@ type ClientError struct {
 
 func (e *ClientError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// Is reports every ClientError as ErrBackendUnavailable. A 4xx (auth,
+// bad request, model-not-found) or the breaker-open status (0) means the
+// backend returned no usable verdict for the content — not that this specific
+// article failed scoring — so it must not consume the article's retry budget.
+func (e *ClientError) Is(target error) bool {
+	return target == ErrBackendUnavailable
 }
 
 // openAIClient is a minimal OpenAI-compatible HTTP client for LLM inference.
@@ -193,7 +212,9 @@ func (c *openAIClient) generate(ctx context.Context, model, prompt string, tempe
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		// Transport-level failure (connection refused, DNS, timeout): the
+		// request never reached the model, so this is backend-unavailable.
+		return "", fmt.Errorf("%w: %v", ErrBackendUnavailable, err)
 	}
 	defer resp.Body.Close()
 
@@ -208,7 +229,8 @@ func (c *openAIClient) generate(ctx context.Context, model, prompt string, tempe
 			c.tripBreaker(resp.StatusCode)
 			return "", &ClientError{StatusCode: resp.StatusCode, Body: string(respBody)}
 		}
-		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+		// 5xx: the server failed to produce a response — backend-unavailable.
+		return "", fmt.Errorf("%w: HTTP %d: %s", ErrBackendUnavailable, resp.StatusCode, respBody)
 	}
 
 	// Successful call — reset the breaker.

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -13,6 +13,67 @@ import (
 	"time"
 )
 
+// Every path where generate fails to obtain a model verdict must report
+// ErrBackendUnavailable so the daemon does not burn an article's retry budget
+// on a transient backend problem (#100).
+func TestGenerateReportsBackendUnavailable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("4xx client error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound) // model-not-found, as in the Olla outage
+			w.Write([]byte(`{"error":"model not found"}`))
+		}))
+		defer srv.Close()
+		_, err := newOpenAIClient(srv.URL, "k").generate(ctx, "m", "hi", 0.7)
+		if !errors.Is(err, ErrBackendUnavailable) {
+			t.Fatalf("4xx: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
+		}
+	})
+
+	t.Run("5xx server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte("upstream down"))
+		}))
+		defer srv.Close()
+		_, err := newOpenAIClient(srv.URL, "k").generate(ctx, "m", "hi", 0.7)
+		if !errors.Is(err, ErrBackendUnavailable) {
+			t.Fatalf("5xx: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
+		}
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		// Point at a closed server so the dial fails (connection refused).
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+		_, err := newOpenAIClient(url, "k").generate(ctx, "m", "hi", 0.7)
+		if !errors.Is(err, ErrBackendUnavailable) {
+			t.Fatalf("transport: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
+		}
+	})
+
+	t.Run("open circuit breaker", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"unauthorized"}`))
+		}))
+		defer srv.Close()
+		c := newOpenAIClient(srv.URL, "bad")
+		for range clientBreakerThreshold {
+			c.generate(ctx, "m", "hi", 0.7) //nolint:errcheck
+		}
+		if !c.isOpen() {
+			t.Fatal("expected breaker open after threshold 4xx")
+		}
+		_, err := c.generate(ctx, "m", "hi", 0.7)
+		if !errors.Is(err, ErrBackendUnavailable) {
+			t.Fatalf("breaker-open: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
+		}
+	})
+}
+
 func TestCircuitBreakerTripsAfterConsecutive4xx(t *testing.T) {
 	// Server that always returns 401.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #100.

## Problem

`GetUnscoredArticlesForUser` excludes articles with `ai_retries >= 3`, and `screenAndScoreArticle` incremented `ai_retries` on **any** `SecurityCheck` error — including circuit-breaker-open rejections (which fail instantly without calling the model), transport failures (connection refused/timeout), and non-200 responses. When the AI backend has a transient outage the breaker fails every in-flight article fast, burning all 3 retries across a few cycles **without a single genuine scoring attempt**, after which the article is permanently excluded.

Observed in production: a ~1h Olla gateway outage (connection refused → HTTP 404 model-not-found → breaker open) orphaned 8 articles; **553** total sit stranded at `ai_retries >= 3 AND ai_scored = FALSE`.

## Fix

- New sentinel `ai.ErrBackendUnavailable`, reported for every path where `generate` fails to obtain a verdict:
  - **breaker open** and **4xx** — `ClientError.Is` matches the sentinel (covers the synthetic status-0 breaker error and 404/401/etc.).
  - **5xx** and **transport error** — wrapped with `%w`.
- `screenAndScoreArticle` skips `IncrementAIRetries` when `errors.Is(err, ai.ErrBackendUnavailable)`, so the article stays eligible and a later cycle retries once the backend recovers.
- Genuine model-response failures (empty/malformed JSON verdict — the model answered but we couldn't parse it) still count toward the give-up cap.

## Tests

- `internal/ai`: `TestGenerateReportsBackendUnavailable` — 4xx, 5xx, transport failure, and open breaker all satisfy `errors.Is(err, ErrBackendUnavailable)`. Existing breaker type-assertion tests still pass.
- `cmd/herald`: `TestScreenAndScore_BackendUnavailableDoesNotBurnRetries` — wrapped sentinel → `retries == 0`; the existing genuine-failure test → `retries == 1`.

## Not included

The 553 existing orphans need an `ai_retries` reset to re-enter the queue. Deliberately left out of this PR — doing it after this lands means re-scored articles won't immediately re-orphan on the next backend blip. Tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)