### PR TITLE
Add a grouping.enabled config toggle

### DIFF
--- a/internal/pipeline/clusterstage_test.go
+++ b/internal/pipeline/clusterstage_test.go
@@ -125,6 +125,40 @@ func TestClusterSkipsTopicRefineOnEmptySummary(t *testing.T) {
 	}
 }
 
+// The grouping toggle (Cfg.Grouping.Enabled) gates the orchestrator's cluster
+// pass: enabled groups the recent cohort, disabled leaves it ungrouped.
+func TestClusterRecentRespectsToggle(t *testing.T) {
+	run := func(enabled bool) (storage.Store, int64) {
+		st, store, feedID := clusterHarness(t, &fakeAI{available: true})
+		st.Cfg.Grouping.Enabled = enabled
+		a := seed(t, store, feedID, "a", "body a")
+		b := seed(t, store, feedID, "b", "body b")
+		embedArt(t, store, a, []float32{1, 0, 0})
+		embedArt(t, store, b, []float32{0.99, 0.05, 0})
+		for _, art := range []storage.Article{a, b} {
+			if err := store.MarkSecurityScored(1, art.ID, 9, "ok", false); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.SetInterestScore(1, art.ID, 8); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := st.clusterRecent(context.Background()); err != nil {
+			t.Fatalf("clusterRecent: %v", err)
+		}
+		return store, a.ID
+	}
+
+	// Positive control: enabled groups the cohort (also proves the setup is valid).
+	if store, id := run(true); groupOf(t, store, id) == nil {
+		t.Fatal("grouping enabled: expected the cohort to be grouped")
+	}
+	// Toggle off: no group forms.
+	if store, id := run(false); groupOf(t, store, id) != nil {
+		t.Fatal("grouping disabled: expected the cohort to stay ungrouped")
+	}
+}
+
 func TestClusterJoinsExistingGroup(t *testing.T) {
 	st, store, feedID := clusterHarness(t, &fakeAI{available: true})
 

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -106,7 +106,7 @@ func (s *Stage) drain(fetch func(limit int) ([]storage.Article, error), process 
 // freshly-embedded articles cluster alongside late-arriving siblings from
 // earlier cycles. No-op when embedding is unconfigured.
 func (s *Stage) clusterRecent(ctx context.Context) error {
-	if s.Embedder == nil {
+	if s.Embedder == nil || !s.Cfg.Grouping.Enabled {
 		return nil
 	}
 	since := time.Now().Add(-s.recencyWindow())

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	} `yaml:"summarization"`
 
 	Grouping struct {
+		// Enabled toggles the staged cluster stage (breaking-news grouping).
+		// Default true; set false to disable auto-grouping entirely (articles
+		// stay ungrouped, still embedded so semantic search keeps working).
+		Enabled             bool    `yaml:"enabled"`
 		SimilarityThreshold float64 `yaml:"similarity_threshold"`
 		// ClusterThreshold is the cosine similarity at which the staged
 		// pipeline's cluster stage joins an article to a group or links two
@@ -103,6 +107,7 @@ func DefaultConfig() *Config {
 	cfg.Ollama.Timeout = 2 * time.Minute
 	cfg.Summarization.MinArticleLength = 200
 	cfg.Summarization.MaxSummaryLength = 500
+	cfg.Grouping.Enabled = true
 	cfg.Grouping.SimilarityThreshold = 0.75
 	cfg.Grouping.ClusterThreshold = 0.75
 	cfg.Grouping.MinClusterSize = 2


### PR DESCRIPTION
Adds `grouping.enabled` (default true) to turn the cluster stage on/off via config — for tuning, and to disable the single-linkage mega-group while it is being worked out. Articles still embed (semantic search unaffected); they just stay ungrouped when off. Gated at `clusterRecent`; tested both ways.