### PR TITLE
Scan the sanitized article view in the AI stages (#121)

### DIFF
--- a/cmd/herald-web/sanitize.go
+++ b/cmd/herald-web/sanitize.go
@@ -1,18 +1,12 @@
 package main
 
-import "github.com/microcosm-cc/bluemonday"
-
-// htmlSanitizer is the single HTML sanitization policy applied to every
-// feed-derived field served to a client that renders it as HTML — the web
-// article view and the Fever API. bluemonday policies are immutable after
-// construction and safe for concurrent use, so one package-level instance
-// serves all requests.
-var htmlSanitizer = bluemonday.UGCPolicy()
+import "github.com/matthewjhunter/herald/internal/sanitize"
 
 // sanitizeHTML strips disallowed tags and attributes (script, event handlers,
-// etc.) from untrusted feed HTML. Every HTML output path MUST route content
-// through here before emitting it — never serve row.Content/Summary raw, or a
-// hostile feed's stored markup becomes a client-side XSS vector.
+// etc.) from untrusted feed HTML before it is rendered as HTML in the web
+// article view or the Fever API. It delegates to internal/sanitize, the single
+// home of herald's sanitization policy; never serve row.Content/Summary raw, or
+// a hostile feed's stored markup becomes a client-side XSS vector.
 func sanitizeHTML(s string) string {
-	return htmlSanitizer.Sanitize(s)
+	return sanitize.HTML(s)
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -7,6 +7,7 @@ import (
 	embedding "github.com/matthewjhunter/go-embedding"
 	"github.com/matthewjhunter/herald/internal/ai"
 	"github.com/matthewjhunter/herald/internal/output"
+	"github.com/matthewjhunter/herald/internal/sanitize"
 	"github.com/matthewjhunter/herald/internal/storage"
 )
 
@@ -101,5 +102,12 @@ func articleContent(a storage.Article) string {
 	if a.LinkedContent != "" {
 		content = content + "\n\n" + a.LinkedContent
 	}
-	return content
+	// Sanitize so every AI stage judges exactly what the web view renders:
+	// scripts and event handlers stripped — which also stops the security model
+	// from flagging legitimate embedded widgets (Rumble/Twitter players) as
+	// malicious — while links and visible prose are preserved (#121). The raw
+	// HTML stays in storage as the source of truth; this is a per-read view.
+	// May return "" when the body was nothing but markup, which the caller
+	// treats as a skip.
+	return sanitize.HTML(content)
 }

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -217,6 +217,46 @@ func TestSecurityStageSkipsWhenBreakerOpen(t *testing.T) {
 	}
 }
 
+func TestArticleContentSanitizes(t *testing.T) {
+	a := storage.Article{
+		Content:       `<p>Breaking news body.</p><script>steal()</script>`,
+		LinkedContent: `<a href="https://example.com" onclick="x()">more</a>`,
+	}
+	got := articleContent(a)
+	for _, bad := range []string{"<script", "steal()", "onclick", "x()"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("articleContent should strip %q, got: %s", bad, got)
+		}
+	}
+	for _, want := range []string{"Breaking news body.", "https://example.com", "more"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("articleContent should keep %q, got: %s", want, got)
+		}
+	}
+}
+
+func TestSecurityStageScansSanitizedContent(t *testing.T) {
+	// The security model must judge the sanitized, user-visible content — not raw
+	// feed HTML — so embedded widget scripts don't read as malicious code (#121).
+	var seen string
+	fake := &fakeAI{available: true, securityFn: func(_, content string) (*ai.SecurityResult, error) {
+		seen = content
+		return &ai.SecurityResult{Safe: true, Score: 9}, nil
+	}}
+	st, store, feedID := newHarness(t, fake)
+	body := `<script src="https://rumble.com/widgets.js"></script><p>` + strings.Repeat("real news ", 60) + `</p>`
+	a := seed(t, store, feedID, "x", body)
+
+	st.Security(context.Background(), []storage.Article{a})
+
+	if strings.Contains(seen, "<script") || strings.Contains(seen, "widgets.js") {
+		t.Errorf("security model received unsanitized content: %s", seen)
+	}
+	if !strings.Contains(seen, "real news") {
+		t.Errorf("security model should still see the visible prose, got: %s", seen)
+	}
+}
+
 func TestSummarizeStage(t *testing.T) {
 	st, store, feedID := newHarness(t, &fakeAI{available: true})
 	mustPass := func(a storage.Article) {

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -1,0 +1,28 @@
+// Package sanitize holds herald's single HTML sanitization policy. Feed content
+// is untrusted: a hostile or sloppy feed can embed <script>, event handlers, or
+// javascript: URIs that become a client-side XSS vector if rendered raw. Every
+// consumer that emits feed-derived HTML — the web article view, the Fever API,
+// rendered newsletter issues — and every consumer that hands feed content to an
+// AI model routes it through this one policy, so the rules live in exactly one
+// place.
+//
+// The policy is applied at read time, not at ingest: the raw HTML is retained in
+// storage as the source of truth. Sanitizing on output (rather than discarding
+// the original on input) means a future bluemonday fix protects already-stored
+// content retroactively, and keeps the unmodified artifact available for audit.
+package sanitize
+
+import "github.com/microcosm-cc/bluemonday"
+
+// htmlPolicy strips disallowed tags and attributes (script, event handlers,
+// javascript: URIs, etc.) while preserving links, images, and visible prose.
+// bluemonday policies are immutable after construction and safe for concurrent
+// use, so one package-level instance serves every caller.
+var htmlPolicy = bluemonday.UGCPolicy()
+
+// HTML returns s with disallowed tags and attributes removed. It is the only
+// sanctioned way to turn untrusted feed HTML into output-safe HTML; never emit
+// or render raw feed content without routing it through here first.
+func HTML(s string) string {
+	return htmlPolicy.Sanitize(s)
+}

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -1,0 +1,54 @@
+package sanitize
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		mustDrop []string
+		mustKeep []string
+	}{
+		{
+			name:     "strips script tags but keeps surrounding prose",
+			in:       `<p>Real news here.</p><script src="https://rumble.com/embedJS/widgets.js"></script>`,
+			mustDrop: []string{"<script", "widgets.js"},
+			mustKeep: []string{"Real news here."},
+		},
+		{
+			name:     "strips inline event handlers",
+			in:       `<a href="https://example.com" onclick="steal()">link</a>`,
+			mustDrop: []string{"onclick", "steal()"},
+			mustKeep: []string{"href", "example.com", "link"},
+		},
+		{
+			name:     "strips javascript: URIs",
+			in:       `<a href="javascript:alert(1)">click</a>`,
+			mustDrop: []string{"javascript:", "alert(1)"},
+			mustKeep: []string{"click"},
+		},
+		{
+			name:     "preserves links so URL signal survives for the security scan",
+			in:       `<p>See <a href="https://malware.example/payload">this</a>.</p>`,
+			mustKeep: []string{"https://malware.example/payload", "this"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HTML(tt.in)
+			for _, d := range tt.mustDrop {
+				if strings.Contains(got, d) {
+					t.Errorf("output should not contain %q\n got: %s", d, got)
+				}
+			}
+			for _, k := range tt.mustKeep {
+				if !strings.Contains(got, k) {
+					t.Errorf("output should contain %q\n got: %s", k, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #121.

The staged pipeline's security stage fed the model **raw feed HTML**, so embedded `<script>` widgets (Rumble/Twitter players) the user never sees were scored as malicious code — diluting the security signal and needlessly down-scoring legitimate articles.

## Change

Two commits:

1. **Extract the bluemonday policy into `internal/sanitize`** — it lived in `cmd/herald-web` (package main), unreachable from the pipeline. Now one shared home; the web layer delegates. Pure refactor.
2. **Sanitize at the `articleContent` chokepoint** so every text stage (security, summarize, curate) judges exactly what the web view renders: scripts and event handlers removed, links and visible prose preserved. Raw HTML stays in storage as the source of truth — a per-read projection, not a destructive transform.

Embedding is unaffected (separate `BuildEmbedInput` path that already strips markup).

## Validation

Unit tests: `internal/sanitize` (scripts/handlers/`javascript:` stripped, links/prose kept) and pipeline tests (`articleContent` strips scripts; the security stage's model input is sanitized).

A/B against the 8 currently-false-flagged production articles, re-scored on sanitized content (scratch DB copy, prod untouched):

| article | raw-scan score | sanitized-scan score |
|---|---|---|
| 4× "malicious JavaScript detected" | 3 | **9–10** |
| 3× prose/markup flags | 4 | **10** |
| 1× suspicious-URL flag (`nrmwiooji.com`) | 4 | **3** |

7 of 8 resolved. The holdout flags a **URL**, which sanitization intentionally preserves so genuine malicious-URL signal still reaches the model — i.e. the security scan doing its job, not a script false-positive. (Security model runs at non-zero temperature, so single-run scores carry some variance; the 4/4 script-case jump is well outside noise.)

Build, `go test -race`, lint, govulncheck all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)