### PR TITLE
Feed tags + tag-grouped two-pane digest feed picker

### DIFF
--- a/cmd/herald-web/feedtags_test.go
+++ b/cmd/herald-web/feedtags_test.go
@@ -1,9 +1,102 @@
 package main
 
 import (
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+
+	herald "github.com/matthewjhunter/herald"
+	"github.com/matthewjhunter/herald/internal/storage"
 )
+
+// TestParseDigestFormTags parses both explicit feeds and followed tags.
+func TestParseDigestFormTags(t *testing.T) {
+	form := url.Values{
+		"name":               {"Sec Brief"},
+		"schedule":           {"daily"},
+		"min_interest_score": {"7.5"},
+		"max_articles":       {"50"},
+		"feed_ids":           {"12", "47", "bad"},
+		"tag_names":          {"security", "  ", "news"},
+		"prompt":             {"  do it  "},
+	}
+	req := httptest.NewRequest("POST", "/newsletters", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if err := req.ParseForm(); err != nil {
+		t.Fatal(err)
+	}
+	name, schedule, _, prompt, cfg := parseDigestForm(req)
+	if name != "Sec Brief" || schedule != "daily" {
+		t.Errorf("name/schedule = %q/%q", name, schedule)
+	}
+	if prompt != "do it" {
+		t.Errorf("prompt = %q, want trimmed 'do it'", prompt)
+	}
+	if len(cfg.IncludeFeeds) != 2 || cfg.IncludeFeeds[0] != 12 || cfg.IncludeFeeds[1] != 47 {
+		t.Errorf("IncludeFeeds = %v, want [12 47] (bad dropped)", cfg.IncludeFeeds)
+	}
+	if len(cfg.IncludeTags) != 2 || cfg.IncludeTags[0] != "security" || cfg.IncludeTags[1] != "news" {
+		t.Errorf("IncludeTags = %v, want [security news] (blank dropped)", cfg.IncludeTags)
+	}
+	if cfg.MinInterestScore != 7.5 || cfg.MaxArticles != 50 {
+		t.Errorf("min/max = %v/%d", cfg.MinInterestScore, cfg.MaxArticles)
+	}
+}
+
+// TestNewsletterListFragmentPicker exercises the edit-form picker inside the real
+// newsletter loop: per-feed FeedTags lookup, tag pre-selection, and the summary line.
+func TestNewsletterListFragmentPicker(t *testing.T) {
+	tags := []string{"Security"}
+	data := newslettersManageData{
+		Feeds:    []herald.Feed{{ID: 12, Title: "Krebs"}, {ID: 47, Title: "Sports"}},
+		FeedTags: map[int64][]string{12: {"Security"}},
+		AllTags:  []string{"Security", "Sports"},
+		Newsletters: []storage.Newsletter{{
+			ID: 5, Name: "Sec Brief", Schedule: "daily",
+			Config: storage.NewsletterConfig{MaxArticles: 50, IncludeFeeds: []int64{47}, IncludeTags: tags},
+		}},
+	}
+	body := render(t, "newsletter_list_fragment", data)
+	for _, want := range []string{
+		`data-picker="5"`,           // edit-form picker keyed by newsletter ID
+		`value="Security" selected`, // followed tag pre-selected in this digest
+		`value="47" data-title="Sports" data-tags="null" selected`, // explicit feed selected
+		"tags: Security", // summary line lists the followed tag
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+// TestFeedPickerTemplate renders the no-JS baseline: two native multi-selects
+// with the right pre-selected feeds and followed tags, plus per-feed tag data.
+func TestFeedPickerTemplate(t *testing.T) {
+	body := render(t, "feed_picker", map[string]any{
+		"Suffix":   "new",
+		"Feeds":    []map[string]any{{"ID": int64(12), "Title": "Krebs"}, {"ID": int64(47), "Title": "Sports"}},
+		"FeedTags": map[int64][]string{12: {"Security"}},
+		"AllTags":  []string{"Security", "Sports"},
+		"SelFeeds": []int64{47},
+		"SelTags":  []string{"Security"},
+	})
+	for _, want := range []string{
+		`name="tag_names"`,
+		`name="feed_ids"`,
+		`value="Security" selected`,        // followed tag pre-selected
+		`value="47" data-title="Sports" `,  // feed option with title
+		`data-tags="[&#34;Security&#34;]"`, // per-feed tags JSON (escaped)
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in:\n%s", want, body)
+		}
+	}
+	// Feed 47 is the selected one; feed 12 is not.
+	if !strings.Contains(body, `value="47" data-title="Sports" data-tags="null" selected`) {
+		t.Errorf("feed 47 should be selected with null tags:\n%s", body)
+	}
+}
 
 // TestFeedTagsCellTemplate renders the per-feed tag cell: chips with remove forms,
 // the add-tag input, and HTML-escaping of tag text.

--- a/cmd/herald-web/feedtags_test.go
+++ b/cmd/herald-web/feedtags_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFeedTagsCellTemplate renders the per-feed tag cell: chips with remove forms,
+// the add-tag input, and HTML-escaping of tag text.
+func TestFeedTagsCellTemplate(t *testing.T) {
+	body := render(t, "feed_tags_cell", map[string]any{
+		"FeedID": int64(42),
+		"Tags":   []string{"Security", "a<b>"},
+	})
+	for _, want := range []string{
+		`id="feed-tags-cell-42"`,
+		"Security",
+		`hx-delete="/feeds/42/tags"`,
+		`hx-post="/feeds/42/tags"`,
+		`name="tag"`,
+		`list="all-tags-list"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in:\n%s", want, body)
+		}
+	}
+	// Tag text is escaped (no raw markup injected).
+	if strings.Contains(body, "a<b>") {
+		t.Errorf("tag not HTML-escaped:\n%s", body)
+	}
+	if !strings.Contains(body, "a&lt;b&gt;") {
+		t.Errorf("expected escaped tag a&lt;b&gt;:\n%s", body)
+	}
+}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -120,6 +120,9 @@ func (h *handlers) init() {
 		"int64in": func(haystack []int64, needle int64) bool {
 			return slices.Contains(haystack, needle)
 		},
+		"strin": func(haystack []string, needle string) bool {
+			return slices.Contains(haystack, needle)
+		},
 		"assetVersion": func() string { return version },
 		"buildVersion": func() string { return version },
 		"buildTime":    func() string { return buildTime },
@@ -226,7 +229,8 @@ type articleViewData struct {
 }
 
 type feedManageData struct {
-	Feeds []feedRow
+	Feeds   []feedRow
+	AllTags []string // every tag the user has applied (datalist autocomplete)
 }
 
 type feedRow struct {
@@ -234,6 +238,7 @@ type feedRow struct {
 	Title                string
 	URL                  string
 	SiteURL              string
+	Tags                 []string
 	TotalArticles        int
 	UnreadArticles       int
 	UnsummarizedArticles int
@@ -509,13 +514,17 @@ func (h *handlers) handleFeedsManage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data := feedManageData{}
+	feedTags, _ := h.engine.GetAllFeedTags(uid)
+	allTags, _ := h.engine.GetUserTags(uid)
+
+	data := feedManageData{AllTags: allTags}
 	for _, f := range feeds {
 		row := feedRow{
 			FeedID:  f.ID,
 			Title:   f.Title,
 			URL:     f.URL,
 			SiteURL: f.SiteURL,
+			Tags:    feedTags[f.ID],
 		}
 		if f.LastError != nil {
 			row.LastError = *f.LastError
@@ -1208,6 +1217,51 @@ func (h *handlers) handleFeedRename(w http.ResponseWriter, r *http.Request) {
 		"FeedID": feedID,
 		"Title":  title,
 	})
+}
+
+// renderFeedTagsCell re-renders one feed's tag cell (chips + add input) after a
+// tag change, so htmx can swap it in place.
+func (h *handlers) renderFeedTagsCell(w http.ResponseWriter, uid, feedID int64) {
+	tags, _ := h.engine.GetFeedTags(uid, feedID)
+	allTags, _ := h.engine.GetUserTags(uid)
+	h.renderFragment(w, "feed_tags_cell", map[string]any{
+		"FeedID":  feedID,
+		"Tags":    tags,
+		"AllTags": allTags,
+	})
+}
+
+// handleFeedTagAdd tags a feed for the current user and returns the updated cell.
+func (h *handlers) handleFeedTagAdd(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	feedID, err := strconv.ParseInt(r.PathValue("feedID"), 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid feed ID", http.StatusBadRequest)
+		return
+	}
+	tag := strings.TrimSpace(r.FormValue("tag"))
+	if tag != "" {
+		if err := h.engine.AddFeedTag(uid, feedID, tag); err != nil {
+			http.Error(w, "Failed to add tag", http.StatusBadRequest)
+			return
+		}
+	}
+	h.renderFeedTagsCell(w, uid, feedID)
+}
+
+// handleFeedTagRemove removes a tag from a feed and returns the updated cell.
+func (h *handlers) handleFeedTagRemove(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	feedID, err := strconv.ParseInt(r.PathValue("feedID"), 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid feed ID", http.StatusBadRequest)
+		return
+	}
+	if err := h.engine.RemoveFeedTag(uid, feedID, r.FormValue("tag")); err != nil {
+		http.Error(w, "Failed to remove tag", http.StatusInternalServerError)
+		return
+	}
+	h.renderFeedTagsCell(w, uid, feedID)
 }
 
 // handleArticleImage serves a cached article image by its ID.

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -123,6 +123,12 @@ func (h *handlers) init() {
 		"strin": func(haystack []string, needle string) bool {
 			return slices.Contains(haystack, needle)
 		},
+		"toJSON": func(v any) (string, error) {
+			b, err := json.Marshal(v)
+			return string(b), err
+		},
+		"emptyInts":    func() []int64 { return nil },
+		"emptyStrs":    func() []string { return nil },
 		"assetVersion": func() string { return version },
 		"buildVersion": func() string { return version },
 		"buildTime":    func() string { return buildTime },
@@ -921,6 +927,8 @@ func (h *handlers) handleGroupMarkRead(w http.ResponseWriter, r *http.Request) {
 type newslettersManageData struct {
 	Newsletters []storage.Newsletter
 	Feeds       []herald.Feed
+	FeedTags    map[int64][]string // feed ID → its tags (picker grouping)
+	AllTags     []string           // distinct tags the user has applied
 }
 
 func (h *handlers) handleNewslettersManage(w http.ResponseWriter, r *http.Request) {
@@ -947,8 +955,9 @@ func (h *handlers) handleNewsletterCreate(w http.ResponseWriter, r *http.Request
 	h.renderFragment(w, "newsletter_list_fragment", h.digestManageData(uid))
 }
 
-// parseDigestForm reads the shared digest-config form (name, schedule, prompt,
-// filters, and the feed multi-select → Config.IncludeFeeds).
+// parseDigestForm reads the shared digest-config form: name, schedule, prompt,
+// filters, the explicit feed picks (feed_ids → Config.IncludeFeeds) and the
+// followed tags (tag_names → Config.IncludeTags).
 func parseDigestForm(r *http.Request) (name, schedule, email, prompt string, config storage.NewsletterConfig) {
 	minScore, _ := strconv.ParseFloat(r.FormValue("min_interest_score"), 64)
 	maxArticles, _ := strconv.Atoi(r.FormValue("max_articles"))
@@ -958,15 +967,23 @@ func parseDigestForm(r *http.Request) (name, schedule, email, prompt string, con
 			feeds = append(feeds, id)
 		}
 	}
-	config = storage.NewsletterConfig{MinInterestScore: minScore, MaxArticles: maxArticles, IncludeFeeds: feeds}
+	var tags []string
+	for _, s := range r.Form["tag_names"] {
+		if s = strings.TrimSpace(s); s != "" {
+			tags = append(tags, s)
+		}
+	}
+	config = storage.NewsletterConfig{MinInterestScore: minScore, MaxArticles: maxArticles, IncludeFeeds: feeds, IncludeTags: tags}
 	return r.FormValue("name"), r.FormValue("schedule"), r.FormValue("email_recipient"), strings.TrimSpace(r.FormValue("prompt")), config
 }
 
-// digestManageData loads the config list plus the user's feeds for the form.
+// digestManageData loads the config list plus the user's feeds and tags for the form.
 func (h *handlers) digestManageData(uid int64) newslettersManageData {
 	configs, _ := h.engine.GetUserNewsletters(uid)
 	feeds, _ := h.engine.GetUserFeeds(uid)
-	return newslettersManageData{Newsletters: configs, Feeds: feeds}
+	feedTags, _ := h.engine.GetAllFeedTags(uid)
+	allTags, _ := h.engine.GetUserTags(uid)
+	return newslettersManageData{Newsletters: configs, Feeds: feeds, FeedTags: feedTags, AllTags: allTags}
 }
 
 func (h *handlers) handleNewsletterDelete(w http.ResponseWriter, r *http.Request) {

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -62,6 +62,8 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)))
 	mux.Handle("GET /feeds/{feedID}/edit-title", auth(http.HandlerFunc(h.handleFeedEditTitle)))
 	mux.Handle("GET /feeds/{feedID}/title", auth(http.HandlerFunc(h.handleFeedTitleDisplay)))
+	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)))
+	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)))
 	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)))
 	mux.Handle("POST /settings/opml-token", auth(http.HandlerFunc(h.handleOPMLTokenGenerate)))
 	mux.Handle("POST /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialSave)))

--- a/cmd/herald-web/templates/feeds_manage.html
+++ b/cmd/herald-web/templates/feeds_manage.html
@@ -45,6 +45,25 @@
 {{end}}
 {{end}}
 
+{{define "feed_tags_cell"}}
+<div id="feed-tags-cell-{{.FeedID}}" style="display:flex;flex-wrap:wrap;align-items:center;gap:0.3rem;">
+    {{range .Tags}}
+    <span class="feed-tag-chip">{{.}}<form style="display:inline;margin:0;"
+            hx-delete="/feeds/{{$.FeedID}}/tags"
+            hx-target="#feed-tags-cell-{{$.FeedID}}" hx-swap="outerHTML">
+        <input type="hidden" name="tag" value="{{.}}">
+        <button type="submit" title="Remove tag">✕</button></form></span>
+    {{end}}
+    <form style="display:inline-flex;margin:0;" autocomplete="off"
+          hx-post="/feeds/{{.FeedID}}/tags"
+          hx-target="#feed-tags-cell-{{.FeedID}}" hx-swap="outerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset();">
+        <input type="text" name="tag" placeholder="+ tag" list="all-tags-list" maxlength="50"
+               style="margin:0;padding:0.1rem 0.4rem;font-size:0.75rem;width:7rem;">
+    </form>
+</div>
+{{end}}
+
 {{define "title"}}Herald - Manage Feeds{{end}}
 {{define "nav"}}{{template "shared-nav" "feeds"}}{{end}}
 {{define "content"}}
@@ -90,6 +109,7 @@
                     <th data-col="3" class="sortable" style="text-align:right;">Unscored</th>
                     <th data-col="4" class="sortable">Last Post</th>
                     <th data-col="5" class="sortable">Last Fetched</th>
+                    <th>Tags</th>
                     <th></th>
                 </tr>
             </thead>
@@ -106,6 +126,7 @@
                     <td style="text-align:right;">{{if .UnsummarizedArticles}}{{.UnsummarizedArticles}}{{else}}0{{end}}</td>
                     <td>{{.LastPostDateFmt}}</td>
                     <td>{{.LastFetchedFmt}}</td>
+                    <td>{{template "feed_tags_cell" (dict "FeedID" .FeedID "Tags" .Tags)}}</td>
                     <td>
                         <button class="outline secondary" style="padding:0.25rem 0.5rem;font-size:0.8rem;"
                                 hx-delete="/feeds/{{.FeedID}}"
@@ -118,11 +139,19 @@
                 {{end}}
             </tbody>
         </table>
+        <datalist id="all-tags-list">{{range .AllTags}}<option value="{{.}}"></option>{{end}}</datalist>
         <style>
             #feeds-table th.sortable { cursor:pointer; user-select:none; white-space:nowrap; }
             #feeds-table th.sortable:hover { opacity:0.75; }
             #feeds-table th.sort-asc::after { content:" ▲"; font-size:0.7em; }
             #feeds-table th.sort-desc::after { content:" ▼"; font-size:0.7em; }
+            .feed-tag-chip { display:inline-flex; align-items:center; gap:0.15rem;
+                background:var(--pico-secondary-background); color:var(--pico-secondary-inverse);
+                border-radius:0.8rem; padding:0.05rem 0.5rem; font-size:0.75rem; white-space:nowrap; }
+            .feed-tag-chip form { display:inline; }
+            .feed-tag-chip button { background:none; border:none; color:inherit; cursor:pointer;
+                padding:0; margin:0; font-size:0.8rem; line-height:1; opacity:0.7; width:auto; }
+            .feed-tag-chip button:hover { opacity:1; }
         </style>
         {{else}}
         <p class="empty-state">No feeds subscribed. Add one above.</p>

--- a/cmd/herald-web/templates/newsletters_manage.html
+++ b/cmd/herald-web/templates/newsletters_manage.html
@@ -22,11 +22,7 @@
                 <label>Min Interest Score<input type="number" name="min_interest_score" value="0" min="0" max="10" step="0.5"></label>
                 <label>Max Articles<input type="number" name="max_articles" value="100" min="1" max="500"></label>
             </div>
-            <label>Feeds to include (none = all feeds)
-                <select multiple name="feed_ids" size="6">
-                    {{range .Feeds}}<option value="{{.ID}}">{{.Title}}</option>{{end}}
-                </select>
-            </label>
+            {{template "feed_picker" (dict "Suffix" "new" "Feeds" .Feeds "FeedTags" .FeedTags "AllTags" .AllTags "SelFeeds" emptyInts "SelTags" emptyStrs)}}
             <label>Prompt (leave blank for the default summary prompt)
                 <textarea name="prompt" rows="6" style="font-family:monospace;font-size:0.85em;"></textarea>
             </label>
@@ -39,6 +35,7 @@
         {{template "newsletter_list_fragment" .}}
     </div>
 </main>
+{{template "feed_picker_assets"}}
 {{end}}
 
 {{define "newsletter_list_fragment"}}
@@ -49,7 +46,8 @@
     <header style="display:flex;justify-content:space-between;align-items:center;">
         <strong>{{.Name}}</strong>
         <span class="meta">{{.Schedule}} &middot; min {{printf "%.1f" .Config.MinInterestScore}} &middot; max {{.Config.MaxArticles}}
-            {{if .Config.IncludeFeeds}}&middot; {{len .Config.IncludeFeeds}} feed(s){{else}}&middot; all feeds{{end}}
+            {{if .Config.IncludeTags}}&middot; tags: {{range $i, $t := .Config.IncludeTags}}{{if $i}}, {{end}}{{$t}}{{end}}{{end}}
+            {{if .Config.IncludeFeeds}}&middot; {{len .Config.IncludeFeeds}} feed(s){{else}}{{if not .Config.IncludeTags}}&middot; all feeds{{end}}{{end}}
             {{if .EmailRecipient}}&middot; ✉ {{.EmailRecipient}}{{end}}</span>
     </header>
     <div style="display:flex;gap:0.5rem;align-items:center;">
@@ -77,12 +75,7 @@
                 <label>Min Interest Score<input type="number" name="min_interest_score" min="0" max="10" step="0.5" value="{{printf "%.1f" .Config.MinInterestScore}}"></label>
                 <label>Max Articles<input type="number" name="max_articles" min="1" max="500" value="{{.Config.MaxArticles}}"></label>
             </div>
-            <label>Feeds to include (none = all feeds)
-                <select multiple name="feed_ids" size="6">
-                    {{$nl := .}}
-                    {{range $feeds}}<option value="{{.ID}}" {{if int64in $nl.Config.IncludeFeeds .ID}}selected{{end}}>{{.Title}}</option>{{end}}
-                </select>
-            </label>
+            {{template "feed_picker" (dict "Suffix" .ID "Feeds" $feeds "FeedTags" $.FeedTags "AllTags" $.AllTags "SelFeeds" .Config.IncludeFeeds "SelTags" .Config.IncludeTags)}}
             <label>Prompt (leave blank for the default summary prompt)
                 <textarea name="prompt" rows="6" style="font-family:monospace;font-size:0.85em;">{{.PromptTemplate}}</textarea>
             </label>
@@ -95,4 +88,151 @@
 {{else}}
 <p class="empty-state">No digests yet.</p>
 {{end}}
+{{end}}
+
+{{/* feed_picker: progressive-enhancement feed selector. The baseline is two
+     native multi-selects (tag_names → followed tags, feed_ids → explicit feeds),
+     fully functional without JS. The script below enhances it into a two-pane
+     transfer list. Context: Suffix, Feeds, FeedTags(map id→[]tag), AllTags,
+     SelFeeds([]int64), SelTags([]string). */}}
+{{define "feed_picker"}}
+<div class="feed-picker" data-picker="{{.Suffix}}">
+    <p class="fp-hint">Pick feeds to summarize. Follow a <strong>tag</strong> to auto-include every feed carrying it (new feeds tagged later join automatically). No tags and no feeds = all feeds.</p>
+    <fieldset class="fp-native">
+        <label>Follow tags
+            <select multiple name="tag_names" size="4" class="fp-tags">
+                {{range .AllTags}}<option value="{{.}}"{{if strin $.SelTags .}} selected{{end}}>{{.}}</option>{{end}}
+            </select>
+        </label>
+        <label>Include individual feeds
+            <select multiple name="feed_ids" size="6" class="fp-feeds">
+                {{range .Feeds}}<option value="{{.ID}}" data-title="{{.Title}}" data-tags="{{toJSON (index $.FeedTags .ID)}}"{{if int64in $.SelFeeds .ID}} selected{{end}}>{{.Title}}</option>{{end}}
+            </select>
+        </label>
+    </fieldset>
+</div>
+{{end}}
+
+{{define "feed_picker_assets"}}
+<style>
+    .feed-picker { margin-bottom: 1rem; }
+    .fp-hint { font-size: 0.8rem; color: var(--pico-muted-color); margin: 0 0 0.4rem; }
+    .feed-picker.fp-on .fp-native { display: none; }
+    .fp-panes { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
+    .fp-pane { border: 1px solid var(--pico-muted-border-color); border-radius: 0.4rem; padding: 0.5rem; }
+    .fp-pane h5 { margin: 0 0 0.4rem; font-size: 0.8rem; text-transform: uppercase; color: var(--pico-muted-color); }
+    .fp-search { width: 100%; margin: 0 0 0.5rem; padding: 0.2rem 0.4rem; font-size: 0.85rem; }
+    .fp-scroll { max-height: 16rem; overflow-y: auto; }
+    .fp-group > summary { cursor: pointer; font-size: 0.8rem; font-weight: 600; padding: 0.2rem 0; }
+    .fp-row { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; padding: 0.15rem 0.25rem; font-size: 0.85rem; }
+    .fp-row button { padding: 0 0.4rem; margin: 0; font-size: 0.8rem; line-height: 1.4; width: auto; }
+    .fp-chip { display: inline-flex; align-items: center; gap: 0.2rem; background: var(--pico-secondary-background); color: var(--pico-secondary-inverse); border-radius: 0.8rem; padding: 0.1rem 0.55rem; margin: 0.15rem 0.2rem 0 0; font-size: 0.8rem; }
+    .fp-chip.fp-tagchip { background: var(--pico-primary-background); color: var(--pico-primary-inverse); }
+    .fp-chip button { background: none; border: none; color: inherit; cursor: pointer; padding: 0; margin: 0; width: auto; font-size: 0.85rem; line-height: 1; }
+    .fp-included-empty { font-size: 0.8rem; color: var(--pico-muted-color); }
+</style>
+<script>
+(function () {
+    function esc(s) { return String(s).replace(/[&<>"]/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]; }); }
+
+    function buildPicker(pick) {
+        if (pick.dataset.fpInit) return;
+        pick.dataset.fpInit = '1';
+        var tagSel = pick.querySelector('.fp-tags');
+        var feedSel = pick.querySelector('.fp-feeds');
+        if (!feedSel) return;
+
+        var feeds = Array.prototype.map.call(feedSel.options, function (o) {
+            var tags = [];
+            try { tags = JSON.parse(o.dataset.tags || '[]') || []; } catch (e) { tags = []; }
+            return { id: o.value, title: o.dataset.title || o.text, tags: tags, opt: o };
+        });
+        var tagOpts = tagSel ? Array.prototype.slice.call(tagSel.options) : [];
+
+        var ui = document.createElement('div');
+        ui.className = 'fp-panes';
+        ui.innerHTML =
+            '<div class="fp-pane fp-avail"><h5>Available</h5>' +
+            '<input type="search" class="fp-search" placeholder="filter feeds…"><div class="fp-scroll"></div></div>' +
+            '<div class="fp-pane fp-incl"><h5>Included</h5><div class="fp-scroll fp-incl-body"></div></div>';
+        pick.appendChild(ui);
+        pick.classList.add('fp-on');
+
+        var availBody = ui.querySelector('.fp-avail .fp-scroll');
+        var inclBody = ui.querySelector('.fp-incl-body');
+        var search = ui.querySelector('.fp-search');
+
+        function tagSelected(name) {
+            var o = tagOpts.find(function (t) { return t.value === name; });
+            return o ? o.selected : false;
+        }
+        function setTag(name, on) {
+            var o = tagOpts.find(function (t) { return t.value === name; });
+            if (o) o.selected = on;
+        }
+
+        function renderAvail() {
+            var q = (search.value || '').toLowerCase();
+            var groups = {}; var order = [];
+            tagOpts.forEach(function (t) { groups[t.value] = []; order.push(t.value); });
+            var untagged = [];
+            feeds.forEach(function (f) {
+                if (q && f.title.toLowerCase().indexOf(q) === -1) return;
+                if (!f.tags.length) { untagged.push(f); return; }
+                f.tags.forEach(function (tg) { if (!(tg in groups)) { groups[tg] = []; order.push(tg); } groups[tg].push(f); });
+            });
+            var html = '';
+            order.forEach(function (tg) {
+                if (!groups[tg].length) return;
+                html += '<details class="fp-group" open><summary>' + esc(tg) +
+                    ' <button type="button" class="outline" data-follow="' + esc(tg) + '">' +
+                    (tagSelected(tg) ? 'following ✓' : 'follow →') + '</button></summary>';
+                groups[tg].forEach(function (f) {
+                    html += '<div class="fp-row"><span>' + esc(f.title) + '</span>' +
+                        '<button type="button" class="outline" data-add="' + esc(f.id) + '">' + (f.opt.selected ? '✓' : '+') + '</button></div>';
+                });
+                html += '</details>';
+            });
+            if (untagged.length) {
+                html += '<details class="fp-group"><summary>Untagged</summary>';
+                untagged.forEach(function (f) {
+                    html += '<div class="fp-row"><span>' + esc(f.title) + '</span>' +
+                        '<button type="button" class="outline" data-add="' + esc(f.id) + '">' + (f.opt.selected ? '✓' : '+') + '</button></div>';
+                });
+                html += '</details>';
+            }
+            availBody.innerHTML = html || '<p class="fp-included-empty">No feeds.</p>';
+        }
+
+        function renderIncl() {
+            var html = '';
+            tagOpts.filter(function (t) { return t.selected; }).forEach(function (t) {
+                html += '<span class="fp-chip fp-tagchip">#' + esc(t.value) +
+                    '<button type="button" data-unfollow="' + esc(t.value) + '">✕</button></span>';
+            });
+            feeds.filter(function (f) { return f.opt.selected; }).forEach(function (f) {
+                html += '<span class="fp-chip">' + esc(f.title) +
+                    '<button type="button" data-rm="' + esc(f.id) + '">✕</button></span>';
+            });
+            inclBody.innerHTML = html || '<p class="fp-included-empty">Nothing selected → all feeds.</p>';
+        }
+
+        function rerender() { renderAvail(); renderIncl(); }
+
+        pick.addEventListener('click', function (e) {
+            var b = e.target.closest('button'); if (!b || !pick.contains(b)) return;
+            if (b.dataset.add != null) { var f = feeds.find(function (x) { return x.id === b.dataset.add; }); if (f) f.opt.selected = true; e.preventDefault(); rerender(); }
+            else if (b.dataset.rm != null) { var f2 = feeds.find(function (x) { return x.id === b.dataset.rm; }); if (f2) f2.opt.selected = false; e.preventDefault(); rerender(); }
+            else if (b.dataset.follow != null) { setTag(b.dataset.follow, true); e.preventDefault(); rerender(); }
+            else if (b.dataset.unfollow != null) { setTag(b.dataset.unfollow, false); e.preventDefault(); rerender(); }
+        });
+        search.addEventListener('input', renderAvail);
+        rerender();
+    }
+
+    function init(root) { (root || document).querySelectorAll('.feed-picker').forEach(buildPicker); }
+    if (document.readyState !== 'loading') init(); else document.addEventListener('DOMContentLoaded', function () { init(); });
+    document.body.addEventListener('htmx:afterSwap', function (e) { init(e.target); });
+})();
+</script>
 {{end}}

--- a/engine.go
+++ b/engine.go
@@ -569,6 +569,67 @@ func (e *Engine) GetUserFeeds(userID int64) ([]Feed, error) {
 	return feedsFromInternal(feeds), nil
 }
 
+// AddFeedTag tags a feed for a user. RemoveFeedTag, GetFeedTags, GetAllFeedTags,
+// and GetUserTags are thin passthroughs to the store for the web handlers.
+func (e *Engine) AddFeedTag(userID, feedID int64, tag string) error {
+	return e.store.AddFeedTag(userID, feedID, tag)
+}
+
+// RemoveFeedTag removes a tag from a feed for a user.
+func (e *Engine) RemoveFeedTag(userID, feedID int64, tag string) error {
+	return e.store.RemoveFeedTag(userID, feedID, tag)
+}
+
+// GetFeedTags returns one feed's tags for a user.
+func (e *Engine) GetFeedTags(userID, feedID int64) ([]string, error) {
+	return e.store.GetFeedTags(userID, feedID)
+}
+
+// GetAllFeedTags returns every tagged feed's tags for a user, keyed by feed ID.
+func (e *Engine) GetAllFeedTags(userID int64) (map[int64][]string, error) {
+	return e.store.GetAllFeedTags(userID)
+}
+
+// GetUserTags returns the distinct tags a user has applied.
+func (e *Engine) GetUserTags(userID int64) ([]string, error) {
+	return e.store.GetUserTags(userID)
+}
+
+// effectiveIncludeFeeds expands a digest config's followed tags (IncludeTags)
+// into the feeds currently carrying them and unions that with the explicit
+// IncludeFeeds, de-duplicated. With no followed tags it returns IncludeFeeds
+// unchanged. A followed tag that resolves to no feeds contributes nothing — if
+// that leaves the union empty and IncludeFeeds was empty, selection falls
+// through to "all feeds" (an empty restriction).
+func (e *Engine) effectiveIncludeFeeds(userID int64, cfg storage.NewsletterConfig) []int64 {
+	if len(cfg.IncludeTags) == 0 {
+		return cfg.IncludeFeeds
+	}
+	tagged, err := e.store.GetFeedsByTags(userID, cfg.IncludeTags)
+	if err != nil {
+		log.Printf("herald: resolve digest tags for user %d: %v", userID, err)
+		return cfg.IncludeFeeds
+	}
+	if len(tagged) == 0 {
+		return cfg.IncludeFeeds
+	}
+	seen := make(map[int64]bool, len(cfg.IncludeFeeds)+len(tagged))
+	out := make([]int64, 0, len(cfg.IncludeFeeds)+len(tagged))
+	for _, id := range cfg.IncludeFeeds {
+		if !seen[id] {
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	for _, id := range tagged {
+		if !seen[id] {
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // feedURLCandidates returns the URLs to attempt for a user-supplied feed
 // input. If the input already contains a scheme it's returned as-is;
 // otherwise https:// is tried first and http:// as a fallback, so a user

--- a/engine_summary.go
+++ b/engine_summary.go
@@ -94,7 +94,12 @@ func (e *Engine) selectDigestArticles(userID int64, newsletterID *int64) ([]stor
 		if limit <= 0 {
 			limit = 1000
 		}
-		articles, _, err := e.store.GetNewsletterArticles(userID, &nl.Config, nl.LastGeneratedAt, limit)
+		// Resolve followed tags to the feeds currently carrying them and merge
+		// into the explicit feed set, so the digest tracks tag membership at
+		// generation time. The storage query stays purely feed-ID based.
+		cfg := nl.Config
+		cfg.IncludeFeeds = e.effectiveIncludeFeeds(userID, cfg)
+		articles, _, err := e.store.GetNewsletterArticles(userID, &cfg, nl.LastGeneratedAt, limit)
 		return articles, err
 	}
 	sum := e.config.Summary

--- a/engine_summary_test.go
+++ b/engine_summary_test.go
@@ -118,6 +118,66 @@ func TestGenerateAISummary(t *testing.T) {
 	}
 }
 
+func TestEffectiveIncludeFeeds(t *testing.T) {
+	store, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "h.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	uid, _ := store.CreateUser("u")
+	f1, _ := store.AddFeed("https://a/feed", "A", "")
+	f2, _ := store.AddFeed("https://b/feed", "B", "")
+	f3, _ := store.AddFeed("https://c/feed", "C", "")
+	for _, f := range []int64{f1, f2, f3} {
+		_ = store.SubscribeUserToFeed(uid, f)
+	}
+	_ = store.AddFeedTag(uid, f1, "security")
+	_ = store.AddFeedTag(uid, f2, "security")
+
+	e := &Engine{store: store}
+
+	// No followed tags → IncludeFeeds returned unchanged.
+	cfg := storage.NewsletterConfig{IncludeFeeds: []int64{f3}}
+	if got := e.effectiveIncludeFeeds(uid, cfg); !sameIDs(got, []int64{f3}) {
+		t.Errorf("no tags: got %v, want [%d]", got, f3)
+	}
+
+	// Followed tag unions with the explicit feed, de-duped (f1 is both tagged and explicit).
+	cfg = storage.NewsletterConfig{IncludeFeeds: []int64{f1, f3}, IncludeTags: []string{"security"}}
+	if got := e.effectiveIncludeFeeds(uid, cfg); !sameIDs(got, []int64{f1, f2, f3}) {
+		t.Errorf("tag+explicit: got %v, want {%d,%d,%d}", got, f1, f2, f3)
+	}
+
+	// Dynamic-follow guarantee: tagging a new feed later adds it without editing the config.
+	_ = store.AddFeedTag(uid, f3, "security")
+	cfg = storage.NewsletterConfig{IncludeTags: []string{"security"}}
+	if got := e.effectiveIncludeFeeds(uid, cfg); !sameIDs(got, []int64{f1, f2, f3}) {
+		t.Errorf("after retag: got %v, want {%d,%d,%d}", got, f1, f2, f3)
+	}
+
+	// A followed tag that resolves to nothing leaves IncludeFeeds untouched.
+	cfg = storage.NewsletterConfig{IncludeFeeds: []int64{f3}, IncludeTags: []string{"nonexistent"}}
+	if got := e.effectiveIncludeFeeds(uid, cfg); !sameIDs(got, []int64{f3}) {
+		t.Errorf("empty tag: got %v, want [%d]", got, f3)
+	}
+}
+
+func sameIDs(got, want []int64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	m := map[int64]bool{}
+	for _, v := range got {
+		m[v] = true
+	}
+	for _, v := range want {
+		if !m[v] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestNewEngineSummaryOverrides(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "h.db")
 	e, err := NewEngine(EngineConfig{

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -109,6 +109,17 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		WHERE search_vector IS NULL`,
 		// Link a generated AI digest to the config (newsletter) that produced it.
 		"ALTER TABLE ai_summaries ADD COLUMN IF NOT EXISTS newsletter_id BIGINT REFERENCES newsletters(id) ON DELETE SET NULL",
+		// Per-user feed tags (many-to-many): group feeds so a digest can follow a
+		// tag. New table for existing DBs; fresh DBs get it from the schema.
+		`CREATE TABLE IF NOT EXISTS feed_tags (
+			user_id    BIGINT NOT NULL DEFAULT 1,
+			feed_id    BIGINT NOT NULL,
+			tag        TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+		)`,
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_tags_unique ON feed_tags(user_id, feed_id, lower(tag))",
+		"CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, lower(tag))",
 	}
 	for _, m := range pgMigrations {
 		if _, err := db.Exec(m); err != nil {
@@ -1876,6 +1887,132 @@ func (s *PostgresStore) SubscribeUserToFeed(userID, feedID int64) error {
 		return fmt.Errorf("failed to subscribe user to feed: %w", err)
 	}
 	return nil
+}
+
+// AddFeedTag tags a feed for a user (idempotent; case-insensitive duplicate is a no-op).
+func (s *PostgresStore) AddFeedTag(userID, feedID int64, tag string) error {
+	tag = normalizeTag(tag)
+	if tag == "" {
+		return fmt.Errorf("empty tag")
+	}
+	_, err := s.db.Exec(
+		"INSERT INTO feed_tags (user_id, feed_id, tag) VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
+		userID, feedID, tag,
+	)
+	if err != nil {
+		return fmt.Errorf("add feed tag: %w", err)
+	}
+	return nil
+}
+
+// RemoveFeedTag removes a tag from a feed for a user (case-insensitive).
+func (s *PostgresStore) RemoveFeedTag(userID, feedID int64, tag string) error {
+	tag = normalizeTag(tag)
+	_, err := s.db.Exec(
+		"DELETE FROM feed_tags WHERE user_id = ? AND feed_id = ? AND lower(tag) = lower(?)",
+		userID, feedID, tag,
+	)
+	if err != nil {
+		return fmt.Errorf("remove feed tag: %w", err)
+	}
+	return nil
+}
+
+// GetFeedTags returns one feed's tags for a user, sorted.
+func (s *PostgresStore) GetFeedTags(userID, feedID int64) ([]string, error) {
+	rows, err := s.db.Query(
+		"SELECT tag FROM feed_tags WHERE user_id = ? AND feed_id = ? ORDER BY tag",
+		userID, feedID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get feed tags: %w", err)
+	}
+	defer rows.Close()
+	var tags []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("scan feed tag: %w", err)
+		}
+		tags = append(tags, t)
+	}
+	return tags, rows.Err()
+}
+
+// GetAllFeedTags returns every tagged feed's tags for a user in one query.
+func (s *PostgresStore) GetAllFeedTags(userID int64) (map[int64][]string, error) {
+	rows, err := s.db.Query(
+		"SELECT feed_id, tag FROM feed_tags WHERE user_id = ? ORDER BY feed_id, tag",
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get all feed tags: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[int64][]string)
+	for rows.Next() {
+		var fid int64
+		var t string
+		if err := rows.Scan(&fid, &t); err != nil {
+			return nil, fmt.Errorf("scan feed tag: %w", err)
+		}
+		out[fid] = append(out[fid], t)
+	}
+	return out, rows.Err()
+}
+
+// GetUserTags returns the distinct tags a user has applied, sorted.
+func (s *PostgresStore) GetUserTags(userID int64) ([]string, error) {
+	rows, err := s.db.Query(
+		"SELECT DISTINCT tag FROM feed_tags WHERE user_id = ? ORDER BY tag",
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user tags: %w", err)
+	}
+	defer rows.Close()
+	var tags []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("scan user tag: %w", err)
+		}
+		tags = append(tags, t)
+	}
+	return tags, rows.Err()
+}
+
+// GetFeedsByTags resolves a set of tags to the distinct feed IDs carrying any of
+// them (case-insensitive). Empty input returns nil.
+func (s *PostgresStore) GetFeedsByTags(userID int64, tags []string) ([]int64, error) {
+	norm := normalizeTags(tags)
+	if len(norm) == 0 {
+		return nil, nil
+	}
+	ph := make([]string, len(norm))
+	args := make([]any, 0, len(norm)+1)
+	args = append(args, userID)
+	for i, t := range norm {
+		ph[i] = "lower(?)"
+		args = append(args, t)
+	}
+	rows, err := s.db.Query(
+		"SELECT DISTINCT feed_id FROM feed_tags WHERE user_id = ? AND lower(tag) IN ("+strings.Join(ph, ",")+") ORDER BY feed_id",
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get feeds by tags: %w", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan feed id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 func (s *PostgresStore) GetUserFeeds(userID int64) ([]Feed, error) {

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -82,6 +82,17 @@ CREATE TABLE IF NOT EXISTS user_feeds (
 
 CREATE INDEX IF NOT EXISTS idx_user_feeds_feed ON user_feeds(feed_id);
 
+CREATE TABLE IF NOT EXISTS feed_tags (
+    user_id INTEGER NOT NULL DEFAULT 1,
+    feed_id INTEGER NOT NULL,
+    tag TEXT NOT NULL COLLATE NOCASE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, feed_id, tag),
+    FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, tag);
+
 CREATE TABLE IF NOT EXISTS article_summaries (
     user_id INTEGER NOT NULL DEFAULT 1,
     article_id INTEGER NOT NULL,

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -88,6 +88,17 @@ CREATE TABLE IF NOT EXISTS user_feeds (
 
 CREATE INDEX IF NOT EXISTS idx_user_feeds_feed ON user_feeds(feed_id);
 
+CREATE TABLE IF NOT EXISTS feed_tags (
+    user_id    BIGINT NOT NULL DEFAULT 1,
+    feed_id    BIGINT NOT NULL,
+    tag        TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_tags_unique ON feed_tags(user_id, feed_id, lower(tag));
+CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, lower(tag));
+
 CREATE TABLE IF NOT EXISTS article_summaries (
     user_id      BIGINT NOT NULL DEFAULT 1,
     article_id   BIGINT NOT NULL,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -114,7 +114,10 @@ type NewsletterConfig struct {
 	ExcludeFeeds      []int64  `json:"exclude_feeds,omitempty"`
 	IncludeCategories []string `json:"include_categories,omitempty"`
 	ExcludeCategories []string `json:"exclude_categories,omitempty"`
-	MaxArticles       int      `json:"max_articles"`
+	// IncludeTags names feed tags this digest follows: at generation time they
+	// resolve to whatever feeds currently carry the tag, unioned with IncludeFeeds.
+	IncludeTags []string `json:"include_tags,omitempty"`
+	MaxArticles int      `json:"max_articles"`
 }
 
 // Newsletter represents a user-defined newsletter/digest configuration.
@@ -343,6 +346,17 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		// NULL = ad-hoc. SQLite can't add a FK via ALTER — fresh DBs get it from
 		// the CREATE TABLE; existing rows just carry the plain column.
 		"ALTER TABLE ai_summaries ADD COLUMN newsletter_id INTEGER",
+		// Per-user feed tags (many-to-many): group feeds so a digest can follow a
+		// tag. New table for existing DBs; fresh DBs get it from the schema.
+		`CREATE TABLE IF NOT EXISTS feed_tags (
+			user_id INTEGER NOT NULL DEFAULT 1,
+			feed_id INTEGER NOT NULL,
+			tag TEXT NOT NULL COLLATE NOCASE,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (user_id, feed_id, tag),
+			FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+		)`,
+		"CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, tag)",
 	}
 	for _, m := range migrations {
 		db.Exec(m) // ignore "duplicate column" errors
@@ -1701,6 +1715,171 @@ func (s *SQLiteStore) SubscribeUserToFeed(userID, feedID int64) error {
 		return fmt.Errorf("failed to subscribe user to feed: %w", err)
 	}
 	return nil
+}
+
+// maxTagLen caps a feed tag's length (runes) to keep the UI and storage sane.
+const maxTagLen = 50
+
+// normalizeTag trims surrounding space, collapses internal whitespace runs to a
+// single space, and caps the length. Returns "" for an effectively empty tag,
+// which callers reject. Case is preserved for display; uniqueness is enforced
+// case-insensitively by the schema (COLLATE NOCASE / lower(tag) index).
+func normalizeTag(tag string) string {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return ""
+	}
+	tag = strings.Join(strings.Fields(tag), " ")
+	if len([]rune(tag)) > maxTagLen {
+		tag = string([]rune(tag)[:maxTagLen])
+	}
+	return tag
+}
+
+// AddFeedTag tags a feed for a user (idempotent; case-insensitive duplicate is a no-op).
+func (s *SQLiteStore) AddFeedTag(userID, feedID int64, tag string) error {
+	tag = normalizeTag(tag)
+	if tag == "" {
+		return fmt.Errorf("empty tag")
+	}
+	_, err := s.db.Exec(
+		"INSERT OR IGNORE INTO feed_tags (user_id, feed_id, tag) VALUES (?, ?, ?)",
+		userID, feedID, tag,
+	)
+	if err != nil {
+		return fmt.Errorf("add feed tag: %w", err)
+	}
+	return nil
+}
+
+// RemoveFeedTag removes a tag from a feed for a user (case-insensitive).
+func (s *SQLiteStore) RemoveFeedTag(userID, feedID int64, tag string) error {
+	tag = normalizeTag(tag)
+	_, err := s.db.Exec(
+		"DELETE FROM feed_tags WHERE user_id = ? AND feed_id = ? AND tag = ?",
+		userID, feedID, tag,
+	)
+	if err != nil {
+		return fmt.Errorf("remove feed tag: %w", err)
+	}
+	return nil
+}
+
+// GetFeedTags returns one feed's tags for a user, sorted.
+func (s *SQLiteStore) GetFeedTags(userID, feedID int64) ([]string, error) {
+	rows, err := s.db.Query(
+		"SELECT tag FROM feed_tags WHERE user_id = ? AND feed_id = ? ORDER BY tag",
+		userID, feedID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get feed tags: %w", err)
+	}
+	defer rows.Close()
+	var tags []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("scan feed tag: %w", err)
+		}
+		tags = append(tags, t)
+	}
+	return tags, rows.Err()
+}
+
+// GetAllFeedTags returns every tagged feed's tags for a user in one query.
+func (s *SQLiteStore) GetAllFeedTags(userID int64) (map[int64][]string, error) {
+	rows, err := s.db.Query(
+		"SELECT feed_id, tag FROM feed_tags WHERE user_id = ? ORDER BY feed_id, tag",
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get all feed tags: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[int64][]string)
+	for rows.Next() {
+		var fid int64
+		var t string
+		if err := rows.Scan(&fid, &t); err != nil {
+			return nil, fmt.Errorf("scan feed tag: %w", err)
+		}
+		out[fid] = append(out[fid], t)
+	}
+	return out, rows.Err()
+}
+
+// GetUserTags returns the distinct tags a user has applied, sorted.
+func (s *SQLiteStore) GetUserTags(userID int64) ([]string, error) {
+	rows, err := s.db.Query(
+		"SELECT DISTINCT tag FROM feed_tags WHERE user_id = ? ORDER BY tag",
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user tags: %w", err)
+	}
+	defer rows.Close()
+	var tags []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("scan user tag: %w", err)
+		}
+		tags = append(tags, t)
+	}
+	return tags, rows.Err()
+}
+
+// GetFeedsByTags resolves a set of tags to the distinct feed IDs carrying any of
+// them (case-insensitive). Empty input returns nil.
+func (s *SQLiteStore) GetFeedsByTags(userID int64, tags []string) ([]int64, error) {
+	norm := normalizeTags(tags)
+	if len(norm) == 0 {
+		return nil, nil
+	}
+	ph := make([]string, len(norm))
+	args := make([]any, 0, len(norm)+1)
+	args = append(args, userID)
+	for i, t := range norm {
+		ph[i] = "?"
+		args = append(args, t)
+	}
+	rows, err := s.db.Query(
+		"SELECT DISTINCT feed_id FROM feed_tags WHERE user_id = ? AND tag IN ("+strings.Join(ph, ",")+") ORDER BY feed_id",
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get feeds by tags: %w", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan feed id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// normalizeTags normalizes a slice of tags, dropping empties and case-insensitive
+// duplicates while preserving order.
+func normalizeTags(tags []string) []string {
+	seen := make(map[string]bool, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		n := normalizeTag(t)
+		if n == "" {
+			continue
+		}
+		k := strings.ToLower(n)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, n)
+	}
+	return out
 }
 
 // GetUserFeeds returns all feeds a user is subscribed to.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2470,6 +2470,124 @@ func eachStore(t *testing.T, fn func(t *testing.T, store Store)) {
 	})
 }
 
+func TestFeedTagsCRUD(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		f1, _ := store.AddFeed("https://a.example/feed", "Krebs", "")
+		f2, _ := store.AddFeed("https://b.example/feed", "The Register", "")
+		f3, _ := store.AddFeed("https://c.example/feed", "Sports Daily", "")
+		for _, f := range []int64{f1, f2, f3} {
+			if err := store.SubscribeUserToFeed(1, f); err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+		}
+
+		// Tag feeds; a feed can carry several tags.
+		for _, tc := range []struct {
+			feed int64
+			tag  string
+		}{{f1, "Security"}, {f2, "Security"}, {f2, "News"}, {f3, "Sports"}} {
+			if err := store.AddFeedTag(1, tc.feed, tc.tag); err != nil {
+				t.Fatalf("AddFeedTag(%d,%q): %v", tc.feed, tc.tag, err)
+			}
+		}
+
+		// Idempotent + case-insensitive duplicate is a no-op.
+		if err := store.AddFeedTag(1, f1, "security"); err != nil {
+			t.Fatalf("dup AddFeedTag: %v", err)
+		}
+		tags, err := store.GetFeedTags(1, f1)
+		if err != nil {
+			t.Fatalf("GetFeedTags: %v", err)
+		}
+		if len(tags) != 1 || tags[0] != "Security" {
+			t.Fatalf("f1 tags = %v, want [Security]", tags)
+		}
+
+		// GetUserTags: distinct, sorted.
+		ut, _ := store.GetUserTags(1)
+		if got := strings.Join(ut, ","); got != "News,Security,Sports" {
+			t.Errorf("GetUserTags = %q, want News,Security,Sports", got)
+		}
+
+		// GetAllFeedTags: one feed → multiple tags.
+		all, _ := store.GetAllFeedTags(1)
+		if len(all[f2]) != 2 {
+			t.Errorf("f2 tags = %v, want 2", all[f2])
+		}
+
+		// GetFeedsByTags: union across tags, case-insensitive, deduped.
+		ids, err := store.GetFeedsByTags(1, []string{"security", "sports"})
+		if err != nil {
+			t.Fatalf("GetFeedsByTags: %v", err)
+		}
+		if !sameIDSet(ids, []int64{f1, f2, f3}) {
+			t.Errorf("GetFeedsByTags(security,sports) = %v, want {%d,%d,%d}", ids, f1, f2, f3)
+		}
+		// A single tag resolves to just its feeds.
+		ids, _ = store.GetFeedsByTags(1, []string{"News"})
+		if !sameIDSet(ids, []int64{f2}) {
+			t.Errorf("GetFeedsByTags(News) = %v, want {%d}", ids, f2)
+		}
+		// Empty / unknown tags → nil.
+		if ids, _ := store.GetFeedsByTags(1, nil); ids != nil {
+			t.Errorf("GetFeedsByTags(nil) = %v, want nil", ids)
+		}
+
+		// Remove one tag (case-insensitive).
+		if err := store.RemoveFeedTag(1, f2, "news"); err != nil {
+			t.Fatalf("RemoveFeedTag: %v", err)
+		}
+		if tags, _ := store.GetFeedTags(1, f2); !sameStrSet(tags, []string{"Security"}) {
+			t.Errorf("f2 tags after remove = %v, want [Security]", tags)
+		}
+
+		// Cascade: deleting the feed row drops its tags. DeleteFeedIfOrphaned only
+		// removes a feed with no subscribers, so unsubscribe first.
+		if err := store.UnsubscribeUserFromFeed(1, f3); err != nil {
+			t.Fatalf("unsubscribe: %v", err)
+		}
+		deleted, err := store.DeleteFeedIfOrphaned(f3)
+		if err != nil || !deleted {
+			t.Fatalf("DeleteFeedIfOrphaned = %v, %v; want true, nil", deleted, err)
+		}
+		if tags, _ := store.GetFeedTags(1, f3); len(tags) != 0 {
+			t.Errorf("f3 tags after feed delete = %v, want none", tags)
+		}
+	})
+}
+
+func sameIDSet(got, want []int64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	m := make(map[int64]bool, len(got))
+	for _, v := range got {
+		m[v] = true
+	}
+	for _, v := range want {
+		if !m[v] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStrSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	m := make(map[string]bool, len(got))
+	for _, v := range got {
+		m[v] = true
+	}
+	for _, v := range want {
+		if !m[v] {
+			return false
+		}
+	}
+	return true
+}
+
 func articleIDs(arts []Article) []int64 {
 	out := make([]int64, len(arts))
 	for i, a := range arts {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -216,6 +216,14 @@ type Store interface {
 	GetAllFeedFavicons() ([]FeedFavicon, error)
 	GetSubscribedFeedsWithoutFavicons() ([]Feed, error)
 
+	// Feed tags (per-user, many-to-many)
+	AddFeedTag(userID, feedID int64, tag string) error
+	RemoveFeedTag(userID, feedID int64, tag string) error
+	GetFeedTags(userID, feedID int64) ([]string, error)
+	GetAllFeedTags(userID int64) (map[int64][]string, error)
+	GetUserTags(userID int64) ([]string, error)
+	GetFeedsByTags(userID int64, tags []string) ([]int64, error)
+
 	// Subscriptions
 	SubscribeUserToFeed(userID, feedID int64) error
 	GetUserFeeds(userID int64) ([]Feed, error)

--- a/types.go
+++ b/types.go
@@ -98,7 +98,10 @@ type NewsletterConfig struct {
 	ExcludeFeeds      []int64  `json:"exclude_feeds,omitempty"`
 	IncludeCategories []string `json:"include_categories,omitempty"`
 	ExcludeCategories []string `json:"exclude_categories,omitempty"`
-	MaxArticles       int      `json:"max_articles"`
+	// IncludeTags names feed tags this digest follows: at generation time they
+	// resolve to whatever feeds currently carry the tag, unioned with IncludeFeeds.
+	IncludeTags []string `json:"include_tags,omitempty"`
+	MaxArticles int      `json:"max_articles"`
 }
 
 // NewsletterIssue represents a single generated newsletter edition.


### PR DESCRIPTION
## What

Replaces the raw `<select multiple>` digest feed picker with a per-user **feed tag** model and a **two-pane transfer-list picker** that groups feeds by tag. A digest can **follow a tag**: it stores the tag name and resolves to whatever feeds currently carry it at generation time, so tagging a new feed later auto-includes it in every digest following that tag — no re-editing.

Design decisions (with the user): tags are **many-to-many** (`feed_tags(user_id, feed_id, tag)`), and digest membership is **dynamic tag-follow** (`Config.IncludeTags`, unioned with explicit `IncludeFeeds`).

## How it's built (4 commits)

1. **Storage** — `feed_tags` table on both backends (SQLite `COLLATE NOCASE`; Postgres unique index on `lower(tag)` for matching case-insensitive uniqueness), via schema const (fresh DBs) + migration slice (existing prod). CRUD + `GetFeedsByTags`. `NewsletterConfig.IncludeTags` rides in the existing `config_json` blob — **no newsletters-table migration**. Tag normalization (trim, collapse whitespace, 50-rune cap, case-insensitive dedupe).
2. **Engine** — `effectiveIncludeFeeds` resolves followed tags to feeds and unions with explicit picks; wired into `selectDigestArticles`. Storage SQL stays feed-ID based. Tag passthroughs for the web layer.
3. **Feeds page** — per-feed Tags cell: chips with remove forms + an inline `+ tag` input with a datalist of existing tags; htmx fragment swaps. Tag text HTML-escaped; remove tag travels as a form value (not a path segment).
4. **Digest picker** — two-pane transfer list. **No-JS baseline** is two native multi-selects (`tag_names`, `feed_ids`) so the form works without scripting; a dependency-free script enhances it into the grouped two-pane UI with selection state living in the native `<option>`s. `parseDigestForm` reads `tag_names → IncludeTags`.

## Verification

- `task check` green: builds (all three binaries), `go test -race ./...`, `golangci-lint` (0 issues), `govulncheck` (clean).
- Storage `TestFeedTagsCRUD` runs on SQLite **and Postgres** (validated against a throwaway PG 16 locally — case-insensitive uniqueness, `ON CONFLICT`, multi-tag union, cascade-on-feed-delete).
- Engine `TestEffectiveIncludeFeeds` covers the union, de-dup, and the dynamic-follow guarantee (tag a feed later → it joins).
- Web tests: `parseDigestForm` tag+feed parsing; `feed_picker`/`feed_tags_cell` baseline render + HTML-escaping; full edit-form fragment with pre-selected feeds/tags.

Migration auto-applies on deploy (no homelab config change). Out of scope (noted as follow-ups): sidebar grouping by tag, bulk tag rename/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)