### PR TITLE
Don't burn the poller's AI retry budget on backend-unavailable errors

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -216,7 +217,14 @@ func (e *Engine) ProcessNewArticles(ctx context.Context, userID int64) ([]Scored
 
 				if secErr != nil {
 					log.Printf("herald: security check failed for article %d: %v", article.ID, secErr)
-					e.store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+					// A backend-unavailable error (breaker open, transport failure,
+					// non-200) means no verdict was produced for this article, so it
+					// must not consume the retry budget — otherwise a transient outage
+					// orphans whatever was in flight (#100). Genuine model-response
+					// failures still count toward the give-up cap.
+					if !errors.Is(secErr, ai.ErrBackendUnavailable) {
+						e.store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+					}
 					return
 				}
 
@@ -264,7 +272,11 @@ func (e *Engine) ProcessNewArticles(ctx context.Context, userID int64) ([]Scored
 				curResult, err := e.ai.CurateArticle(ctx, userID, article.Title, content, e.config.Preferences.Keywords)
 				if err != nil {
 					log.Printf("herald: curation failed for article %d: %v", article.ID, err)
-					e.store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+					// See the security-check branch above: don't burn the retry
+					// budget when the backend never produced a verdict (#100).
+					if !errors.Is(err, ai.ErrBackendUnavailable) {
+						e.store.IncrementAIRetries(userID, article.ID) //nolint:errcheck
+					}
 					return
 				}
 


### PR DESCRIPTION
The herald-mcp poller path (`engine.ProcessNewArticles`) incremented `ai_retries` on **any** security-check or curation error — including circuit-breaker-open rejections, transport failures, and non-200 responses. A transient AI-backend outage fails every in-flight article fast, burning all 3 retries across a few cycles without a single genuine verdict, and the article is then permanently excluded from the unscored queue.

`#100` (7b55876) fixed exactly this for the CLI screening path (`screenAndScoreArticle`) but left the engine path untouched. This mirrors that fix: skip `IncrementAIRetries` when the error `Is` `ai.ErrBackendUnavailable`, so the article stays eligible and a later cycle retries once the backend recovers. Genuine model-response failures (unparseable verdict) still count toward the give-up cap.

Found while evaluating #64 (closed as already-fixed): the 3-strike exclusion (`c0e22a6`) and the transient/permanent distinction (`#100`) cover the CLI path, but the poller had the inverse failure mode — orphaning articles on a transient outage rather than hot-looping.

## Test note

`Engine` holds a concrete `*ai.AIProcessor` rather than an injectable interface, so unit-testing this branch would require refactoring `Engine` to take an AI interface — out of scope here. The identical logic is already covered on the CLI path by `TestScreenAndScore_BackendUnavailableDoesNotBurnRetries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)