### PR TITLE
Authed in-process smoke harness + template-init race fix (phase 2a)

### DIFF
--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/infodancer/oidclient"
@@ -27,6 +28,7 @@ type handlers struct {
 	engine     *herald.Engine
 	validator  *oidclient.Client
 	pages      map[string]*template.Template // per-page template sets
+	pagesOnce  sync.Once                     // guards lazy template parsing
 	adminRole  string                        // JWT role value that grants admin access (default: "admin")
 	adminUsers []string                      // fallback email list when the IdP does not issue role claims
 }
@@ -109,10 +111,14 @@ func (h *handlers) loadPromptEntries(userID int64) []promptUIEntry {
 // This avoids Go's template namespace collision where multiple files defining the
 // same block name (e.g. "nav") overwrite each other.
 func (h *handlers) init() {
-	if h.pages != nil {
-		return
-	}
+	h.pagesOnce.Do(h.parseTemplates)
+}
 
+// parseTemplates builds the per-page template trees. It runs exactly once via
+// pagesOnce: the previous lazy guard (assign h.pages, then populate it) let a
+// concurrent first request observe a half-built map and 500 with "unknown
+// template" -- a race the smoke harness surfaced under concurrent probing.
+func (h *handlers) parseTemplates() {
 	funcMap := template.FuncMap{
 		"safeHTML": func(s string) template.HTML {
 			return template.HTML(s) //nolint:gosec // already sanitized by bluemonday
@@ -166,12 +172,14 @@ func (h *handlers) init() {
 	// Pages that get their own template tree.
 	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "stats.html", "status.html", "newsletters_manage.html"}
 
-	h.pages = make(map[string]*template.Template, len(pages))
+	built := make(map[string]*template.Template, len(pages))
 	for _, page := range pages {
 		files := append(shared, page)
 		t := template.Must(template.New("").Funcs(funcMap).ParseFS(tmplFS, files...))
-		h.pages[page] = t
+		built[page] = t
 	}
+	// Publish only once fully built so no reader sees a partial map.
+	h.pages = built
 }
 
 // --- Template data types ---

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -64,22 +64,27 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("GET /status", auth(http.HandlerFunc(h.handleProcessingStatus)))
 
 	// htmx fragment routes.
+	//
+	// Parameterized read routes carry smoke.Example() values that reference the
+	// deterministic smoke fixture (each entity is the first row in a fresh DB,
+	// so its id is 1). The fixture is seeded by TestSmokeRoutesAuthenticated
+	// (and, for the phase-2b container preview, by an equivalent seeder).
 	mux.Handle("GET /search", auth(http.HandlerFunc(h.handleSearch)))
 	mux.Handle("GET /articles", auth(http.HandlerFunc(h.handleArticleList)))
-	mux.Handle("GET /articles/{articleID}", auth(http.HandlerFunc(h.handleArticleView)))
+	mux.Handle("GET /articles/{articleID}", auth(http.HandlerFunc(h.handleArticleView)), smoke.Example("articleID", "1"))
 	mux.Handle("GET /sidebar", auth(http.HandlerFunc(h.handleSidebar)))
 	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)), smoke.Write())
 	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Write())
-	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)))
-	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)))
+	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)), smoke.Example("imageID", "1"))
+	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/export.opml", auth(http.HandlerFunc(h.handleOPMLExport)))
 	mux.Handle("POST /feeds/discover", auth(http.HandlerFunc(h.handleFeedDiscover)), smoke.Write())
 	mux.Handle("POST /feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)), smoke.Write())
 	mux.Handle("POST /feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)), smoke.Write())
 	mux.Handle("DELETE /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)), smoke.Write())
 	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)), smoke.Write())
-	mux.Handle("GET /feeds/{feedID}/edit-title", auth(http.HandlerFunc(h.handleFeedEditTitle)))
-	mux.Handle("GET /feeds/{feedID}/title", auth(http.HandlerFunc(h.handleFeedTitleDisplay)))
+	mux.Handle("GET /feeds/{feedID}/edit-title", auth(http.HandlerFunc(h.handleFeedEditTitle)), smoke.Example("feedID", "1"))
+	mux.Handle("GET /feeds/{feedID}/title", auth(http.HandlerFunc(h.handleFeedTitleDisplay)), smoke.Example("feedID", "1"))
 	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)), smoke.Write())
 	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)), smoke.Write())
 	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)), smoke.Write())
@@ -89,7 +94,7 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("POST /filters", auth(http.HandlerFunc(h.handleFilterAdd)), smoke.Write())
 	mux.Handle("POST /filters/threshold", auth(http.HandlerFunc(h.handleFilterThreshold)), smoke.Write())
 	mux.Handle("DELETE /filters/{ruleID}", auth(http.HandlerFunc(h.handleFilterDelete)), smoke.Write())
-	mux.Handle("GET /feeds/{feedID}/metadata", auth(http.HandlerFunc(h.handleFeedMetadata)))
+	mux.Handle("GET /feeds/{feedID}/metadata", auth(http.HandlerFunc(h.handleFeedMetadata)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/metadata", auth(http.HandlerFunc(h.handleFeedMetadataByQuery)))
 	mux.Handle("GET /filters/values", auth(http.HandlerFunc(h.handleFilterValues)))
 
@@ -107,7 +112,7 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 
 	// AI Summary routes — list in the top pane, a selected digest in the reading pane.
 	mux.Handle("GET /summary", auth(http.HandlerFunc(h.handleSummaryView)))
-	mux.Handle("GET /summary/{id}", auth(http.HandlerFunc(h.handleSummaryDetail)))
+	mux.Handle("GET /summary/{id}", auth(http.HandlerFunc(h.handleSummaryDetail)), smoke.Example("id", "1"))
 	mux.Handle("POST /summary/generate", auth(http.HandlerFunc(h.handleSummaryGenerate)), smoke.Write())
 	mux.Handle("POST /summary/{id}/mark-read", auth(http.HandlerFunc(h.handleSummaryMarkRead)), smoke.Write())
 

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -68,7 +68,10 @@
       "method": "GET",
       "pattern": "/articles/{articleID}",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "articleID": "1"
+      },
+      "complete": true
     },
     {
       "method": "POST",
@@ -147,19 +150,28 @@
       "method": "GET",
       "pattern": "/feeds/{feedID}/edit-title",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "feedID": "1"
+      },
+      "complete": true
     },
     {
       "method": "GET",
       "pattern": "/feeds/{feedID}/favicon",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "feedID": "1"
+      },
+      "complete": true
     },
     {
       "method": "GET",
       "pattern": "/feeds/{feedID}/metadata",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "feedID": "1"
+      },
+      "complete": true
     },
     {
       "method": "DELETE",
@@ -179,7 +191,10 @@
       "method": "GET",
       "pattern": "/feeds/{feedID}/title",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "feedID": "1"
+      },
+      "complete": true
     },
     {
       "method": "GET",
@@ -252,7 +267,10 @@
       "method": "GET",
       "pattern": "/images/{imageID}",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "imageID": "1"
+      },
+      "complete": true
     },
     {
       "method": "GET",
@@ -403,7 +421,10 @@
       "method": "GET",
       "pattern": "/summary/{id}",
       "effect": "read_only",
-      "complete": false
+      "example_params": {
+        "id": "1"
+      },
+      "complete": true
     },
     {
       "method": "POST",

--- a/cmd/herald-web/smoke_run_test.go
+++ b/cmd/herald-web/smoke_run_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/infodancer/smoke"
+	herald "github.com/matthewjhunter/herald"
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// smokePNG is an arbitrary non-empty image blob. The image/favicon handlers
+// write the bytes verbatim with the stored MIME type; they don't decode it, so
+// the PNG signature is enough to exercise a 200 response.
+var smokePNG = []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+
+// TestSmokeRoutesAuthenticated is the phase-2a authed smoke harness: it boots
+// the real wired router against a real (SQLite) store, seeds a deterministic
+// fixture, mints a valid session cookie via the fake OIDC provider, and runs
+// the smoke library over every route in the manifest with that cookie. Unlike
+// the per-handler tests (which exercise one handler each), this drives the
+// fully assembled server end-to-end and fails on any 5xx/4xx -- the class of
+// wiring/DI/route-registration regression that unit tests against fakes miss.
+//
+// It is in-process (no preview container yet): it catches handler/route/DB-
+// wiring 502s, not deployment/migration/image regressions. Those are phase 2b.
+//
+// The fixture pins ids to 1 (each entity is the first row in a fresh DB), which
+// the smoke.Example() annotations in routes.go reference. The smoke user is made
+// admin (via the adminUsers email fallback) so /admin/* routes return 200 rather
+// than 403.
+func TestSmokeRoutesAuthenticated(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "smoke.db")
+
+	// herald-web runs read-only in production; mirror that. Incidental writes
+	// (e.g. auto-mark-read) are best-effort and ignored by the handlers.
+	engine, err := herald.NewEngine(herald.EngineConfig{DBPath: dbPath, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	t.Cleanup(func() { engine.Close() })
+
+	st, err := storage.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	// Seed the fixture. newTestValidator issues a token for sub "test-sub-1" /
+	// "tester@example.com"; provision the matching user so request-time
+	// GetOrProvisionOIDCUser resolves to it and user-scoped routes (summary)
+	// find their rows.
+	user, err := engine.GetOrProvisionOIDCUser("test-sub-1", "Tester", "tester@example.com")
+	if err != nil {
+		t.Fatalf("GetOrProvisionOIDCUser: %v", err)
+	}
+	feedID, err := st.AddFeed("https://example.com/feed", "Test Feed", "A test feed")
+	if err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+	if err := st.SubscribeUserToFeed(user.ID, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed: %v", err)
+	}
+	pub := time.Now().Add(-time.Hour)
+	articleID, err := st.AddArticle(&storage.Article{
+		FeedID:        feedID,
+		GUID:          "smoke-guid-1",
+		Title:         "Smoke Article",
+		URL:           "https://example.com/article/1",
+		Content:       "<p>Hello, world!</p>",
+		Summary:       "A test summary",
+		Author:        "Test Author",
+		PublishedDate: &pub,
+	})
+	if err != nil {
+		t.Fatalf("AddArticle: %v", err)
+	}
+	if _, err := st.StoreArticleImage(articleID, "https://example.com/img.png", smokePNG, "image/png", 1, 1); err != nil {
+		t.Fatalf("StoreArticleImage: %v", err)
+	}
+	if err := st.StoreFeedFavicon(feedID, smokePNG, "image/png"); err != nil {
+		t.Fatalf("StoreFeedFavicon: %v", err)
+	}
+	sumID, err := st.CreateAISummary(&storage.AISummary{UserID: user.ID, Model: "test-model", Prompt: "test prompt"})
+	if err != nil {
+		t.Fatalf("CreateAISummary: %v", err)
+	}
+	if err := st.UpdateAISummaryDone(sumID, "Smoke Headline", "<p>Summary body</p>", []int64{articleID}, 1, 1); err != nil {
+		t.Fatalf("UpdateAISummaryDone: %v", err)
+	}
+
+	// Confirm the deterministic ids the manifest examples assume.
+	if user.ID != 1 || feedID != 1 || articleID != 1 || sumID != 1 {
+		t.Fatalf("fixture ids not deterministic: user=%d feed=%d article=%d summary=%d (want all 1)",
+			user.ID, feedID, articleID, sumID)
+	}
+
+	validator, token := newTestValidator(t)
+	// adminRole "admin" with no role claim falls back to the adminUsers email
+	// list, granting the smoke user admin so /admin/* returns 200.
+	mux := newRouter(engine, validator, "admin", []string{"tester@example.com"})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	report, err := smoke.Run(context.Background(), mux.Registry().Manifest(), smoke.RunOptions{
+		BaseURL: srv.URL,
+		Target:  smoke.Preview,
+		Cookie:  "test_jwt=" + token,
+		// Writes are smoke.Write()-skipped (no payloads/CSRF wired yet); this is
+		// the authed reads pass. Converting writes to real probes is follow-up.
+		IncludeWrites: false,
+	})
+	if err != nil {
+		t.Fatalf("smoke.Run: %v", err)
+	}
+
+	pass, fail, skip := report.Counts()
+	t.Logf("smoke authed run: %d pass, %d fail, %d skip (of %d routes)", pass, fail, skip, len(mux.Registry().Manifest().Routes))
+	if pass == 0 {
+		t.Fatalf("no routes passed -- the harness likely isn't reaching the server")
+	}
+	for _, res := range report.Failed() {
+		t.Errorf("FAIL %s %s -> status %d: %s", res.Method, res.Pattern, res.Status, res.Reason)
+	}
+}


### PR DESCRIPTION
Phase 2a of smoke testing (phase 1 was #135): an **in-process authenticated** smoke harness that drives the fully wired `herald-web` end-to-end and asserts no 5xx/4xx on any route. It already paid for itself by surfacing a real concurrency bug (first commit).

## `TestSmokeRoutesAuthenticated`

Boots the assembled router against a real SQLite store, seeds a deterministic fixture (each entity is the first row in a fresh DB -> id `1`), mints a valid session cookie via the existing fake-OIDC test provider, and runs the `smoke` library over every route in the manifest with that cookie.

- **No herald-web auth-bypass ships.** herald validates the JWT normally against the fake provider's JWKS -- the same mechanism the existing handler tests already use. The product code has no test seam.
- Catches wiring/DI/route-registration/template regressions the per-handler unit tests (one handler each, against fakes) miss, because it drives the *assembled* server under *concurrent* probing.
- The 7 parameterized read routes now carry `smoke.Example()` values pinned to the fixture -> `smolder gate` reports **all 64 routes covered** (was 7 uncovered).
- The smoke user is made admin (via the `adminUsers` email fallback) so `/admin/*` returns 200.

## Bug it caught: data race in lazy template init (first commit)

`handlers.init()` assigned `h.pages` and *then* populated it in a loop, guarded only by `if h.pages != nil`. herald-web serves concurrently and never pre-warms `init()`, so a burst of first requests after startup could observe a half-built (or concurrently-mutated) map and 500 with "unknown template" -- nondeterministically, and a concurrent map read/write is UB besides. Reproduced as flaky 500s on `/stats` and `/feeds/{feedID}/edit-title` (0-4 failures per run). Fixed with `sync.Once` + publish-once-fully-built.

## Scope

In-process only: catches handler/route/DB-wiring 502s, **not** deployment/migration/image regressions -- those need the **phase-2b** per-PR preview container (real Dockerfile, real webauth OIDC, browsable URL), which needs homelab infra and is the tracked follow-up. Write routes remain `smoke.Write()`-skipped (no payloads/CSRF wired yet); converting them to real probes is also follow-up.

## Checks

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go test -race ./cmd/herald-web/` all green; the race fix verified across many non-race runs (was flaky, now 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)