### PR TITLE
Guard group naming against conversational LLM replies

### DIFF
--- a/internal/ai/summarization.go
+++ b/internal/ai/summarization.go
@@ -125,10 +125,38 @@ Summary:
 	}
 
 	topic = strings.TrimSpace(topic)
-	if len(topic) > 200 {
-		topic = topic[:200]
+	// A degenerate group summary (e.g. an over-large, incoherent cluster) makes
+	// the model reply conversationally — "Please provide the summary…" — instead
+	// of a label. Reject anything that doesn't look like a topic label so the
+	// caller keeps the group's existing (article-title) topic rather than storing
+	// the model's chatter as the name.
+	if !looksLikeTopicLabel(topic) {
+		return "", nil
 	}
 	return topic, nil
+}
+
+// looksLikeTopicLabel reports whether s is a plausible short topic label rather
+// than a conversational reply, refusal, or request for more input.
+func looksLikeTopicLabel(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > 100 {
+		return false
+	}
+	if strings.HasSuffix(s, "?") || strings.HasSuffix(s, ":") {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, marker := range []string{
+		"please provide", "provide the", "topic label", "i can ", "i need",
+		"i am ", "i'm ", "as an ai", "sorry", "cannot", "can't", "unable",
+		"no articles", "no summary", "could you", "can you",
+	} {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	return true
 }
 
 // NewsletterInput represents an article for newsletter content generation.

--- a/internal/ai/summarization_test.go
+++ b/internal/ai/summarization_test.go
@@ -1,0 +1,38 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLooksLikeTopicLabel(t *testing.T) {
+	valid := []string{
+		"Russia Strikes Kyiv in Missile Barrage",
+		"Federal Reserve Holds Rates Steady",
+		"Israel-Lebanon Border Escalation",
+		"Harvard Antisemitism Investigation",
+	}
+	for _, s := range valid {
+		if !looksLikeTopicLabel(s) {
+			t.Errorf("expected valid label: %q", s)
+		}
+	}
+
+	invalid := []string{
+		// The exact production bug: a conversational request stored as a label.
+		"Please provide the summary of related news articles so I can generate the topic label.",
+		"I can generate a label once you share the articles.",
+		"I need the article summaries first.",
+		"Sorry, I cannot do that.",
+		"As an AI, I'm unable to summarize without input.",
+		"What articles would you like me to label?",
+		"Here is the topic label:",
+		"",
+		strings.Repeat("x", 150), // too long to be a label
+	}
+	for _, s := range invalid {
+		if looksLikeTopicLabel(s) {
+			t.Errorf("expected invalid (conversational/too-long): %q", s)
+		}
+	}
+}

--- a/internal/pipeline/clusterstage.go
+++ b/internal/pipeline/clusterstage.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 
 	embedding "github.com/matthewjhunter/go-embedding"
 	"github.com/matthewjhunter/herald/internal/ai"
@@ -207,8 +208,10 @@ func (s *Stage) nameGroup(ctx context.Context, groupID int64) {
 		s.Formatter.Warning("failed to store summary for group %d: %v", groupID, err)
 		return
 	}
-	// Refine the topic label once the group is substantial.
-	if len(arts) >= 3 {
+	// Refine the topic label once the group is substantial — but only from a
+	// real summary. An empty summary (degenerate/over-large cluster) would make
+	// the refiner reply conversationally; skip it and keep the seed topic.
+	if len(arts) >= 3 && strings.TrimSpace(res.Summary) != "" {
 		if refined, err := s.AI.RefineGroupTopic(ctx, s.UserID, res.Summary); err == nil && refined != "" {
 			s.Store.UpdateGroupTopic(groupID, refined) //nolint:errcheck
 		}

--- a/internal/pipeline/clusterstage_test.go
+++ b/internal/pipeline/clusterstage_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	embedding "github.com/matthewjhunter/go-embedding"
@@ -71,6 +72,56 @@ func TestClusterFormsNewGroupFromSiblings(t *testing.T) {
 	// The new group was named via the LLM.
 	if sum, err := store.GetGroupSummary(*ga); err != nil || sum == nil || sum.Headline == "" {
 		t.Fatalf("expected the new group to be named, got %+v (err %v)", sum, err)
+	}
+}
+
+// An empty group summary (degenerate/over-large cluster) must not trigger topic
+// refinement — otherwise the model replies conversationally and the chatter is
+// stored as the group name (the "Please provide the summary…" prod bug).
+func TestClusterSkipsTopicRefineOnEmptySummary(t *testing.T) {
+	fake := &fakeAI{available: true}
+	fake.groupSummaryFn = func(string, []ai.GroupSummaryInput) (*ai.GroupSummaryResult, error) {
+		return &ai.GroupSummaryResult{Headline: "Headline", Summary: ""}, nil // degenerate
+	}
+	refineCalled := false
+	fake.refineTopicFn = func(string) (string, error) {
+		refineCalled = true
+		return "Please provide the summary of related news articles so I can generate the topic label.", nil
+	}
+	st, store, feedID := clusterHarness(t, fake)
+
+	a := seed(t, store, feedID, "a", "body a")
+	b := seed(t, store, feedID, "b", "body b")
+	c := seed(t, store, feedID, "c", "body c")
+	embedArt(t, store, a, []float32{1, 0, 0})
+	embedArt(t, store, b, []float32{0.99, 0.05, 0})
+	embedArt(t, store, c, []float32{0.98, 0.1, 0}) // all three cluster together (>=3 → refine path)
+	for _, art := range []storage.Article{a, b, c} {
+		if err := store.UpdateArticleAISummary(1, art.ID, "summary of "+art.GUID); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SetInterestScore(1, art.ID, 8); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := st.Cluster(context.Background(), []storage.Article{a, b, c}); err != nil {
+		t.Fatalf("Cluster: %v", err)
+	}
+
+	gid := groupOf(t, store, a.ID)
+	if gid == nil {
+		t.Fatal("expected a group to form")
+	}
+	g, err := store.GetGroup(*gid)
+	if err != nil || g == nil {
+		t.Fatalf("GetGroup: %v", err)
+	}
+	if refineCalled {
+		t.Error("RefineGroupTopic must not be called when the group summary is empty")
+	}
+	if strings.Contains(g.Topic, "Please provide") {
+		t.Fatalf("conversational reply leaked into group topic: %q", g.Topic)
 	}
 }
 


### PR DESCRIPTION
Fixes the production bug where a group was named literally *"Please provide the summary of related news articles so I can generate the topic label."*

**Mechanism:** a degenerate 100-article cluster made `GenerateGroupSummary` return an empty summary; `RefineGroupTopic("")` then asked the model to label nothing, it replied conversationally, and the reply passed the only guard (`refined != ""`) into the group's display name.

**Guards added:**
- `nameGroup` skips topic refinement when the summary is empty/whitespace — the group keeps its seed topic (first article's title).
- `RefineGroupTopic` validates output via `looksLikeTopicLabel` (rejects requests/refusals/sentences, too-long strings, trailing `?`/`:`) and returns `""` otherwise.

Tested: `looksLikeTopicLabel` over the exact prod string + valid labels; a cluster-stage test that an empty summary skips refinement and never stores the chatter.

Stops *new* broken names; existing mis-named groups keep theirs until re-clustered/disbanded. The root cause (single-linkage chaining collapsing the corpus into one mega-group) is a separate tuning question, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)