### PR TITLE
Processing Status tab: real pipeline state, cycle throughput, and feed-health fixes

### DIFF
--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1525,10 +1525,38 @@ func (h *handlers) handleStats(w http.ResponseWriter, r *http.Request) {
 	h.renderPage(w, r, "stats.html", data)
 }
 
+// cycleView is a daemon cycle formatted for display.
+type cycleView struct {
+	When         string // relative, e.g. "25m ago"
+	Duration     string // e.g. "8.5s"
+	NewArticles  int
+	Processed    int
+	HighInterest int
+	FeedsErrored int
+	BackendUp    bool
+}
+
+// statusPageData is the template data for the processing-status page.
+type statusPageData struct {
+	Processing *herald.ProcessingStats
+	HasCycles  bool
+	LastCycle  cycleView
+	Recent     []cycleView
+}
+
+// fmtDurationMs renders a millisecond duration compactly (e.g. "8.5s", "1m3s").
+func fmtDurationMs(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
+}
+
 // handleProcessingStatus renders the overall AI-pipeline processing status:
 // an aggregate funnel (fetched -> scored -> passed -> summarized -> curated)
-// plus the real backlog and feed-fetch health. Distinct from /stats, which
-// shows score *outcomes* per feed.
+// plus the real backlog, feed-fetch health, and recent daemon-cycle throughput.
+// Distinct from /stats, which shows score *outcomes* per feed.
 func (h *handlers) handleProcessingStatus(w http.ResponseWriter, r *http.Request) {
 	h.init()
 	uid := userFromContext(r.Context()).ID
@@ -1538,7 +1566,28 @@ func (h *handlers) handleProcessingStatus(w http.ResponseWriter, r *http.Request
 		h.renderError(w, http.StatusInternalServerError, "Failed to load processing status")
 		return
 	}
-	h.renderPage(w, r, "status.html", ps)
+
+	// Recent cycles are global (the daemon processes all users per cycle), so they
+	// aren't user-scoped. Failure to load them is non-fatal -- the funnel still renders.
+	recent, _ := h.engine.GetRecentCycleStats(10)
+	data := statusPageData{Processing: ps}
+	for _, c := range recent {
+		t := c.CompletedAt
+		data.Recent = append(data.Recent, cycleView{
+			When:         formatDate(&t),
+			Duration:     fmtDurationMs(c.DurationMs),
+			NewArticles:  c.NewArticles,
+			Processed:    c.Processed,
+			HighInterest: c.HighInterest,
+			FeedsErrored: c.FeedsErrored,
+			BackendUp:    c.AIBackendAvailable,
+		})
+	}
+	if len(data.Recent) > 0 {
+		data.HasCycles = true
+		data.LastCycle = data.Recent[0]
+	}
+	h.renderPage(w, r, "status.html", data)
 }
 
 // adminStatsData is the template data for the admin stats page.

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -249,6 +249,7 @@ type feedRow struct {
 	UnreadArticles       int
 	UnsummarizedArticles int
 	LastError            string
+	ConsecutiveErrors    int
 	LastFetchedFmt       string
 	LastPostDateFmt      string
 }
@@ -535,6 +536,7 @@ func (h *handlers) handleFeedsManage(w http.ResponseWriter, r *http.Request) {
 		if f.LastError != nil {
 			row.LastError = *f.LastError
 		}
+		row.ConsecutiveErrors = f.ConsecutiveErrors
 		if f.LastFetched != nil {
 			row.LastFetchedFmt = formatDate(f.LastFetched)
 		}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -164,7 +164,7 @@ func (h *handlers) init() {
 	shared := []string{"base.html", "nav.html", "settings_subnav.html", "feed_sidebar.html", "article_list.html", "article_row.html", "article_view.html", "search_results.html", "ai_summary_list.html", "ai_summary_detail.html", "error.html"}
 
 	// Pages that get their own template tree.
-	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "stats.html", "newsletters_manage.html"}
+	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "stats.html", "status.html", "newsletters_manage.html"}
 
 	h.pages = make(map[string]*template.Template, len(pages))
 	for _, page := range pages {
@@ -1523,6 +1523,22 @@ func (h *handlers) handleStats(w http.ResponseWriter, r *http.Request) {
 		IntDonut: makeDonut(t.IntHigh, t.IntMedium, t.IntLow, fmt.Sprintf("%d%%", int(t.IntHighPct()))),
 	}
 	h.renderPage(w, r, "stats.html", data)
+}
+
+// handleProcessingStatus renders the overall AI-pipeline processing status:
+// an aggregate funnel (fetched -> scored -> passed -> summarized -> curated)
+// plus the real backlog and feed-fetch health. Distinct from /stats, which
+// shows score *outcomes* per feed.
+func (h *handlers) handleProcessingStatus(w http.ResponseWriter, r *http.Request) {
+	h.init()
+	uid := userFromContext(r.Context()).ID
+
+	ps, err := h.engine.GetProcessingStats(uid)
+	if err != nil {
+		h.renderError(w, http.StatusInternalServerError, "Failed to load processing status")
+		return
+	}
+	h.renderPage(w, r, "status.html", ps)
 }
 
 // adminStatsData is the template data for the admin stats page.

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -909,3 +909,18 @@ func TestHandleGroupDisband(t *testing.T) {
 		t.Error("group should be deleted after DELETE /groups/{id}")
 	}
 }
+
+func TestHandleProcessingStatus(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequest(t, tf, "GET", "/status", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"Processing Status", "Pending backlog", "Pipeline", "Summarized"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("status page missing %q", want)
+		}
+	}
+}

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -528,6 +528,13 @@ func TestHandleFeedsManage(t *testing.T) {
 	if !strings.Contains(body, "example.com/feed") {
 		t.Error("feeds page should contain feed URL")
 	}
+	// The column reflects what it actually measures (no summary), not "Unscored".
+	if !strings.Contains(body, "Unsummarized") {
+		t.Error("feeds page should label the column Unsummarized")
+	}
+	if strings.Contains(body, ">Unscored<") {
+		t.Error("feeds page should no longer use the misleading Unscored header")
+	}
 }
 
 func TestHandleSettings(t *testing.T) {

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -44,6 +44,7 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("GET /settings/prompts", auth(http.HandlerFunc(h.handleSettingsPrompts)))
 	mux.Handle("GET /filters", auth(http.HandlerFunc(h.handleFilters)))
 	mux.Handle("GET /stats", auth(http.HandlerFunc(h.handleStats)))
+	mux.Handle("GET /status", auth(http.HandlerFunc(h.handleProcessingStatus)))
 
 	// htmx fragment routes.
 	mux.Handle("GET /search", auth(http.HandlerFunc(h.handleSearch)))

--- a/cmd/herald-web/templates/feeds_manage.html
+++ b/cmd/herald-web/templates/feeds_manage.html
@@ -106,7 +106,7 @@
                     <th data-col="0" class="sortable">Feed</th>
                     <th data-col="1" class="sortable" style="text-align:right;">Articles</th>
                     <th data-col="2" class="sortable" style="text-align:right;">Unread</th>
-                    <th data-col="3" class="sortable" style="text-align:right;">Unscored</th>
+                    <th data-col="3" class="sortable" style="text-align:right;">Unsummarized</th>
                     <th data-col="4" class="sortable">Last Post</th>
                     <th data-col="5" class="sortable">Last Fetched</th>
                     <th>Tags</th>
@@ -119,7 +119,7 @@
                     <td>
                         <strong id="feed-title-cell-{{.FeedID}}">{{template "feed_title_display" .}}</strong><br>
                         <small class="secondary">{{.URL}}</small>
-                        {{if .LastError}}<br><small style="color:var(--pico-del-color);">Error: {{.LastError}}</small>{{end}}
+                        {{if gt .ConsecutiveErrors 0}}<br><small style="color:var(--pico-del-color);">&#9888; Failing ({{.ConsecutiveErrors}}x since last success){{if .LastError}}: {{.LastError}}{{end}}</small>{{else if .LastError}}<br><small class="secondary">Last error: {{.LastError}}</small>{{end}}
                     </td>
                     <td style="text-align:right;">{{.TotalArticles}}</td>
                     <td style="text-align:right;">{{.UnreadArticles}}</td>

--- a/cmd/herald-web/templates/nav.html
+++ b/cmd/herald-web/templates/nav.html
@@ -4,6 +4,7 @@
     <a href="/feeds"{{if eq . "feeds"}} aria-current="page"{{end}}>Feeds</a>
     <a href="/newsletters"{{if eq . "newsletters"}} aria-current="page"{{end}}>Newsletters</a>
     <a href="/stats"{{if eq . "stats"}} aria-current="page"{{end}}>Stats</a>
+    <a href="/status"{{if eq . "status"}} aria-current="page"{{end}}>Status</a>
     <a href="/settings"{{if eq . "settings"}} aria-current="page"{{end}}>Settings</a>
 </nav>
 {{end}}

--- a/cmd/herald-web/templates/status.html
+++ b/cmd/herald-web/templates/status.html
@@ -1,0 +1,48 @@
+{{define "title"}}Herald - Processing Status{{end}}
+{{define "nav"}}{{template "shared-nav" "status"}}{{end}}
+
+{{define "content"}}
+<main class="container" style="max-width:900px;">
+  <h2>Processing Status</h2>
+  <p class="secondary">
+    Where your articles sit in the AI pipeline right now, across all feeds.
+    For per-feed score breakdowns see <a href="/stats">Stats</a>.
+  </p>
+
+  {{/* Headline cards: the numbers that need action */}}
+  <div style="display:flex;gap:1rem;flex-wrap:wrap;margin:1.5rem 0;">
+    <article style="flex:1;min-width:160px;text-align:center;">
+      <div style="font-size:2rem;font-weight:bold;">{{.Pending}}</div>
+      <div class="secondary">Pending backlog</div>
+    </article>
+    <article style="flex:1;min-width:160px;text-align:center;{{if gt .Stuck 0}}border-color:#f44336;{{end}}">
+      <div style="font-size:2rem;font-weight:bold;{{if gt .Stuck 0}}color:#f44336;{{end}}">{{.Stuck}}</div>
+      <div class="secondary">Stuck (out of retries)</div>
+    </article>
+    <article style="flex:1;min-width:160px;text-align:center;{{if gt .FeedsErroring 0}}border-color:#ff9800;{{end}}">
+      <div style="font-size:2rem;font-weight:bold;{{if gt .FeedsErroring 0}}color:#ff9800;{{end}}">{{.FeedsErroring}}<span class="secondary" style="font-size:1rem;">&nbsp;/&nbsp;{{.FeedsTotal}}</span></div>
+      <div class="secondary">Feeds erroring</div>
+    </article>
+  </div>
+
+  {{/* Pipeline funnel: fetched -> security -> summarize -> curate */}}
+  <h3>Pipeline</h3>
+  <figure>
+    <table role="grid">
+      <tbody>
+        <tr><th>Total articles</th><td><strong>{{.TotalArticles}}</strong></td><td class="secondary"></td></tr>
+        <tr><th>Scored</th><td>{{.Scored}}</td><td class="secondary">security verdict recorded</td></tr>
+        <tr><td style="padding-left:2rem;">Security passed</td><td>{{.SecurityPassed}}</td><td class="secondary">&ge; 7.0 -- eligible for summary + interest</td></tr>
+        <tr><td style="padding-left:2rem;">Security rejected</td><td>{{.SecurityRejected}}</td><td class="secondary">below threshold</td></tr>
+        <tr><td style="padding-left:2rem;">Skipped</td><td>{{.SecuritySkipped}}</td><td class="secondary">no content / too short</td></tr>
+        <tr><th>Summarized</th><td>{{.Summarized}}</td><td class="secondary">{{.SummarizeSkipped}} skipped (can't be shortened)</td></tr>
+        <tr><th>Curated</th><td>{{.Curated}}</td><td class="secondary">interest scored</td></tr>
+      </tbody>
+    </table>
+  </figure>
+  <p class="secondary" style="font-size:0.85em;">
+    "Pending" is the real backlog the daemon will pick up next cycle.
+    "Stuck" articles have hit the retry limit and won't be retried without intervention.
+  </p>
+</main>
+{{end}}

--- a/cmd/herald-web/templates/status.html
+++ b/cmd/herald-web/templates/status.html
@@ -2,6 +2,7 @@
 {{define "nav"}}{{template "shared-nav" "status"}}{{end}}
 
 {{define "content"}}
+{{- $p := .Processing -}}
 <main class="container" style="max-width:900px;">
   <h2>Processing Status</h2>
   <p class="secondary">
@@ -12,31 +13,49 @@
   {{/* Headline cards: the numbers that need action */}}
   <div style="display:flex;gap:1rem;flex-wrap:wrap;margin:1.5rem 0;">
     <article style="flex:1;min-width:160px;text-align:center;">
-      <div style="font-size:2rem;font-weight:bold;">{{.Pending}}</div>
+      <div style="font-size:2rem;font-weight:bold;">{{$p.Pending}}</div>
       <div class="secondary">Pending backlog</div>
     </article>
-    <article style="flex:1;min-width:160px;text-align:center;{{if gt .Stuck 0}}border-color:#f44336;{{end}}">
-      <div style="font-size:2rem;font-weight:bold;{{if gt .Stuck 0}}color:#f44336;{{end}}">{{.Stuck}}</div>
+    <article style="flex:1;min-width:160px;text-align:center;{{if gt $p.Stuck 0}}border-color:#f44336;{{end}}">
+      <div style="font-size:2rem;font-weight:bold;{{if gt $p.Stuck 0}}color:#f44336;{{end}}">{{$p.Stuck}}</div>
       <div class="secondary">Stuck (out of retries)</div>
     </article>
-    <article style="flex:1;min-width:160px;text-align:center;{{if gt .FeedsErroring 0}}border-color:#ff9800;{{end}}">
-      <div style="font-size:2rem;font-weight:bold;{{if gt .FeedsErroring 0}}color:#ff9800;{{end}}">{{.FeedsErroring}}<span class="secondary" style="font-size:1rem;">&nbsp;/&nbsp;{{.FeedsTotal}}</span></div>
+    <article style="flex:1;min-width:160px;text-align:center;{{if gt $p.FeedsErroring 0}}border-color:#ff9800;{{end}}">
+      <div style="font-size:2rem;font-weight:bold;{{if gt $p.FeedsErroring 0}}color:#ff9800;{{end}}">{{$p.FeedsErroring}}<span class="secondary" style="font-size:1rem;">&nbsp;/&nbsp;{{$p.FeedsTotal}}</span></div>
       <div class="secondary">Feeds erroring</div>
     </article>
   </div>
+
+  {{/* Last cycle: throughput + backend health from the daemon */}}
+  {{if .HasCycles}}
+  {{- $c := .LastCycle -}}
+  <h3>Last cycle <span class="secondary" style="font-weight:normal;font-size:0.8em;">{{$c.When}}, took {{$c.Duration}}</span></h3>
+  <div style="display:flex;gap:1.5rem;flex-wrap:wrap;align-items:center;margin-bottom:0.5rem;">
+    <div>AI backend:
+      {{if $c.BackendUp}}<strong style="color:#4caf50;">up</strong>
+      {{else}}<strong style="color:#f44336;">down</strong>{{end}}
+    </div>
+    <div class="secondary">new: <strong>{{$c.NewArticles}}</strong></div>
+    <div class="secondary">processed: <strong>{{$c.Processed}}</strong></div>
+    <div class="secondary">high-interest: <strong>{{$c.HighInterest}}</strong></div>
+  </div>
+  {{else}}
+  <h3>Last cycle</h3>
+  <p class="secondary">No daemon cycles recorded yet.</p>
+  {{end}}
 
   {{/* Pipeline funnel: fetched -> security -> summarize -> curate */}}
   <h3>Pipeline</h3>
   <figure>
     <table role="grid">
       <tbody>
-        <tr><th>Total articles</th><td><strong>{{.TotalArticles}}</strong></td><td class="secondary"></td></tr>
-        <tr><th>Scored</th><td>{{.Scored}}</td><td class="secondary">security verdict recorded</td></tr>
-        <tr><td style="padding-left:2rem;">Security passed</td><td>{{.SecurityPassed}}</td><td class="secondary">&ge; 7.0 -- eligible for summary + interest</td></tr>
-        <tr><td style="padding-left:2rem;">Security rejected</td><td>{{.SecurityRejected}}</td><td class="secondary">below threshold</td></tr>
-        <tr><td style="padding-left:2rem;">Skipped</td><td>{{.SecuritySkipped}}</td><td class="secondary">no content / too short</td></tr>
-        <tr><th>Summarized</th><td>{{.Summarized}}</td><td class="secondary">{{.SummarizeSkipped}} skipped (can't be shortened)</td></tr>
-        <tr><th>Curated</th><td>{{.Curated}}</td><td class="secondary">interest scored</td></tr>
+        <tr><th>Total articles</th><td><strong>{{$p.TotalArticles}}</strong></td><td class="secondary"></td></tr>
+        <tr><th>Scored</th><td>{{$p.Scored}}</td><td class="secondary">security verdict recorded</td></tr>
+        <tr><td style="padding-left:2rem;">Security passed</td><td>{{$p.SecurityPassed}}</td><td class="secondary">&ge; 7.0 -- eligible for summary + interest</td></tr>
+        <tr><td style="padding-left:2rem;">Security rejected</td><td>{{$p.SecurityRejected}}</td><td class="secondary">below threshold</td></tr>
+        <tr><td style="padding-left:2rem;">Skipped</td><td>{{$p.SecuritySkipped}}</td><td class="secondary">no content / too short</td></tr>
+        <tr><th>Summarized</th><td>{{$p.Summarized}}</td><td class="secondary">{{$p.SummarizeSkipped}} skipped (can't be shortened)</td></tr>
+        <tr><th>Curated</th><td>{{$p.Curated}}</td><td class="secondary">interest scored</td></tr>
       </tbody>
     </table>
   </figure>
@@ -44,5 +63,30 @@
     "Pending" is the real backlog the daemon will pick up next cycle.
     "Stuck" articles have hit the retry limit and won't be retried without intervention.
   </p>
+
+  {{/* Recent cycle history */}}
+  {{if .HasCycles}}
+  <h3>Recent cycles</h3>
+  <figure>
+    <table role="grid">
+      <thead>
+        <tr><th>When</th><th>Duration</th><th>New</th><th>Processed</th><th>High-interest</th><th>Feeds errored</th><th>Backend</th></tr>
+      </thead>
+      <tbody>
+        {{range .Recent}}
+        <tr>
+          <td>{{.When}}</td>
+          <td>{{.Duration}}</td>
+          <td>{{.NewArticles}}</td>
+          <td>{{.Processed}}</td>
+          <td>{{.HighInterest}}</td>
+          <td{{if gt .FeedsErrored 0}} style="color:#ff9800;"{{end}}>{{.FeedsErrored}}</td>
+          <td>{{if .BackendUp}}up{{else}}<span style="color:#f44336;">down</span>{{end}}</td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+  </figure>
+  {{end}}
 </main>
 {{end}}

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -344,6 +344,7 @@ func processCmd() *cobra.Command {
 // and the `daemon` command call this. It uses the package-level cfg and
 // outputFormat variables.
 func doFetch(ctx context.Context) error {
+	cycleStart := time.Now()
 	formatter := output.NewFormatter(output.Format(outputFormat))
 
 	store, err := storage.NewStore(cfg.Database.Path)
@@ -351,6 +352,34 @@ func doFetch(ctx context.Context) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 	defer store.Close()
+
+	// Persist a per-cycle summary on the way out so the web UI can show
+	// throughput and backend health without access to the daemon's memory. The
+	// closure reads fetchResult/aiBackendUp, populated as the cycle runs, and
+	// records whatever progress was made even on an early return. Registered
+	// after store.Close()'s defer, so it runs first (LIFO) while the store is
+	// still open.
+	var fetchResult *output.FetchResult
+	aiBackendUp := false
+	defer func() {
+		if fetchResult == nil {
+			return
+		}
+		if err := store.RecordCycleStats(storage.CycleStats{
+			CompletedAt:        time.Now(),
+			DurationMs:         time.Since(cycleStart).Milliseconds(),
+			FeedsTotal:         fetchResult.FeedsTotal,
+			FeedsDownloaded:    fetchResult.FeedsDownloaded,
+			FeedsNotModified:   fetchResult.FeedsNotModified,
+			FeedsErrored:       fetchResult.FeedsErrored,
+			NewArticles:        fetchResult.NewArticles,
+			Processed:          fetchResult.ProcessedCount,
+			HighInterest:       fetchResult.HighInterest,
+			AIBackendAvailable: aiBackendUp,
+		}); err != nil {
+			formatter.Warning("failed to record cycle stats: %v", err)
+		}
+	}()
 
 	// Get all feeds due to fetch this cycle. Adaptive scheduling stages
 	// next_fetch_at across feeds, so it's normal for an individual cycle to
@@ -363,7 +392,7 @@ func doFetch(ctx context.Context) error {
 
 	// Fetch each feed once (efficient)
 	fetcher := feeds.NewFetcher(store)
-	fetchResult := &output.FetchResult{FeedsTotal: len(subscribedFeeds)}
+	fetchResult = &output.FetchResult{FeedsTotal: len(subscribedFeeds)}
 	for _, feed := range subscribedFeeds {
 		feedCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		result, err := fetcher.FetchFeed(feedCtx, feed)
@@ -433,6 +462,7 @@ func doFetch(ctx context.Context) error {
 		formatter.Warning("skipping AI processing (Ollama may not be running)")
 		return formatter.OutputFetchResult(fetchResult)
 	}
+	aiBackendUp = processor.BackendAvailable()
 
 	// Get all users who have subscriptions
 	allUserIDs, err := store.GetAllSubscribingUsers()

--- a/engine.go
+++ b/engine.go
@@ -1319,6 +1319,32 @@ func (e *Engine) GetProcessingStats(userID int64) (*ProcessingStats, error) {
 	}, nil
 }
 
+// GetRecentCycleStats returns the most recent completed daemon cycles, newest
+// first, for the processing-status view.
+func (e *Engine) GetRecentCycleStats(limit int) ([]CycleStats, error) {
+	rows, err := e.store.GetRecentCycleStats(limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CycleStats, len(rows))
+	for i, c := range rows {
+		out[i] = CycleStats{
+			ID:                 c.ID,
+			CompletedAt:        c.CompletedAt,
+			DurationMs:         c.DurationMs,
+			FeedsTotal:         c.FeedsTotal,
+			FeedsDownloaded:    c.FeedsDownloaded,
+			FeedsNotModified:   c.FeedsNotModified,
+			FeedsErrored:       c.FeedsErrored,
+			NewArticles:        c.NewArticles,
+			Processed:          c.Processed,
+			HighInterest:       c.HighInterest,
+			AIBackendAvailable: c.AIBackendAvailable,
+		}
+	}
+	return out, nil
+}
+
 // PendingCounts returns the number of articles awaiting AI processing.
 func (e *Engine) PendingCounts(userID int64) (unsummarized, unscored int, err error) {
 	unsummarized, err = e.store.GetUnsummarizedArticleCount(userID)

--- a/engine.go
+++ b/engine.go
@@ -1296,6 +1296,29 @@ func (e *Engine) GetScoreStats(userID int64) (*ScoreStatsResult, error) {
 	return result, nil
 }
 
+// GetProcessingStats returns an aggregate snapshot of the AI pipeline state for
+// a user's articles (pipeline progress, not score outcomes; not per-feed).
+func (e *Engine) GetProcessingStats(userID int64) (*ProcessingStats, error) {
+	p, err := e.store.GetProcessingStats(userID)
+	if err != nil {
+		return nil, err
+	}
+	return &ProcessingStats{
+		TotalArticles:    p.TotalArticles,
+		Scored:           p.Scored,
+		Pending:          p.Pending,
+		Stuck:            p.Stuck,
+		SecurityPassed:   p.SecurityPassed,
+		SecurityRejected: p.SecurityRejected,
+		SecuritySkipped:  p.SecuritySkipped,
+		Summarized:       p.Summarized,
+		SummarizeSkipped: p.SummarizeSkipped,
+		Curated:          p.Curated,
+		FeedsTotal:       p.FeedsTotal,
+		FeedsErroring:    p.FeedsErroring,
+	}, nil
+}
+
 // PendingCounts returns the number of articles awaiting AI processing.
 func (e *Engine) PendingCounts(userID int64) (unsummarized, unscored int, err error) {
 	unsummarized, err = e.store.GetUnsummarizedArticleCount(userID)

--- a/engine.go
+++ b/engine.go
@@ -1804,15 +1804,16 @@ func (e *Engine) GetArticleImage(imageID int64) (*storage.ArticleImage, error) {
 
 func feedFromInternal(f storage.Feed) Feed {
 	return Feed{
-		ID:          f.ID,
-		URL:         f.URL,
-		Title:       f.Title,
-		Description: f.Description,
-		SiteURL:     f.SiteURL,
-		LastFetched: f.LastFetched,
-		LastError:   f.LastError,
-		Enabled:     f.Enabled,
-		CreatedAt:   f.CreatedAt,
+		ID:                f.ID,
+		URL:               f.URL,
+		Title:             f.Title,
+		Description:       f.Description,
+		SiteURL:           f.SiteURL,
+		LastFetched:       f.LastFetched,
+		LastError:         f.LastError,
+		Enabled:           f.Enabled,
+		CreatedAt:         f.CreatedAt,
+		ConsecutiveErrors: f.ConsecutiveErrors,
 	}
 }
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1474,6 +1474,55 @@ func (s *PostgresStore) GetProcessingStats(userID int64) (*ProcessingStats, erro
 	return &p, nil
 }
 
+// RecordCycleStats persists one completed daemon cycle, then prunes to a bounded
+// history so the table can't grow without limit on a long-running daemon.
+func (s *PostgresStore) RecordCycleStats(cs CycleStats) error {
+	if _, err := s.db.Exec(
+		`INSERT INTO cycle_stats
+		   (completed_at, duration_ms, feeds_total, feeds_downloaded, feeds_not_modified,
+		    feeds_errored, new_articles, processed, high_interest, ai_backend_available)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cs.CompletedAt, cs.DurationMs, cs.FeedsTotal, cs.FeedsDownloaded, cs.FeedsNotModified,
+		cs.FeedsErrored, cs.NewArticles, cs.Processed, cs.HighInterest, cs.AIBackendAvailable,
+	); err != nil {
+		return fmt.Errorf("record cycle stats: %w", err)
+	}
+	// Keep the most recent 500 cycles (~10 days at a 30m cadence).
+	if _, err := s.db.Exec(
+		`DELETE FROM cycle_stats WHERE id NOT IN (
+		   SELECT id FROM cycle_stats ORDER BY completed_at DESC LIMIT 500)`,
+	); err != nil {
+		return fmt.Errorf("prune cycle stats: %w", err)
+	}
+	return nil
+}
+
+// GetRecentCycleStats returns the most recent completed cycles, newest first.
+func (s *PostgresStore) GetRecentCycleStats(limit int) ([]CycleStats, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(
+		`SELECT id, completed_at, duration_ms, feeds_total, feeds_downloaded, feeds_not_modified,
+		        feeds_errored, new_articles, processed, high_interest, ai_backend_available
+		 FROM cycle_stats ORDER BY completed_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get recent cycle stats: %w", err)
+	}
+	defer rows.Close()
+	var out []CycleStats
+	for rows.Next() {
+		var c CycleStats
+		if err := rows.Scan(&c.ID, &c.CompletedAt, &c.DurationMs, &c.FeedsTotal, &c.FeedsDownloaded,
+			&c.FeedsNotModified, &c.FeedsErrored, &c.NewArticles, &c.Processed, &c.HighInterest,
+			&c.AIBackendAvailable); err != nil {
+			return nil, fmt.Errorf("scan cycle stats: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
 func (s *PostgresStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 	rows, err := s.db.Query(`
 		SELECT f.id, COALESCE(uf.user_title, f.title),

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1426,6 +1426,54 @@ func (s *PostgresStore) GetArticleSummary(userID, articleID int64) (*ArticleSumm
 
 // --- Feed stats ---
 
+// GetProcessingStats returns an aggregate snapshot of the AI pipeline state for a
+// user's articles (not broken down by feed). "pending" uses ai_retries < 3 (the
+// retry budget the pipeline honours); "stuck" is everything that has exhausted it.
+func (s *PostgresStore) GetProcessingStats(userID int64) (*ProcessingStats, error) {
+	var p ProcessingStats
+	err := s.db.QueryRow(`
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN rs.ai_scored = TRUE THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = FALSE) AND COALESCE(rs.ai_retries, 0) < 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = FALSE) AND COALESCE(rs.ai_retries, 0) >= 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.security_score >= 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.security_score IS NOT NULL AND rs.security_score < 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.ai_scored = TRUE AND rs.security_score IS NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.interest_score IS NOT NULL THEN 1 ELSE 0 END), 0)
+		FROM articles a
+		JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
+		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?`,
+		userID, userID,
+	).Scan(&p.TotalArticles, &p.Scored, &p.Pending, &p.Stuck,
+		&p.SecurityPassed, &p.SecurityRejected, &p.SecuritySkipped, &p.Curated)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (funnel): %w", err)
+	}
+
+	err = s.db.QueryRow(`
+		SELECT
+			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND ai_summary <> ''),
+			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND COALESCE(skip_reason, '') <> '')`,
+		userID, userID,
+	).Scan(&p.Summarized, &p.SummarizeSkipped)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (summaries): %w", err)
+	}
+
+	err = s.db.QueryRow(`
+		SELECT
+			(SELECT COUNT(*) FROM user_feeds WHERE user_id = ?),
+			(SELECT COUNT(*) FROM feeds f JOIN user_feeds uf ON uf.feed_id = f.id
+			 WHERE uf.user_id = ? AND f.consecutive_errors > 0)`,
+		userID, userID,
+	).Scan(&p.FeedsTotal, &p.FeedsErroring)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (feeds): %w", err)
+	}
+	return &p, nil
+}
+
 func (s *PostgresStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 	rows, err := s.db.Query(`
 		SELECT f.id, COALESCE(uf.user_title, f.title),

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -279,4 +279,19 @@ CREATE TABLE IF NOT EXISTS ai_summaries (
     FOREIGN KEY (newsletter_id) REFERENCES newsletters(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_ai_summaries_user ON ai_summaries(user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS cycle_stats (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    completed_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    duration_ms          INTEGER NOT NULL DEFAULT 0,
+    feeds_total          INTEGER NOT NULL DEFAULT 0,
+    feeds_downloaded     INTEGER NOT NULL DEFAULT 0,
+    feeds_not_modified   INTEGER NOT NULL DEFAULT 0,
+    feeds_errored        INTEGER NOT NULL DEFAULT 0,
+    new_articles         INTEGER NOT NULL DEFAULT 0,
+    processed            INTEGER NOT NULL DEFAULT 0,
+    high_interest        INTEGER NOT NULL DEFAULT 0,
+    ai_backend_available BOOLEAN NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_cycle_stats_completed ON cycle_stats(completed_at DESC);
 `

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -282,4 +282,19 @@ CREATE TABLE IF NOT EXISTS ai_summaries (
     FOREIGN KEY (newsletter_id) REFERENCES newsletters(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_ai_summaries_user ON ai_summaries(user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS cycle_stats (
+    id                   BIGSERIAL PRIMARY KEY,
+    completed_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    duration_ms          BIGINT NOT NULL DEFAULT 0,
+    feeds_total          INTEGER NOT NULL DEFAULT 0,
+    feeds_downloaded     INTEGER NOT NULL DEFAULT 0,
+    feeds_not_modified   INTEGER NOT NULL DEFAULT 0,
+    feeds_errored        INTEGER NOT NULL DEFAULT 0,
+    new_articles         INTEGER NOT NULL DEFAULT 0,
+    processed            INTEGER NOT NULL DEFAULT 0,
+    high_interest        INTEGER NOT NULL DEFAULT 0,
+    ai_backend_available BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_cycle_stats_completed ON cycle_stats(completed_at DESC);
 `

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1426,6 +1426,55 @@ func (s *SQLiteStore) GetProcessingStats(userID int64) (*ProcessingStats, error)
 	return &p, nil
 }
 
+// RecordCycleStats persists one completed daemon cycle, then prunes to a bounded
+// history so the table can't grow without limit on a long-running daemon.
+func (s *SQLiteStore) RecordCycleStats(cs CycleStats) error {
+	if _, err := s.db.Exec(
+		`INSERT INTO cycle_stats
+		   (completed_at, duration_ms, feeds_total, feeds_downloaded, feeds_not_modified,
+		    feeds_errored, new_articles, processed, high_interest, ai_backend_available)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cs.CompletedAt, cs.DurationMs, cs.FeedsTotal, cs.FeedsDownloaded, cs.FeedsNotModified,
+		cs.FeedsErrored, cs.NewArticles, cs.Processed, cs.HighInterest, cs.AIBackendAvailable,
+	); err != nil {
+		return fmt.Errorf("record cycle stats: %w", err)
+	}
+	// Keep the most recent 500 cycles (~10 days at a 30m cadence).
+	if _, err := s.db.Exec(
+		`DELETE FROM cycle_stats WHERE id NOT IN (
+		   SELECT id FROM cycle_stats ORDER BY completed_at DESC LIMIT 500)`,
+	); err != nil {
+		return fmt.Errorf("prune cycle stats: %w", err)
+	}
+	return nil
+}
+
+// GetRecentCycleStats returns the most recent completed cycles, newest first.
+func (s *SQLiteStore) GetRecentCycleStats(limit int) ([]CycleStats, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(
+		`SELECT id, completed_at, duration_ms, feeds_total, feeds_downloaded, feeds_not_modified,
+		        feeds_errored, new_articles, processed, high_interest, ai_backend_available
+		 FROM cycle_stats ORDER BY completed_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get recent cycle stats: %w", err)
+	}
+	defer rows.Close()
+	var out []CycleStats
+	for rows.Next() {
+		var c CycleStats
+		if err := rows.Scan(&c.ID, &c.CompletedAt, &c.DurationMs, &c.FeedsTotal, &c.FeedsDownloaded,
+			&c.FeedsNotModified, &c.FeedsErrored, &c.NewArticles, &c.Processed, &c.HighInterest,
+			&c.AIBackendAvailable); err != nil {
+			return nil, fmt.Errorf("scan cycle stats: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
 // CreateArticleGroup creates a new article group
 func (s *SQLiteStore) CreateArticleGroup(userID int64, topic string) (int64, error) {
 	result, err := s.db.Exec(

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1377,6 +1377,55 @@ func (s *SQLiteStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 	return stats, rows.Err()
 }
 
+// GetProcessingStats returns an aggregate snapshot of the AI pipeline state for a
+// user's articles (not broken down by feed). Counts mirror the daemon's own
+// work-selection predicates: "pending" uses ai_retries < 3 (the retry budget the
+// pipeline honours) and "stuck" is everything that has exhausted it.
+func (s *SQLiteStore) GetProcessingStats(userID int64) (*ProcessingStats, error) {
+	var p ProcessingStats
+	err := s.db.QueryRow(`
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN rs.ai_scored = 1 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = 0) AND COALESCE(rs.ai_retries, 0) < 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = 0) AND COALESCE(rs.ai_retries, 0) >= 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.security_score >= 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.security_score IS NOT NULL AND rs.security_score < 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.ai_scored = 1 AND rs.security_score IS NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN rs.interest_score IS NOT NULL THEN 1 ELSE 0 END), 0)
+		FROM articles a
+		JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
+		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?`,
+		userID, userID,
+	).Scan(&p.TotalArticles, &p.Scored, &p.Pending, &p.Stuck,
+		&p.SecurityPassed, &p.SecurityRejected, &p.SecuritySkipped, &p.Curated)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (funnel): %w", err)
+	}
+
+	err = s.db.QueryRow(`
+		SELECT
+			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND ai_summary <> ''),
+			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND COALESCE(skip_reason, '') <> '')`,
+		userID, userID,
+	).Scan(&p.Summarized, &p.SummarizeSkipped)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (summaries): %w", err)
+	}
+
+	err = s.db.QueryRow(`
+		SELECT
+			(SELECT COUNT(*) FROM user_feeds WHERE user_id = ?),
+			(SELECT COUNT(*) FROM feeds f JOIN user_feeds uf ON uf.feed_id = f.id
+			 WHERE uf.user_id = ? AND f.consecutive_errors > 0)`,
+		userID, userID,
+	).Scan(&p.FeedsTotal, &p.FeedsErroring)
+	if err != nil {
+		return nil, fmt.Errorf("get processing stats (feeds): %w", err)
+	}
+	return &p, nil
+}
+
 // CreateArticleGroup creates a new article group
 func (s *SQLiteStore) CreateArticleGroup(userID int64, topic string) (int64, error) {
 	result, err := s.db.Exec(

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2846,3 +2846,43 @@ func TestGetProcessingStats(t *testing.T) {
 		}
 	}
 }
+
+func TestCycleStats(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	base := time.Now()
+	for i := range 3 {
+		if err := store.RecordCycleStats(CycleStats{
+			CompletedAt:        base.Add(time.Duration(i) * time.Minute),
+			DurationMs:         int64(1000 * (i + 1)),
+			FeedsTotal:         10,
+			FeedsDownloaded:    5,
+			NewArticles:        i,
+			Processed:          i * 2,
+			HighInterest:       i,
+			FeedsErrored:       i,
+			AIBackendAvailable: i%2 == 0,
+		}); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+	}
+
+	recent, err := store.GetRecentCycleStats(10)
+	if err != nil {
+		t.Fatalf("get recent: %v", err)
+	}
+	if len(recent) != 3 {
+		t.Fatalf("got %d cycles, want 3", len(recent))
+	}
+	// Newest first (completed_at DESC): the i=2 row.
+	if recent[0].Processed != 4 || recent[0].DurationMs != 3000 || !recent[0].AIBackendAvailable {
+		t.Errorf("newest cycle mismatch: %+v", recent[0])
+	}
+	if recent[2].NewArticles != 0 {
+		t.Errorf("oldest cycle NewArticles = %d, want 0", recent[2].NewArticles)
+	}
+	if one, _ := store.GetRecentCycleStats(1); len(one) != 1 {
+		t.Fatalf("limit=1 returned %d rows", len(one))
+	}
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2759,3 +2759,90 @@ func TestGetUngroupedEmbeddedArticles(t *testing.T) {
 		}
 	})
 }
+
+func TestGetProcessingStats(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	feed1, _ := store.AddFeed("https://ex.com/f1", "Feed One", "")
+	feed2, _ := store.AddFeed("https://ex.com/f2", "Feed Two", "")
+	if err := store.SubscribeUserToFeed(1, feed1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SubscribeUserToFeed(1, feed2); err != nil {
+		t.Fatal(err)
+	}
+	// feed2 has a failing latest fetch.
+	if err := store.UpdateFeedError(feed2, "boom: context canceled"); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	add := func(guid string) int64 {
+		id, err := store.AddArticle(&Article{
+			FeedID: feed1, GUID: guid, Title: guid,
+			URL: "https://ex.com/" + guid, Content: "body", PublishedDate: &now,
+		})
+		if err != nil {
+			t.Fatalf("add %s: %v", guid, err)
+		}
+		return id
+	}
+
+	add("a1") // untouched -> pending
+
+	a2 := add("a2") // scored, security pass, curated, summarized
+	if err := store.MarkSecurityScored(1, a2, 8, "ok", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetInterestScore(1, a2, 7); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateArticleAISummary(1, a2, "a real summary"); err != nil {
+		t.Fatal(err)
+	}
+
+	a3 := add("a3") // scored, security rejected, summarize-skipped
+	if err := store.MarkSecurityScored(1, a3, 3, "unsafe", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkSummarizationSkipped(1, a3, "too short"); err != nil {
+		t.Fatal(err)
+	}
+
+	a4 := add("a4") // unscored with retries maxed -> stuck
+	for range 3 {
+		if err := store.IncrementAIRetries(1, a4); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ps, err := store.GetProcessingStats(1)
+	if err != nil {
+		t.Fatalf("GetProcessingStats: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"TotalArticles", ps.TotalArticles, 4},
+		{"Scored", ps.Scored, 2},
+		{"Pending", ps.Pending, 1},
+		{"Stuck", ps.Stuck, 1},
+		{"SecurityPassed", ps.SecurityPassed, 1},
+		{"SecurityRejected", ps.SecurityRejected, 1},
+		{"SecuritySkipped", ps.SecuritySkipped, 0},
+		{"Curated", ps.Curated, 1},
+		{"Summarized", ps.Summarized, 1},
+		{"SummarizeSkipped", ps.SummarizeSkipped, 1},
+		{"FeedsTotal", ps.FeedsTotal, 2},
+		{"FeedsErroring", ps.FeedsErroring, 1},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -40,6 +40,23 @@ type ProcessingStats struct {
 	FeedsErroring    int // feeds whose latest fetch failed (consecutive_errors > 0)
 }
 
+// CycleStats is one completed run of the fetch+process daemon cycle. Persisted so
+// the web UI can show throughput and backend health without access to the
+// daemon's in-memory state. (storage-internal type)
+type CycleStats struct {
+	ID                 int64
+	CompletedAt        time.Time
+	DurationMs         int64
+	FeedsTotal         int
+	FeedsDownloaded    int
+	FeedsNotModified   int
+	FeedsErrored       int
+	NewArticles        int
+	Processed          int
+	HighInterest       int
+	AIBackendAvailable bool
+}
+
 // Store defines the storage interface for herald's data layer.
 type Store interface {
 	Close() error
@@ -75,6 +92,8 @@ type Store interface {
 	ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error)
 	GetScoreStats(userID int64) (*ScoreStatsResult, error)
 	GetProcessingStats(userID int64) (*ProcessingStats, error)
+	RecordCycleStats(stats CycleStats) error
+	GetRecentCycleStats(limit int) ([]CycleStats, error)
 
 	// Feeds
 	AddFeed(url, title, description string) (int64, error)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -21,6 +21,25 @@ type ScoreStatsResult struct {
 	Total FeedScoreStats
 }
 
+// ProcessingStats is an aggregate snapshot of where a user's articles sit in the
+// AI pipeline (fetch -> security -> summarize -> curate). Unlike ScoreStatsResult
+// it counts pipeline *state* (how much is done vs pending), not score outcomes,
+// and is not broken down by feed. (storage-internal type)
+type ProcessingStats struct {
+	TotalArticles    int // articles in the user's subscribed feeds
+	Scored           int // read_state.ai_scored = true
+	Pending          int // unscored, ai_retries < maxRetries -- the real backlog
+	Stuck            int // unscored, ai_retries >= maxRetries -- given up, needs attention
+	SecurityPassed   int // security_score >= securityPassThreshold
+	SecurityRejected int // security_score present and below the pass threshold
+	SecuritySkipped  int // scored but no security score (no content / too short)
+	Summarized       int // has a real (non-skipped) AI summary
+	SummarizeSkipped int // summary row marked skipped (deterministic rejection)
+	Curated          int // interest_score present
+	FeedsTotal       int // feeds the user subscribes to
+	FeedsErroring    int // feeds whose latest fetch failed (consecutive_errors > 0)
+}
+
 // Store defines the storage interface for herald's data layer.
 type Store interface {
 	Close() error
@@ -55,6 +74,7 @@ type Store interface {
 	IncrementAIRetries(userID, articleID int64) error
 	ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error)
 	GetScoreStats(userID int64) (*ScoreStatsResult, error)
+	GetProcessingStats(userID int64) (*ProcessingStats, error)
 
 	// Feeds
 	AddFeed(url, title, description string) (int64, error)

--- a/types.go
+++ b/types.go
@@ -244,6 +244,24 @@ type ScoreStatsResult struct {
 	Total FeedScoreStats
 }
 
+// ProcessingStats is an aggregate snapshot of where a user's articles sit in the
+// AI pipeline (fetch -> security -> summarize -> curate). It reports pipeline
+// state (done vs pending), not score outcomes, and is not broken down by feed.
+type ProcessingStats struct {
+	TotalArticles    int
+	Scored           int
+	Pending          int // real backlog: unscored, within the retry budget
+	Stuck            int // unscored but out of retries -- needs attention
+	SecurityPassed   int
+	SecurityRejected int
+	SecuritySkipped  int // scored but no security verdict (no content / too short)
+	Summarized       int
+	SummarizeSkipped int
+	Curated          int
+	FeedsTotal       int
+	FeedsErroring    int
+}
+
 // UserPreferences holds all user-configurable preference values.
 type UserPreferences struct {
 	Keywords          []string `json:"keywords"`

--- a/types.go
+++ b/types.go
@@ -262,6 +262,22 @@ type ProcessingStats struct {
 	FeedsErroring    int
 }
 
+// CycleStats is one completed run of the fetch+process daemon cycle, persisted so
+// the web UI can report throughput and backend health.
+type CycleStats struct {
+	ID                 int64
+	CompletedAt        time.Time
+	DurationMs         int64
+	FeedsTotal         int
+	FeedsDownloaded    int
+	FeedsNotModified   int
+	FeedsErrored       int
+	NewArticles        int
+	Processed          int
+	HighInterest       int
+	AIBackendAvailable bool
+}
+
 // UserPreferences holds all user-configurable preference values.
 type UserPreferences struct {
 	Keywords          []string `json:"keywords"`

--- a/types.go
+++ b/types.go
@@ -68,6 +68,9 @@ type Feed struct {
 	LastError   *string    `json:"last_error,omitempty"`
 	Enabled     bool       `json:"enabled"`
 	CreatedAt   time.Time  `json:"created_at"`
+	// ConsecutiveErrors is the number of failed fetches since the last success;
+	// reset to 0 on a successful fetch. >0 means the feed is currently failing.
+	ConsecutiveErrors int `json:"consecutive_errors,omitempty"`
 }
 
 // SearchResult holds a single search hit with match metadata.


### PR DESCRIPTION
## Why

The Feeds page presented an "Unscored" column that actually counted *unsummarized* articles -- dominated by no-content/too-short items the security stage intentionally skips. It read ~3,000 when the real unscored backlog was ~2, and there was no view of overall pipeline progress, throughput, or backend health. (Diagnosed while chasing a scoring outage; the column overstated the backlog ~1,500x.)

## What

Three commits:

1. **Add a `/status` tab** (distinct from `/stats`, which shows per-feed score *outcomes*). Aggregate pipeline state for the user's articles:
   - Headline cards: real **pending backlog** (`ai_retries < 3`, matching the daemon's own work selection), **stuck** count (retries exhausted), and **feeds erroring** (`consecutive_errors > 0`, not stale `last_error`).
   - Pipeline funnel: total -> scored -> security pass/reject/skipped -> summarized -> curated.

2. **Persist daemon cycle stats** so the web process (separate from the daemon) can show throughput + backend health. New `cycle_stats` table (sqlite + postgres, bounded to the last 500 rows); `doFetch` records one row per cycle via a defer covering every exit path; the Status tab gains a "Last cycle" block and a recent-cycles history table.

3. **Feeds-page cleanup**: rename "Unscored" -> "Unsummarized" (matches what it measures), and replace the raw error string with a "Failing (Nx since last success)" badge driven by `consecutive_errors`.

## Notes

- TDD throughout; `task check` clean (build, `go test -race`, golangci-lint 0 issues).
- New `GetProcessingStats` / `RecordCycleStats` / `GetRecentCycleStats` on the Store (both backends), engine passthroughs, public types.
- The cycle-history table populates only after a patched **herald-fetcher** runs a cycle; the funnel/backlog cards work immediately.
- Follow-up left for later: the daemon could also persist breaker-open events for finer backend-health detail.