### PR TITLE
Make summary input-token budget configurable

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"763f9d9b-c60e-406a-b811-a1c5f96a4244","pid":3014369,"procStart":"234412161","acquiredAt":1780612447154}

--- a/cmd/herald-web/config.go
+++ b/cmd/herald-web/config.go
@@ -36,6 +36,10 @@ type SummaryConfig struct {
 	// DisableThinking turns off a reasoning backend's thinking pass (Qwen3 via
 	// Lemonade) so the digest is real content, not an unfinished reasoning_content.
 	DisableThinking bool `toml:"disable_thinking"`
+	// MaxInputTokens caps the digest prompt's input budget. Set it below the
+	// model's context window minus the output budget so Herald trims oldest
+	// articles itself instead of the backend silently dropping them. 0 = default.
+	MaxInputTokens int `toml:"max_input_tokens"`
 }
 
 // WebauthConfig holds webauth OIDC settings.

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -113,6 +113,7 @@ func main() {
 		SummaryModel:           cfg.Summary.Model,
 		SummaryAPIKey:          os.Getenv("HERALD_SUMMARY_API_KEY"),
 		SummaryDisableThinking: cfg.Summary.DisableThinking,
+		SummaryMaxInputTokens:  cfg.Summary.MaxInputTokens,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "herald-web: %v\n", err)

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -513,6 +513,7 @@ func processNewsletters(ctx context.Context) error {
 		SummaryModel:           cfg.Summary.Model,
 		SummaryAPIKey:          os.Getenv("HERALD_SUMMARY_API_KEY"),
 		SummaryDisableThinking: cfg.Summary.DisableThinking,
+		SummaryMaxInputTokens:  cfg.Summary.MaxInputTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("create engine for newsletters: %w", err)

--- a/engine.go
+++ b/engine.go
@@ -99,6 +99,9 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		storeCfg.Summary.Model = cfg.SummaryModel
 	}
 	storeCfg.Summary.DisableThinking = cfg.SummaryDisableThinking
+	if cfg.SummaryMaxInputTokens > 0 {
+		storeCfg.Summary.MaxInputTokens = cfg.SummaryMaxInputTokens
+	}
 	var summarizer *ai.CloudSummarizer
 	if storeCfg.Summary.BaseURL != "" {
 		summarizer = ai.NewCloudSummarizer(

--- a/engine_summary_test.go
+++ b/engine_summary_test.go
@@ -118,6 +118,38 @@ func TestGenerateAISummary(t *testing.T) {
 	}
 }
 
+func TestNewEngineSummaryOverrides(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "h.db")
+	e, err := NewEngine(EngineConfig{
+		DBPath:                 dbPath,
+		ReadOnly:               true,
+		SummaryBaseURL:         "http://example.invalid/v1",
+		SummaryDisableThinking: true,
+		SummaryMaxInputTokens:  100000,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer e.Close()
+
+	if got := e.config.Summary.MaxInputTokens; got != 100000 {
+		t.Errorf("MaxInputTokens = %d, want 100000 (override)", got)
+	}
+	if !e.config.Summary.DisableThinking {
+		t.Error("DisableThinking should be true")
+	}
+
+	// 0 must leave the default untouched, not zero the budget.
+	e2, err := NewEngine(EngineConfig{DBPath: filepath.Join(t.TempDir(), "h2.db"), ReadOnly: true})
+	if err != nil {
+		t.Fatalf("NewEngine 2: %v", err)
+	}
+	defer e2.Close()
+	if got := e2.config.Summary.MaxInputTokens; got != 170000 {
+		t.Errorf("default MaxInputTokens = %d, want 170000", got)
+	}
+}
+
 func digestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/types.go
+++ b/types.go
@@ -25,6 +25,11 @@ type EngineConfig struct {
 	// SummaryDisableThinking turns off the summary backend's reasoning pass
 	// (Qwen3 via Lemonade) so the completion is content, not reasoning_content.
 	SummaryDisableThinking bool
+	// SummaryMaxInputTokens caps the digest prompt's input budget so Herald trims
+	// oldest articles itself (newest-first, with a log line) instead of letting the
+	// backend silently context-shift them out. Must sit below the model's context
+	// window minus the output budget. 0 keeps the config/default value.
+	SummaryMaxInputTokens int
 }
 
 // User represents a registered household member.


### PR DESCRIPTION
## Problem

The digest prompt budget (`MaxInputTokens`) was hardcoded to the `DefaultConfig` value (170000) and never plumbed from config, so neither binary could lower it. That matched the 256K-context Sonnet/Nenya assumption, but the local Qwen backend now serves a **128K** window. A full-backlog digest (~120 articles × 6000 chars ≈ 150–180K tokens) overflowed it, and llama.cpp's `--context-shift` **silently dropped the oldest articles** from the digest.

## Fix

Plumb `max_input_tokens` through `config → EngineConfig.SummaryMaxInputTokens → storeCfg.Summary` (override only when > 0). Set below the model window minus the output budget and Herald trims oldest articles itself, newest-first, with a log line (engine_summary.go:243) — visible truncation instead of a silent backend drop.

Companion homelab change sets `max_input_tokens = 100000` on both summary configs.

## Verification

- `go build`, `go test -race ./...`, `golangci-lint` all green.
- New `TestNewEngineSummaryOverrides`: override applies when set; 0 leaves the 170000 default intact (doesn't zero the budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)