### PR TITLE
Disable reasoning pass for Qwen digest backend

### DIFF
--- a/cmd/herald-web/config.go
+++ b/cmd/herald-web/config.go
@@ -33,6 +33,9 @@ type SummaryConfig struct {
 	BaseURL string `toml:"base_url"`
 	// Model is the cloud model name (defaults to claude-sonnet-4-6 when empty).
 	Model string `toml:"model"`
+	// DisableThinking turns off a reasoning backend's thinking pass (Qwen3 via
+	// Lemonade) so the digest is real content, not an unfinished reasoning_content.
+	DisableThinking bool `toml:"disable_thinking"`
 }
 
 // WebauthConfig holds webauth OIDC settings.

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -109,9 +109,10 @@ func main() {
 		// AI Summary cloud backend — built even though the engine is read-only
 		// (it is one streaming HTTPS call, not the Olla pipeline). The key comes
 		// from the environment so it is never committed to config.
-		SummaryBaseURL: cfg.Summary.BaseURL,
-		SummaryModel:   cfg.Summary.Model,
-		SummaryAPIKey:  os.Getenv("HERALD_SUMMARY_API_KEY"),
+		SummaryBaseURL:         cfg.Summary.BaseURL,
+		SummaryModel:           cfg.Summary.Model,
+		SummaryAPIKey:          os.Getenv("HERALD_SUMMARY_API_KEY"),
+		SummaryDisableThinking: cfg.Summary.DisableThinking,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "herald-web: %v\n", err)

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -509,9 +509,10 @@ func processNewsletters(ctx context.Context) error {
 		UserID:        cfg.DefaultUserID,
 		// Scheduled AI digests need the summarizer in the daemon (built only when
 		// a summary backend is configured). Same fields herald-web passes.
-		SummaryBaseURL: cfg.Summary.BaseURL,
-		SummaryModel:   cfg.Summary.Model,
-		SummaryAPIKey:  os.Getenv("HERALD_SUMMARY_API_KEY"),
+		SummaryBaseURL:         cfg.Summary.BaseURL,
+		SummaryModel:           cfg.Summary.Model,
+		SummaryAPIKey:          os.Getenv("HERALD_SUMMARY_API_KEY"),
+		SummaryDisableThinking: cfg.Summary.DisableThinking,
 	})
 	if err != nil {
 		return fmt.Errorf("create engine for newsletters: %w", err)

--- a/engine.go
+++ b/engine.go
@@ -98,11 +98,13 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	if cfg.SummaryModel != "" {
 		storeCfg.Summary.Model = cfg.SummaryModel
 	}
+	storeCfg.Summary.DisableThinking = cfg.SummaryDisableThinking
 	var summarizer *ai.CloudSummarizer
 	if storeCfg.Summary.BaseURL != "" {
 		summarizer = ai.NewCloudSummarizer(
 			storeCfg.Summary.BaseURL, cfg.SummaryAPIKey,
 			storeCfg.Summary.Model, storeCfg.Summary.Timeout,
+			storeCfg.Summary.DisableThinking,
 		)
 	}
 

--- a/engine_summary_test.go
+++ b/engine_summary_test.go
@@ -76,7 +76,7 @@ func TestGenerateAISummary(t *testing.T) {
 	cfg.Summary.MinSecurityScore = 7
 	e := &Engine{
 		store:      store,
-		summarizer: ai.NewCloudSummarizer(srv.URL, "", "test-model", time.Minute),
+		summarizer: ai.NewCloudSummarizer(srv.URL, "", "test-model", time.Minute, false),
 		config:     cfg,
 	}
 
@@ -163,7 +163,7 @@ func TestGenerateForConfig(t *testing.T) {
 
 	e := &Engine{
 		store:      store,
-		summarizer: ai.NewCloudSummarizer(srv.URL, "", "m", time.Minute),
+		summarizer: ai.NewCloudSummarizer(srv.URL, "", "m", time.Minute, false),
 		config:     storage.DefaultConfig(),
 	}
 	if err := e.SetDigestChrome("<p>HEADER</p>", "<p>FOOTER</p>"); err != nil {

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -150,6 +150,12 @@ type chatRequest struct {
 	Temperature float64       `json:"temperature,omitempty"`
 	MaxTokens   int           `json:"max_tokens,omitempty"`
 	Stream      bool          `json:"stream"`
+	// ChatTemplateKwargs passes extra arguments to the server's chat template.
+	// Used to disable a reasoning model's thinking pass (e.g. Qwen3 via
+	// llama.cpp/Lemonade: {"enable_thinking": false}) so the whole completion
+	// budget isn't spent on reasoning_content, leaving content empty. Omitted
+	// when nil, so non-reasoning backends (Gemma, Anthropic) are unaffected.
+	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 }
 
 type chatMessage struct {

--- a/internal/ai/cloud.go
+++ b/internal/ai/cloud.go
@@ -21,16 +21,22 @@ type cloudClient struct {
 	baseURL    string // includes the /v1 prefix; "/chat/completions" is appended
 	apiKey     string
 	httpClient *http.Client
+	// disableThinking sends chat_template_kwargs.enable_thinking=false so a
+	// reasoning backend (Qwen3 via Lemonade) emits its answer as content instead
+	// of spending the token budget on a reasoning_content pass that never
+	// finishes — the failure mode that surfaced as "stream ended with no content".
+	disableThinking bool
 }
 
-func newCloudClient(baseURL, apiKey string, timeout time.Duration) *cloudClient {
+func newCloudClient(baseURL, apiKey string, timeout time.Duration, disableThinking bool) *cloudClient {
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
 	return &cloudClient{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		apiKey:     apiKey,
-		httpClient: &http.Client{Timeout: timeout},
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		apiKey:          apiKey,
+		httpClient:      &http.Client{Timeout: timeout},
+		disableThinking: disableThinking,
 	}
 }
 
@@ -62,6 +68,9 @@ func (c *cloudClient) generateStream(ctx context.Context, model, prompt string, 
 		Temperature: temperature,
 		MaxTokens:   maxTokens,
 		Stream:      true,
+	}
+	if c.disableThinking {
+		body.ChatTemplateKwargs = map[string]any{"enable_thinking": false}
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -166,11 +175,11 @@ type CloudSummarizer struct {
 
 // NewCloudSummarizer returns a summarizer, or nil if baseURL is empty (feature
 // disabled).
-func NewCloudSummarizer(baseURL, apiKey, model string, timeout time.Duration) *CloudSummarizer {
+func NewCloudSummarizer(baseURL, apiKey, model string, timeout time.Duration, disableThinking bool) *CloudSummarizer {
 	if strings.TrimSpace(baseURL) == "" {
 		return nil
 	}
-	return &CloudSummarizer{client: newCloudClient(baseURL, apiKey, timeout), model: model}
+	return &CloudSummarizer{client: newCloudClient(baseURL, apiKey, timeout, disableThinking), model: model}
 }
 
 // Model returns the configured cloud model name.

--- a/internal/ai/cloud_test.go
+++ b/internal/ai/cloud_test.go
@@ -1,10 +1,63 @@
 package ai
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestGenerateStreamThinkingToggle verifies that disableThinking controls the
+// chat_template_kwargs.enable_thinking field in the request body — the fix for
+// Qwen3 reasoning models burning the whole completion budget on a thinking pass
+// (surfacing as "stream ended with no content").
+func TestGenerateStreamThinkingToggle(t *testing.T) {
+	cases := []struct {
+		name            string
+		disableThinking bool
+		wantKwargs      bool
+	}{
+		{"disabled sends enable_thinking=false", true, true},
+		{"default omits chat_template_kwargs", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, &gotBody)
+				w.Header().Set("Content-Type", "text/event-stream")
+				io.WriteString(w, `data: {"choices":[{"delta":{"content":"ok"}}]}`+"\n\n")
+				io.WriteString(w, "data: [DONE]\n\n")
+			}))
+			defer srv.Close()
+
+			c := newCloudClient(srv.URL, "", time.Minute, tc.disableThinking)
+			text, _, _, err := c.generateStream(context.Background(), "m", "hi", 0.5, 64)
+			if err != nil {
+				t.Fatalf("generateStream: %v", err)
+			}
+			if text != "ok" {
+				t.Errorf("text = %q, want %q", text, "ok")
+			}
+			kwargs, present := gotBody["chat_template_kwargs"]
+			if present != tc.wantKwargs {
+				t.Fatalf("chat_template_kwargs present = %v, want %v (body: %v)", present, tc.wantKwargs, gotBody)
+			}
+			if tc.wantKwargs {
+				m, ok := kwargs.(map[string]any)
+				if !ok || m["enable_thinking"] != false {
+					t.Errorf("chat_template_kwargs = %v, want {enable_thinking:false}", kwargs)
+				}
+			}
+		})
+	}
+}
 
 func TestParseSSE(t *testing.T) {
 	t.Run("accumulates deltas and records usage", func(t *testing.T) {

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -93,6 +93,9 @@ type Config struct {
 		BodyCharCap      int           `yaml:"body_char_cap"`      // per-article body truncation
 		MaxOutputTokens  int           `yaml:"max_output_tokens"`  // completion cap
 		Timeout          time.Duration `yaml:"timeout"`
+		// DisableThinking turns off a reasoning backend's thinking pass (Qwen3 via
+		// Lemonade) so the completion is real content, not reasoning_content.
+		DisableThinking bool `yaml:"disable_thinking"`
 	} `yaml:"summary,omitempty"`
 }
 

--- a/types.go
+++ b/types.go
@@ -22,6 +22,9 @@ type EngineConfig struct {
 	SummaryBaseURL string
 	SummaryModel   string // optional override; defaults to the config model
 	SummaryAPIKey  string
+	// SummaryDisableThinking turns off the summary backend's reasoning pass
+	// (Qwen3 via Lemonade) so the completion is content, not reasoning_content.
+	SummaryDisableThinking bool
 }
 
 // User represents a registered household member.


### PR DESCRIPTION
## Problem

AI digests on the local Qwen3.6-35B-A3B backend (Lemonade) were failing with "stream ended with no content". The cause was **not** Lemonade unloading the model (the earlier diagnosis) — Qwen3.6 is a reasoning model. Left on, it emits its entire completion into `reasoning_content` and hits the token cap (`finish_reason: length`) before producing any `content`. Herald's cloud client only reads `content`, so it saw an empty stream.

Reproduced live against the loaded model:
```
content: ''
reasoning_content: "Here's a thinking process: 1. Analyze User Input..."
finish_reason: length
```

## Fix

Add a `DisableThinking` toggle plumbed `config → EngineConfig → CloudSummarizer → cloudClient`. When set, the request carries `chat_template_kwargs.enable_thinking=false`, which makes Qwen emit content directly (verified live over the streaming path). The field is `omitempty`, so non-reasoning backends (Gemma, Anthropic via Nenya) are unaffected.

## Verification

- `go build ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./...` all green.
- New unit test (`TestGenerateStreamThinkingToggle`) asserts the kwarg is present-and-`false` when enabled, absent otherwise.
- Live streaming generation against the real Qwen endpoint returns real content with the flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)