### PR TITLE
Report the real security score in the curate stage's processed event (#119)

### DIFF
--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -166,10 +166,23 @@ func (s *Stage) Curate(ctx context.Context, in []storage.Article) []storage.Arti
 		s.Formatter.Warning("pipeline: skipping curation stage for user %d — AI backend unavailable (breaker open)", s.UserID)
 		return nil
 	}
-	return s.mapArticles(ctx, in, s.curateOne)
+	// The security verdict lives in read_state, not on the in-memory Article, so
+	// fetch it once for the batch to report alongside the interest score (#119).
+	batchIDs := make([]int64, len(in))
+	for i, a := range in {
+		batchIDs[i] = a.ID
+	}
+	secScores, err := s.Store.GetSecurityScores(s.UserID, batchIDs)
+	if err != nil {
+		s.Formatter.Warning("pipeline: could not load security scores for curation reporting: %v", err)
+		secScores = nil
+	}
+	return s.mapArticles(ctx, in, func(ctx context.Context, article storage.Article) *storage.Article {
+		return s.curateOne(ctx, article, secScores[article.ID])
+	})
 }
 
-func (s *Stage) curateOne(ctx context.Context, article storage.Article) *storage.Article {
+func (s *Stage) curateOne(ctx context.Context, article storage.Article, securityScore float64) *storage.Article {
 	content := articleContent(article)
 	curResult, err := s.AI.CurateArticle(ctx, s.UserID, article.Title, content, s.Cfg.Preferences.Keywords)
 	if err != nil {
@@ -179,6 +192,6 @@ func (s *Stage) curateOne(ctx context.Context, article storage.Article) *storage
 	// Record only the interest score; the security verdict was written by the
 	// security stage and must not be clobbered (SetInterestScore leaves it).
 	s.Store.SetInterestScore(s.UserID, article.ID, curResult.InterestScore) //nolint:errcheck
-	s.Formatter.OutputProcessingStatus(article.ID, article.Title, curResult.InterestScore, 0, true)
+	s.Formatter.OutputProcessingStatus(article.ID, article.Title, curResult.InterestScore, securityScore, true)
 	return &article
 }

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -1,7 +1,9 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"path/filepath"
@@ -308,6 +310,41 @@ func TestCurateStage(t *testing.T) {
 		scored, _ := store.GetUnsummarizedScoredArticles(1, 7.0, 10)
 		if len(scored) != 1 {
 			t.Fatalf("security score must survive curation, got %v", ids(scored))
+		}
+	})
+
+	t.Run("processed event reports the persisted security score, not zero", func(t *testing.T) {
+		fake := &fakeAI{available: true, curateFn: func(string, string) (*ai.CurationResult, error) {
+			return &ai.CurationResult{InterestScore: 8.0}, nil
+		}}
+		st, store, feedID := newHarness(t, fake)
+		var buf bytes.Buffer
+		st.Formatter = output.NewFormatterWithWriters(output.FormatJSON, &buf, io.Discard)
+		a := seed(t, store, feedID, "x", "body text")
+		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+			t.Fatal(err)
+		}
+
+		st.Curate(context.Background(), []storage.Article{a})
+
+		var ev struct {
+			Event         string  `json:"event"`
+			SecurityScore float64 `json:"security_score"`
+			InterestScore float64 `json:"interest_score"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &ev); err != nil {
+			t.Fatalf("decode processed event: %v (out=%q)", err, buf.String())
+		}
+		if ev.Event != "article_processed" {
+			t.Fatalf("event = %q, want article_processed", ev.Event)
+		}
+		// The curate stage must surface the verdict the security stage wrote,
+		// not a 0 placeholder — the event feeds logs and notifications (#119).
+		if ev.SecurityScore != 9 {
+			t.Errorf("security_score = %v, want 9 (persisted verdict)", ev.SecurityScore)
+		}
+		if ev.InterestScore != 8 {
+			t.Errorf("interest_score = %v, want 8", ev.InterestScore)
 		}
 	})
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1522,6 +1522,41 @@ func (s *PostgresStore) GetArticleInterestScores(userID int64, articleIDs []int6
 	return scores, rows.Err()
 }
 
+// GetSecurityScores returns the persisted security_score for each of the given
+// articles (user-scoped), skipping any with a NULL score. The curate stage uses
+// it to report the verdict the security stage wrote, since that score is not
+// carried on the in-memory Article (#119).
+func (s *PostgresStore) GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error) {
+	if len(articleIDs) == 0 {
+		return map[int64]float64{}, nil
+	}
+	placeholders := make([]string, len(articleIDs))
+	args := make([]any, 0, len(articleIDs)+1)
+	args = append(args, userID)
+	for i, id := range articleIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := `SELECT article_id, security_score FROM read_state
+		WHERE user_id = ? AND article_id IN (` + strings.Join(placeholders, ",") + `)
+		AND security_score IS NOT NULL`
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get security scores: %w", err)
+	}
+	defer rows.Close()
+	scores := make(map[int64]float64, len(articleIDs))
+	for rows.Next() {
+		var id int64
+		var score float64
+		if err := rows.Scan(&id, &score); err != nil {
+			return nil, fmt.Errorf("scan security score: %w", err)
+		}
+		scores[id] = score
+	}
+	return scores, rows.Err()
+}
+
 func (s *PostgresStore) UpdateGroupSummary(groupID int64, headline, summary string, articleCount int, maxInterestScore *float64) error {
 	_, err := s.db.Exec(
 		`INSERT INTO group_summaries (group_id, headline, summary, article_count, max_interest_score, generated_at)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1425,6 +1425,41 @@ func (s *SQLiteStore) GetArticleInterestScores(userID int64, articleIDs []int64)
 	return scores, rows.Err()
 }
 
+// GetSecurityScores returns the persisted security_score for each of the given
+// articles (user-scoped), skipping any with a NULL score. The curate stage uses
+// it to report the verdict the security stage wrote, since that score is not
+// carried on the in-memory Article (#119).
+func (s *SQLiteStore) GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error) {
+	if len(articleIDs) == 0 {
+		return map[int64]float64{}, nil
+	}
+	placeholders := make([]string, len(articleIDs))
+	args := make([]any, 0, len(articleIDs)+1)
+	args = append(args, userID)
+	for i, id := range articleIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := `SELECT article_id, security_score FROM read_state
+		WHERE user_id = ? AND article_id IN (` + strings.Join(placeholders, ",") + `)
+		AND security_score IS NOT NULL`
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get security scores: %w", err)
+	}
+	defer rows.Close()
+	scores := make(map[int64]float64, len(articleIDs))
+	for rows.Next() {
+		var id int64
+		var score float64
+		if err := rows.Scan(&id, &score); err != nil {
+			return nil, fmt.Errorf("scan security score: %w", err)
+		}
+		scores[id] = score
+	}
+	return scores, rows.Err()
+}
+
 // UpdateGroupSummary stores or updates the summary for a group
 func (s *SQLiteStore) UpdateGroupSummary(groupID int64, headline, summary string, articleCount int, maxInterestScore *float64) error {
 	_, err := s.db.Exec(

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -127,6 +127,7 @@ type Store interface {
 	AddArticleToGroup(groupID, articleID int64) error
 	GetGroupArticles(groupID int64) ([]Article, error)
 	GetArticleInterestScores(userID int64, articleIDs []int64) (map[int64]float64, error)
+	GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error)
 	UpdateGroupSummary(groupID int64, headline, summary string, articleCount int, maxInterestScore *float64) error
 	GetGroupSummary(groupID int64) (*GroupSummary, error)
 	GetUserGroups(userID int64) ([]ArticleGroup, error)


### PR DESCRIPTION
Fixes #119.

The staged pipeline's curate stage emitted the `article_processed` status event with a hardcoded `security_score: 0`, because security and curation run as separate state-driven passes and the security verdict isn't carried on the in-memory `Article` — it's in `read_state`. The persisted score and the security gate were always correct (verified in the #117 smoke test); only the logged/notified value was wrong.

## Change

- Add `GetSecurityScores(userID, articleIDs)` — a batched, user-scoped `read_state` lookup mirroring the existing `GetArticleInterestScores` (both backends).
- The curate stage fetches it **once per drain page** (not per-article) and reports the real verdict alongside the interest score.
- A NULL score or lookup error degrades to the prior `0` rather than failing the stage.

## Test

`TestCurateStage/processed_event_reports_the_persisted_security_score,_not_zero` captures the JSON event and asserts `security_score == 9` (the persisted verdict) instead of `0`. Build, `go test -race`, lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)