### PR TITLE
build: pin oidclient to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/infodancer/oidclient v0.0.0-20260519092425-e7def6e0ae83
+	github.com/infodancer/oidclient v0.1.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/matthewjhunter/go-embedding v0.4.6
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infodancer/oidclient v0.0.0-20260519092425-e7def6e0ae83 h1:DxiFVKwePQhSPmekdgdKUZh/XfbY1k03laQMqQk+vBI=
-github.com/infodancer/oidclient v0.0.0-20260519092425-e7def6e0ae83/go.mod h1:xUu4KdMmte7MI1McYihOERTFUQ+HdU0C2JXaG+ynk+c=
+github.com/infodancer/oidclient v0.1.0 h1:RmmVwzf2G38yBnW4TUECn7dXB4lRdSJlQxif48ruWsY=
+github.com/infodancer/oidclient v0.1.0/go.mod h1:6vGWxWv4vVx0xQ0M0pyHuHjh+8Rbp3HKjcLXLC7/280=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=


### PR DESCRIPTION
oidclient now has a tagged release (`v0.1.0`). Replace the pseudo-version pin with the tag for a reproducible, auditable RP dependency on the auth path.

- `go build ./...` clean
- go.mod/go.sum only

🤖 Generated with [Claude Code](https://claude.com/claude-code)