### PR TITLE
Add smoke route-coverage to herald-web (phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+      - name: Smoke route coverage (warn)
+        run: go tool smolder gate --manifest cmd/herald-web/smoke-manifest.json --mode warn
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
         continue-on-error: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,16 @@ tasks:
     cmds:
       - govulncheck ./...
 
+  smoke:gen:
+    desc: Regenerate the committed smoke route manifest from herald-web's routes.
+    cmds:
+      - UPDATE_SMOKE_MANIFEST=1 go test ./cmd/herald-web/ -run TestSmokeManifestUpToDate
+
+  smoke:gate:
+    desc: List routes lacking smoke coverage (warn; pass MODE=fail to hard-gate).
+    cmds:
+      - go tool smolder gate --manifest cmd/herald-web/smoke-manifest.json --mode {{.MODE | default "warn"}}
+
   check:
     desc: Run all CI checks (test, vet, fmt, lint, vulncheck)
     cmds:

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -4,8 +4,11 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"os"
+	"strconv"
 
 	"github.com/infodancer/oidclient"
+	"github.com/infodancer/smoke"
 	herald "github.com/matthewjhunter/herald"
 )
 
@@ -13,25 +16,39 @@ import (
 var embedded embed.FS
 
 // newRouter sets up all routes using Go 1.22+ enhanced routing.
-func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string) http.Handler {
-	mux := http.NewServeMux()
+//
+// The mux is a smoke.Mux: a drop-in *http.ServeMux wrap that records a spec for
+// every registration so the route surface can be enumerated for black-box smoke
+// testing (the producer half of github.com/infodancer/smoke). Write routes are
+// marked smoke.Write() (recorded as mutating + skipped until phase-2 wires auth
+// and request payloads); routes that can't be probed by a bare GET are
+// smoke.Skip()'d with a reason. Parameterized read routes are left without
+// example params on purpose — they surface in `smolder gate` as the phase-2
+// fixture backlog. Returning *smoke.Mux (still an http.Handler) lets the drift
+// test read the registry; callers use it as a handler unchanged.
+func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string) *smoke.Mux {
+	mux := smoke.NewMux()
 
 	// Static files — no auth required.
 	staticFS, _ := fs.Sub(embedded, "static")
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticFS)))
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticFS)),
+		smoke.Skip("static file server subtree"))
 
 	h := &handlers{engine: engine, validator: validator, adminRole: adminRole, adminUsers: adminUsers}
 	auth := h.requireAuth
 
 	// Auth callback — receives the code from webauth, exchanges it for a JWT cookie.
-	mux.HandleFunc("GET /auth/callback", h.handleCallback)
+	mux.HandleFunc("GET /auth/callback", h.handleCallback,
+		smoke.Skip("OIDC callback; requires a code & state, not a bare GET"))
 
 	// OPML sync — token-authenticated, no JWT required.
-	mux.HandleFunc("GET /opml/{userID}/{token}", h.handleOPMLSync)
+	mux.HandleFunc("GET /opml/{userID}/{token}", h.handleOPMLSync,
+		smoke.Skip("token-authenticated OPML sync; requires a valid per-user token"))
 
 	// Fever API — uses its own api_key auth, not JWT.
 	mux.HandleFunc("GET /fever/", h.handleFever)
-	mux.HandleFunc("POST /fever/", h.handleFever)
+	mux.HandleFunc("POST /fever/", h.handleFever,
+		smoke.Skip("Fever API sync endpoint; own api_key auth, POST"))
 
 	// Logout — no auth check needed; just redirects to webauth logout.
 	mux.HandleFunc("GET /auth/logout", h.handleLogout)
@@ -50,65 +67,88 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("GET /articles", auth(http.HandlerFunc(h.handleArticleList)))
 	mux.Handle("GET /articles/{articleID}", auth(http.HandlerFunc(h.handleArticleView)))
 	mux.Handle("GET /sidebar", auth(http.HandlerFunc(h.handleSidebar)))
-	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)))
-	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)))
+	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)), smoke.Write())
+	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Write())
 	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)))
 	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)))
 	mux.Handle("GET /feeds/export.opml", auth(http.HandlerFunc(h.handleOPMLExport)))
-	mux.Handle("POST /feeds/discover", auth(http.HandlerFunc(h.handleFeedDiscover)))
-	mux.Handle("POST /feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)))
-	mux.Handle("POST /feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)))
-	mux.Handle("DELETE /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)))
-	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)))
+	mux.Handle("POST /feeds/discover", auth(http.HandlerFunc(h.handleFeedDiscover)), smoke.Write())
+	mux.Handle("POST /feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)), smoke.Write())
+	mux.Handle("POST /feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)), smoke.Write())
+	mux.Handle("DELETE /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)), smoke.Write())
+	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)), smoke.Write())
 	mux.Handle("GET /feeds/{feedID}/edit-title", auth(http.HandlerFunc(h.handleFeedEditTitle)))
 	mux.Handle("GET /feeds/{feedID}/title", auth(http.HandlerFunc(h.handleFeedTitleDisplay)))
-	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)))
-	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)))
-	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)))
-	mux.Handle("POST /settings/opml-token", auth(http.HandlerFunc(h.handleOPMLTokenGenerate)))
-	mux.Handle("POST /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialSave)))
-	mux.Handle("DELETE /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialDelete)))
-	mux.Handle("POST /filters", auth(http.HandlerFunc(h.handleFilterAdd)))
-	mux.Handle("POST /filters/threshold", auth(http.HandlerFunc(h.handleFilterThreshold)))
-	mux.Handle("DELETE /filters/{ruleID}", auth(http.HandlerFunc(h.handleFilterDelete)))
+	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)), smoke.Write())
+	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)), smoke.Write())
+	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)), smoke.Write())
+	mux.Handle("POST /settings/opml-token", auth(http.HandlerFunc(h.handleOPMLTokenGenerate)), smoke.Write())
+	mux.Handle("POST /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialSave)), smoke.Write())
+	mux.Handle("DELETE /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialDelete)), smoke.Write())
+	mux.Handle("POST /filters", auth(http.HandlerFunc(h.handleFilterAdd)), smoke.Write())
+	mux.Handle("POST /filters/threshold", auth(http.HandlerFunc(h.handleFilterThreshold)), smoke.Write())
+	mux.Handle("DELETE /filters/{ruleID}", auth(http.HandlerFunc(h.handleFilterDelete)), smoke.Write())
 	mux.Handle("GET /feeds/{feedID}/metadata", auth(http.HandlerFunc(h.handleFeedMetadata)))
 	mux.Handle("GET /feeds/metadata", auth(http.HandlerFunc(h.handleFeedMetadataByQuery)))
 	mux.Handle("GET /filters/values", auth(http.HandlerFunc(h.handleFilterValues)))
 
 	// Group virtual feed actions.
-	mux.Handle("POST /groups/{groupID}/mute", auth(http.HandlerFunc(h.handleGroupMute)))
-	mux.Handle("DELETE /groups/{groupID}", auth(http.HandlerFunc(h.handleGroupDisband)))
-	mux.Handle("POST /groups/{groupID}/mark-read", auth(http.HandlerFunc(h.handleGroupMarkRead)))
+	mux.Handle("POST /groups/{groupID}/mute", auth(http.HandlerFunc(h.handleGroupMute)), smoke.Write())
+	mux.Handle("DELETE /groups/{groupID}", auth(http.HandlerFunc(h.handleGroupDisband)), smoke.Write())
+	mux.Handle("POST /groups/{groupID}/mark-read", auth(http.HandlerFunc(h.handleGroupMarkRead)), smoke.Write())
 
 	// Newsletter routes.
 	mux.Handle("GET /newsletters", auth(http.HandlerFunc(h.handleNewslettersManage)))
-	mux.Handle("POST /newsletters", auth(http.HandlerFunc(h.handleNewsletterCreate)))
-	mux.Handle("PATCH /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterUpdate)))
-	mux.Handle("DELETE /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterDelete)))
-	mux.Handle("POST /newsletters/{newsletterID}/generate", auth(http.HandlerFunc(h.handleNewsletterGenerate)))
+	mux.Handle("POST /newsletters", auth(http.HandlerFunc(h.handleNewsletterCreate)), smoke.Write())
+	mux.Handle("PATCH /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterUpdate)), smoke.Write())
+	mux.Handle("DELETE /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterDelete)), smoke.Write())
+	mux.Handle("POST /newsletters/{newsletterID}/generate", auth(http.HandlerFunc(h.handleNewsletterGenerate)), smoke.Write())
 
 	// AI Summary routes — list in the top pane, a selected digest in the reading pane.
 	mux.Handle("GET /summary", auth(http.HandlerFunc(h.handleSummaryView)))
 	mux.Handle("GET /summary/{id}", auth(http.HandlerFunc(h.handleSummaryDetail)))
-	mux.Handle("POST /summary/generate", auth(http.HandlerFunc(h.handleSummaryGenerate)))
-	mux.Handle("POST /summary/{id}/mark-read", auth(http.HandlerFunc(h.handleSummaryMarkRead)))
+	mux.Handle("POST /summary/generate", auth(http.HandlerFunc(h.handleSummaryGenerate)), smoke.Write())
+	mux.Handle("POST /summary/{id}/mark-read", auth(http.HandlerFunc(h.handleSummaryMarkRead)), smoke.Write())
 
 	// Ollama model list (used by prompt settings pages).
 	mux.Handle("GET /api/ollama/models", auth(http.HandlerFunc(h.handleOllamaModels)))
 
 	// Per-user AI prompt customization.
-	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)))
-	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)))
+	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Write())
+	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)), smoke.Write())
 
 	// Admin-only routes.
 	adminAuth := h.requireAdmin
 	mux.Handle("GET /admin/feeds/export.opml", auth(adminAuth(http.HandlerFunc(h.handleAdminOPMLExport))))
 	mux.Handle("GET /admin/stats", auth(adminAuth(http.HandlerFunc(h.handleAdminStats))))
 	mux.Handle("GET /admin/prompts", auth(adminAuth(http.HandlerFunc(h.handleAdminPrompts))))
-	mux.Handle("POST /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptSave))))
-	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))))
+	mux.Handle("POST /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptSave))), smoke.Write())
+	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))), smoke.Write())
 	mux.Handle("GET /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))))
-	mux.Handle("POST /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))))
+	mux.Handle("POST /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))), smoke.Write())
+
+	// Smoke manifest introspection — emits the recorded RouteSpecs as JSON for
+	// the smolder runner. Gated on SMOKE_MANIFEST because it enumerates the
+	// route surface, so it must never be exposed on prod. Registered on the raw
+	// ServeMux so it does not appear in its own output.
+	if smokeManifestEnabled() {
+		mux.ServeMux().HandleFunc("GET /_smoke/manifest", func(w http.ResponseWriter, r *http.Request) {
+			data, err := mux.Registry().Manifest().MarshalJSON()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(data)
+		})
+	}
 
 	return mux
+}
+
+// smokeManifestEnabled reports whether the SMOKE_MANIFEST env var is truthy,
+// gating the route-surface introspection endpoint.
+func smokeManifestEnabled() bool {
+	v, err := strconv.ParseBool(os.Getenv("SMOKE_MANIFEST"))
+	return err == nil && v
 }

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -1,0 +1,416 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "pattern": "/admin/digest",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/admin/digest",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/admin/feeds/export.opml",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/admin/prompts",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/admin/prompts/{promptType}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/admin/prompts/{promptType}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/admin/stats",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/api/ollama/models",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/articles",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/articles/mark-all-read",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/articles/{articleID}",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "POST",
+      "pattern": "/articles/{articleID}/star",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/auth/callback",
+      "effect": "read_only",
+      "skip": "OIDC callback; requires a code \u0026 state, not a bare GET",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/auth/logout",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/feeds",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/feeds/discover",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/export.opml",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/feeds/import",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/metadata",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/feeds/{feedID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "PATCH",
+      "pattern": "/feeds/{feedID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/{feedID}/edit-title",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/{feedID}/favicon",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/{feedID}/metadata",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/feeds/{feedID}/tags",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/feeds/{feedID}/tags",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/feeds/{feedID}/title",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "GET",
+      "pattern": "/fever/",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/fever/",
+      "effect": "mutating",
+      "skip": "Fever API sync endpoint; own api_key auth, POST",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/filters",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/filters",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/filters/threshold",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/filters/values",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/filters/{ruleID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/groups/{groupID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/groups/{groupID}/mark-read",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/groups/{groupID}/mute",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/images/{imageID}",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "GET",
+      "pattern": "/newsletters",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/newsletters",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/newsletters/{newsletterID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "PATCH",
+      "pattern": "/newsletters/{newsletterID}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/newsletters/{newsletterID}/generate",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/opml/{userID}/{token}",
+      "effect": "read_only",
+      "skip": "token-authenticated OPML sync; requires a valid per-user token",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/search",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/settings",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/settings",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/settings/fever",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/settings/fever",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/settings/opml-token",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/settings/prompts",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/settings/prompts/{promptType}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/settings/prompts/{promptType}",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/settings/sync",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/sidebar",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/static/",
+      "effect": "read_only",
+      "skip": "static file server subtree",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/stats",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/summary",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "POST",
+      "pattern": "/summary/generate",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/summary/{id}",
+      "effect": "read_only",
+      "complete": false
+    },
+    {
+      "method": "POST",
+      "pattern": "/summary/{id}/mark-read",
+      "effect": "mutating",
+      "skip": "write — smoke phase 2 (auth + payloads)",
+      "complete": true
+    },
+    {
+      "method": "GET",
+      "pattern": "/{$}",
+      "effect": "read_only",
+      "complete": true
+    }
+  ]
+}

--- a/cmd/herald-web/smoke_manifest_test.go
+++ b/cmd/herald-web/smoke_manifest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -41,7 +42,35 @@ func TestSmokeManifestUpToDate(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Errorf("smoke manifest drift: routes changed but %s is stale.\n"+
-			"Regenerate: UPDATE_SMOKE_MANIFEST=1 go test ./cmd/herald-web/ -run TestSmokeManifestUpToDate",
-			smokeManifestPath)
+			"Regenerate: UPDATE_SMOKE_MANIFEST=1 go test ./cmd/herald-web/ -run TestSmokeManifestUpToDate\n%s",
+			smokeManifestPath, lineDiff(string(want), string(got)))
 	}
+}
+
+// lineDiff reports lines present in want-but-not-got and got-but-not-want, so a
+// drift failure pinpoints which routes were added or removed regardless of
+// ordering. It is a set difference, not a positional diff.
+func lineDiff(want, got string) string {
+	wantSet := map[string]bool{}
+	for _, l := range strings.Split(want, "\n") {
+		wantSet[l] = true
+	}
+	gotSet := map[string]bool{}
+	for _, l := range strings.Split(got, "\n") {
+		gotSet[l] = true
+	}
+	var b strings.Builder
+	b.WriteString("lines only in committed (want):\n")
+	for _, l := range strings.Split(want, "\n") {
+		if !gotSet[l] {
+			b.WriteString("  - " + l + "\n")
+		}
+	}
+	b.WriteString("lines only in generated (got):\n")
+	for _, l := range strings.Split(got, "\n") {
+		if !wantSet[l] {
+			b.WriteString("  + " + l + "\n")
+		}
+	}
+	return b.String()
 }

--- a/cmd/herald-web/smoke_manifest_test.go
+++ b/cmd/herald-web/smoke_manifest_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// smokeManifestPath is the committed route manifest, consumed by the smolder
+// CLI (gate + live runs) and kept in sync by this test.
+const smokeManifestPath = "smoke-manifest.json"
+
+// TestSmokeManifestUpToDate asserts the committed manifest matches the routes
+// newRouter actually registers. Regenerate after adding or changing routes:
+//
+//	UPDATE_SMOKE_MANIFEST=1 go test ./cmd/herald-web/ -run TestSmokeManifestUpToDate
+//
+// This is the drift gate for the route surface: a new route that isn't
+// reflected here fails CI until the manifest is regenerated (which also
+// surfaces the route to the smolder coverage gate). newRouter only records
+// specs at registration time and never touches the engine/validator, so a nil
+// engine is sufficient to enumerate the surface without a database.
+func TestSmokeManifestUpToDate(t *testing.T) {
+	got, err := newRouter(nil, nil, "", nil).Registry().Manifest().MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = append(got, '\n')
+
+	if os.Getenv("UPDATE_SMOKE_MANIFEST") != "" {
+		if err := os.WriteFile(smokeManifestPath, got, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s", smokeManifestPath)
+		return
+	}
+
+	want, err := os.ReadFile(smokeManifestPath)
+	if err != nil {
+		t.Fatalf("read %s (regenerate with UPDATE_SMOKE_MANIFEST=1): %v", smokeManifestPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("smoke manifest drift: routes changed but %s is stale.\n"+
+			"Regenerate: UPDATE_SMOKE_MANIFEST=1 go test ./cmd/herald-web/ -run TestSmokeManifestUpToDate",
+			smokeManifestPath)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/infodancer/oidclient v0.1.0
+	github.com/infodancer/smoke v0.1.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/matthewjhunter/go-embedding v0.4.6
 	github.com/microcosm-cc/bluemonday v1.0.27
@@ -57,3 +58,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+tool github.com/infodancer/smoke/cmd/smolder

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infodancer/oidclient v0.1.0 h1:RmmVwzf2G38yBnW4TUECn7dXB4lRdSJlQxif48ruWsY=
 github.com/infodancer/oidclient v0.1.0/go.mod h1:6vGWxWv4vVx0xQ0M0pyHuHjh+8Rbp3HKjcLXLC7/280=
+github.com/infodancer/smoke v0.1.0 h1:meBKkJHVtkFwV0NZ2YzOHTn9Fc+JG4flkRfrNd/30yU=
+github.com/infodancer/smoke v0.1.0/go.mod h1:zh5UdP94gj1koedPhrzaaXJbysCyv1x7NiJpWQiSloc=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=


### PR DESCRIPTION
Wires [github.com/infodancer/smoke](https://github.com/infodancer/smoke) `v0.1.0` into `herald-web` so the route surface is enumerable for black-box smoke testing -- the producer half of the system OSG already proved against a ~160-route surface. herald-web is the same stdlib `net/http` stack with the same OIDC/webauth auth, so the pattern transfers directly. herald is smoke's second consumer, which is what triggered tagging it `v0.1.0`.

## What this does (phase 1)

- **`routes.go`**: `http.NewServeMux` -> `smoke.NewMux`. Write routes (`POST/PUT/PATCH/DELETE`) are marked `smoke.Write()` (recorded mutating + skipped until phase 2 wires auth + payloads); the OIDC callback, OPML sync, fever `POST`, and static subtree are `smoke.Skip()`'d with reasons. `newRouter` now returns `*smoke.Mux` (still an `http.Handler`, callers unchanged) so the drift test can read the registry.
- **`GET /_smoke/manifest`** endpoint, gated on `SMOKE_MANIFEST` and registered on the raw `ServeMux` so it never appears in its own output or on prod.
- **`smoke-manifest.json`**: committed route manifest (63 routes).
- **`TestSmokeManifestUpToDate`**: drift gate -- a route added without updating the manifest fails CI. Runs DB-free (nil engine; `newRouter` never derefs engine/validator at registration). Regenerate with `task smoke:gen`.
- **Taskfile**: `smoke:gen` (regenerate) and `smoke:gate` (coverage warn).
- **CI**: non-failing `smolder gate --mode warn` step in the checks job, surfacing uncovered routes in logs.

## Consumption

herald does not vendor -- it consumes smoke by version (`require v0.1.0`, no `replace`) + a `tool` directive for `smolder`, matching its existing convention for `oidclient`/`go-embedding` via the public proxy.

## Scope / what this does NOT do yet

This gives route-inventory discipline -- the manifest can't silently rot. It does **not** yet catch the wiring/DI/migration 502-class bug, because nothing probes a running server. The gate currently warns on **7 parameterized read routes** that need fixture seed data -- the phase-2 backlog, surfaced rather than hidden.

**Phase 2** (planned, separate): authed probes via a `smokeauth`-equivalent against webauth + a per-PR preview site to run `smolder run` against. herald CI has no running-server stage today.

## Checks

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go test -race ./cmd/herald-web/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)