### PR TITLE
Untrack stray .claude/scheduled_tasks.lock; ignore .claude/

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"763f9d9b-c60e-406a-b811-a1c5f96a4244","pid":3014369,"procStart":"234412161","acquiredAt":1780612447154}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ config/config.yaml
 
 # Claude Code / OMC state
 .omc/
+.claude/
 
 # direnv environment (contains DSNs and secrets for MCP servers)
 .envrc


### PR DESCRIPTION
A `git add -A` in #131 swept up the Claude Code scheduler lock file (`.claude/scheduled_tasks.lock`). Remove it from tracking and gitignore the whole `.claude/` state dir so local agent state never lands in the repo again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)