### PR TITLE
Convert write routes to real smoke probes

### DIFF
--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -19,13 +20,18 @@ var embedded embed.FS
 //
 // The mux is a smoke.Mux: a drop-in *http.ServeMux wrap that records a spec for
 // every registration so the route surface can be enumerated for black-box smoke
-// testing (the producer half of github.com/infodancer/smoke). Write routes are
-// marked smoke.Write() (recorded as mutating + skipped until phase-2 wires auth
-// and request payloads); routes that can't be probed by a bare GET are
-// smoke.Skip()'d with a reason. Parameterized read routes are left without
-// example params on purpose — they surface in `smolder gate` as the phase-2
-// fixture backlog. Returning *smoke.Mux (still an http.Handler) lets the drift
-// test read the registry; callers use it as a handler unchanged.
+// testing (the producer half of github.com/infodancer/smoke). Mutating routes
+// carry smoke.Form()/Body() payloads and (for destructive ops) smoke.Example()
+// path params that reference the smoke fixture, so they are real probes; the few
+// that can't run in-process — an upstream feed fetch, AI generation, a multipart
+// upload — keep a smoke.Skip() with the specific reason. Parameterized reads
+// likewise carry example params. Returning *smoke.Mux (still an http.Handler)
+// lets the smoke harness and drift test read the registry; callers use it as a
+// handler unchanged.
+//
+// Fixture id convention: each seeded entity is the first row in a fresh DB, so
+// its id is 1; destructive writes target a dedicated second row (id 2) so they
+// don't delete what the read probes need. See TestSmokeRoutesAuthenticated.
 func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string) *smoke.Mux {
 	mux := smoke.NewMux()
 
@@ -73,65 +79,67 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("GET /articles", auth(http.HandlerFunc(h.handleArticleList)))
 	mux.Handle("GET /articles/{articleID}", auth(http.HandlerFunc(h.handleArticleView)), smoke.Example("articleID", "1"))
 	mux.Handle("GET /sidebar", auth(http.HandlerFunc(h.handleSidebar)))
-	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)), smoke.Write())
-	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Write())
+	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)), smoke.Form(url.Values{"ids": {"1"}}))
+	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Example("articleID", "1"), smoke.Form(url.Values{"starred": {"true"}}))
 	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)), smoke.Example("imageID", "1"))
 	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/export.opml", auth(http.HandlerFunc(h.handleOPMLExport)))
-	mux.Handle("POST /feeds/discover", auth(http.HandlerFunc(h.handleFeedDiscover)), smoke.Write())
-	mux.Handle("POST /feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)), smoke.Write())
-	mux.Handle("POST /feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)), smoke.Write())
-	mux.Handle("DELETE /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)), smoke.Write())
-	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)), smoke.Write())
+	mux.Handle("POST /feeds/discover", auth(http.HandlerFunc(h.handleFeedDiscover)), smoke.Skip("triggers an upstream feed fetch (DiscoverFeeds)"))
+	mux.Handle("POST /feeds", auth(http.HandlerFunc(h.handleFeedSubscribe)), smoke.Skip("triggers an upstream feed fetch (SubscribeFeed)"))
+	mux.Handle("POST /feeds/import", auth(http.HandlerFunc(h.handleOPMLImport)), smoke.Skip("multipart OPML file upload"))
+	mux.Handle("DELETE /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedUnsubscribe)), smoke.Example("feedID", "2"))
+	mux.Handle("PATCH /feeds/{feedID}", auth(http.HandlerFunc(h.handleFeedRename)), smoke.Example("feedID", "1"), smoke.Form(url.Values{"title": {"Renamed Feed"}}))
 	mux.Handle("GET /feeds/{feedID}/edit-title", auth(http.HandlerFunc(h.handleFeedEditTitle)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/{feedID}/title", auth(http.HandlerFunc(h.handleFeedTitleDisplay)), smoke.Example("feedID", "1"))
-	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)), smoke.Write())
-	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)), smoke.Write())
-	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)), smoke.Write())
-	mux.Handle("POST /settings/opml-token", auth(http.HandlerFunc(h.handleOPMLTokenGenerate)), smoke.Write())
-	mux.Handle("POST /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialSave)), smoke.Write())
-	mux.Handle("DELETE /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialDelete)), smoke.Write())
-	mux.Handle("POST /filters", auth(http.HandlerFunc(h.handleFilterAdd)), smoke.Write())
-	mux.Handle("POST /filters/threshold", auth(http.HandlerFunc(h.handleFilterThreshold)), smoke.Write())
-	mux.Handle("DELETE /filters/{ruleID}", auth(http.HandlerFunc(h.handleFilterDelete)), smoke.Write())
+	mux.Handle("POST /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagAdd)), smoke.Example("feedID", "1"), smoke.Form(url.Values{"tag": {"smoke-added"}}))
+	mux.Handle("DELETE /feeds/{feedID}/tags", auth(http.HandlerFunc(h.handleFeedTagRemove)), smoke.Example("feedID", "1"), smoke.Form(url.Values{"tag": {"smoke-seed"}}))
+	mux.Handle("POST /settings", auth(http.HandlerFunc(h.handleSettingsSave)), smoke.Form(url.Values{"keywords": {"go,security"}, "interest_threshold": {"0.5"}}))
+	mux.Handle("POST /settings/opml-token", auth(http.HandlerFunc(h.handleOPMLTokenGenerate)))
+	mux.Handle("POST /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialSave)), smoke.Form(url.Values{"fever_email": {"smoke@example.com"}, "fever_password": {"smoke-pass"}}))
+	mux.Handle("DELETE /settings/fever", auth(http.HandlerFunc(h.handleFeverCredentialDelete)))
+	mux.Handle("POST /filters", auth(http.HandlerFunc(h.handleFilterAdd)), smoke.Form(url.Values{"axis": {"author"}, "value": {"Smoke Author"}, "score": {"100"}}))
+	mux.Handle("POST /filters/threshold", auth(http.HandlerFunc(h.handleFilterThreshold)), smoke.Form(url.Values{"filter_threshold": {"5"}}))
+	mux.Handle("DELETE /filters/{ruleID}", auth(http.HandlerFunc(h.handleFilterDelete)), smoke.Example("ruleID", "1"))
 	mux.Handle("GET /feeds/{feedID}/metadata", auth(http.HandlerFunc(h.handleFeedMetadata)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/metadata", auth(http.HandlerFunc(h.handleFeedMetadataByQuery)))
 	mux.Handle("GET /filters/values", auth(http.HandlerFunc(h.handleFilterValues)))
 
-	// Group virtual feed actions.
-	mux.Handle("POST /groups/{groupID}/mute", auth(http.HandlerFunc(h.handleGroupMute)), smoke.Write())
-	mux.Handle("DELETE /groups/{groupID}", auth(http.HandlerFunc(h.handleGroupDisband)), smoke.Write())
-	mux.Handle("POST /groups/{groupID}/mark-read", auth(http.HandlerFunc(h.handleGroupMarkRead)), smoke.Write())
+	// Group virtual feed actions. mute/mark-read use the shared group 1;
+	// disband targets the dedicated group 2.
+	mux.Handle("POST /groups/{groupID}/mute", auth(http.HandlerFunc(h.handleGroupMute)), smoke.Example("groupID", "1"))
+	mux.Handle("DELETE /groups/{groupID}", auth(http.HandlerFunc(h.handleGroupDisband)), smoke.Example("groupID", "2"))
+	mux.Handle("POST /groups/{groupID}/mark-read", auth(http.HandlerFunc(h.handleGroupMarkRead)), smoke.Example("groupID", "1"))
 
-	// Newsletter routes.
+	// Newsletter routes. update uses newsletter 1; delete targets newsletter 2.
 	mux.Handle("GET /newsletters", auth(http.HandlerFunc(h.handleNewslettersManage)))
-	mux.Handle("POST /newsletters", auth(http.HandlerFunc(h.handleNewsletterCreate)), smoke.Write())
-	mux.Handle("PATCH /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterUpdate)), smoke.Write())
-	mux.Handle("DELETE /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterDelete)), smoke.Write())
-	mux.Handle("POST /newsletters/{newsletterID}/generate", auth(http.HandlerFunc(h.handleNewsletterGenerate)), smoke.Write())
+	mux.Handle("POST /newsletters", auth(http.HandlerFunc(h.handleNewsletterCreate)), smoke.Form(url.Values{"name": {"Smoke Newsletter"}, "schedule": {"daily"}, "min_interest_score": {"0.3"}, "max_articles": {"10"}}))
+	mux.Handle("PATCH /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterUpdate)), smoke.Example("newsletterID", "1"), smoke.Form(url.Values{"name": {"Updated Newsletter"}, "schedule": {"daily"}, "min_interest_score": {"0.3"}, "max_articles": {"10"}}))
+	mux.Handle("DELETE /newsletters/{newsletterID}", auth(http.HandlerFunc(h.handleNewsletterDelete)), smoke.Example("newsletterID", "2"))
+	mux.Handle("POST /newsletters/{newsletterID}/generate", auth(http.HandlerFunc(h.handleNewsletterGenerate)), smoke.Skip("triggers AI summary generation (background)"))
 
 	// AI Summary routes — list in the top pane, a selected digest in the reading pane.
 	mux.Handle("GET /summary", auth(http.HandlerFunc(h.handleSummaryView)))
 	mux.Handle("GET /summary/{id}", auth(http.HandlerFunc(h.handleSummaryDetail)), smoke.Example("id", "1"))
-	mux.Handle("POST /summary/generate", auth(http.HandlerFunc(h.handleSummaryGenerate)), smoke.Write())
-	mux.Handle("POST /summary/{id}/mark-read", auth(http.HandlerFunc(h.handleSummaryMarkRead)), smoke.Write())
+	mux.Handle("POST /summary/generate", auth(http.HandlerFunc(h.handleSummaryGenerate)), smoke.Skip("triggers AI summary generation (background)"))
+	mux.Handle("POST /summary/{id}/mark-read", auth(http.HandlerFunc(h.handleSummaryMarkRead)), smoke.Example("id", "1"))
 
 	// Ollama model list (used by prompt settings pages).
 	mux.Handle("GET /api/ollama/models", auth(http.HandlerFunc(h.handleOllamaModels)))
 
-	// Per-user AI prompt customization.
-	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Write())
-	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)), smoke.Write())
+	// Per-user AI prompt customization. save targets "summarization"; reset
+	// targets the seeded "curation" prompt so the two don't interact.
+	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Example("promptType", "summarization"), smoke.Form(url.Values{"template": {"Summarize: {{.Content}}"}}))
+	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)), smoke.Example("promptType", "curation"))
 
 	// Admin-only routes.
 	adminAuth := h.requireAdmin
 	mux.Handle("GET /admin/feeds/export.opml", auth(adminAuth(http.HandlerFunc(h.handleAdminOPMLExport))))
 	mux.Handle("GET /admin/stats", auth(adminAuth(http.HandlerFunc(h.handleAdminStats))))
 	mux.Handle("GET /admin/prompts", auth(adminAuth(http.HandlerFunc(h.handleAdminPrompts))))
-	mux.Handle("POST /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptSave))), smoke.Write())
-	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))), smoke.Write())
+	mux.Handle("POST /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptSave))), smoke.Example("promptType", "summarization"), smoke.Form(url.Values{"template": {"Admin summarize: {{.Content}}"}}))
+	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))), smoke.Example("promptType", "curation"))
 	mux.Handle("GET /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))))
-	mux.Handle("POST /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))), smoke.Write())
+	mux.Handle("POST /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))), smoke.Form(url.Values{"header": {"<p>Header</p>"}, "footer": {"<p>Footer</p>"}}))
 
 	// Smoke manifest introspection — emits the recorded RouteSpecs as JSON for
 	// the smolder runner. Gated on SMOKE_MANIFEST because it enumerates the

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -10,7 +10,8 @@
       "method": "POST",
       "pattern": "/admin/digest",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "footer=%3Cp%3EFooter%3C%2Fp%3E\u0026header=%3Cp%3EHeader%3C%2Fp%3E",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -29,14 +30,20 @@
       "method": "DELETE",
       "pattern": "/admin/prompts/{promptType}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "promptType": "curation"
+      },
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/admin/prompts/{promptType}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "promptType": "summarization"
+      },
+      "request_body": "template=Admin+summarize%3A+%7B%7B.Content%7D%7D",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -61,7 +68,8 @@
       "method": "POST",
       "pattern": "/articles/mark-all-read",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "ids=1",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -77,7 +85,11 @@
       "method": "POST",
       "pattern": "/articles/{articleID}/star",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "articleID": "1"
+      },
+      "request_body": "starred=true",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -103,14 +115,14 @@
       "method": "POST",
       "pattern": "/feeds",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "skip": "triggers an upstream feed fetch (SubscribeFeed)",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/feeds/discover",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "skip": "triggers an upstream feed fetch (DiscoverFeeds)",
       "complete": true
     },
     {
@@ -123,7 +135,7 @@
       "method": "POST",
       "pattern": "/feeds/import",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "skip": "multipart OPML file upload",
       "complete": true
     },
     {
@@ -136,14 +148,20 @@
       "method": "DELETE",
       "pattern": "/feeds/{feedID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "feedID": "2"
+      },
       "complete": true
     },
     {
       "method": "PATCH",
       "pattern": "/feeds/{feedID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "feedID": "1"
+      },
+      "request_body": "title=Renamed+Feed",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -177,14 +195,22 @@
       "method": "DELETE",
       "pattern": "/feeds/{feedID}/tags",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "feedID": "1"
+      },
+      "request_body": "tag=smoke-seed",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/feeds/{feedID}/tags",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "feedID": "1"
+      },
+      "request_body": "tag=smoke-added",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -219,14 +245,16 @@
       "method": "POST",
       "pattern": "/filters",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "axis=author\u0026score=100\u0026value=Smoke+Author",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/filters/threshold",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "filter_threshold=5",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -239,28 +267,36 @@
       "method": "DELETE",
       "pattern": "/filters/{ruleID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "ruleID": "1"
+      },
       "complete": true
     },
     {
       "method": "DELETE",
       "pattern": "/groups/{groupID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "groupID": "2"
+      },
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/groups/{groupID}/mark-read",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "groupID": "1"
+      },
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/groups/{groupID}/mute",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "groupID": "1"
+      },
       "complete": true
     },
     {
@@ -282,28 +318,35 @@
       "method": "POST",
       "pattern": "/newsletters",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "max_articles=10\u0026min_interest_score=0.3\u0026name=Smoke+Newsletter\u0026schedule=daily",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "DELETE",
       "pattern": "/newsletters/{newsletterID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "newsletterID": "2"
+      },
       "complete": true
     },
     {
       "method": "PATCH",
       "pattern": "/newsletters/{newsletterID}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "newsletterID": "1"
+      },
+      "request_body": "max_articles=10\u0026min_interest_score=0.3\u0026name=Updated+Newsletter\u0026schedule=daily",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/newsletters/{newsletterID}/generate",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "skip": "triggers AI summary generation (background)",
       "complete": true
     },
     {
@@ -329,28 +372,28 @@
       "method": "POST",
       "pattern": "/settings",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "interest_threshold=0.5\u0026keywords=go%2Csecurity",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "DELETE",
       "pattern": "/settings/fever",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/settings/fever",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "request_body": "fever_email=smoke%40example.com\u0026fever_password=smoke-pass",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/settings/opml-token",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
       "complete": true
     },
     {
@@ -363,14 +406,20 @@
       "method": "DELETE",
       "pattern": "/settings/prompts/{promptType}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "promptType": "curation"
+      },
       "complete": true
     },
     {
       "method": "POST",
       "pattern": "/settings/prompts/{promptType}",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "promptType": "summarization"
+      },
+      "request_body": "template=Summarize%3A+%7B%7B.Content%7D%7D",
+      "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },
     {
@@ -414,7 +463,7 @@
       "method": "POST",
       "pattern": "/summary/generate",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "skip": "triggers AI summary generation (background)",
       "complete": true
     },
     {
@@ -430,7 +479,9 @@
       "method": "POST",
       "pattern": "/summary/{id}/mark-read",
       "effect": "mutating",
-      "skip": "write — smoke phase 2 (auth + payloads)",
+      "example_params": {
+        "id": "1"
+      },
       "complete": true
     },
     {

--- a/cmd/herald-web/smoke_run_test.go
+++ b/cmd/herald-web/smoke_run_test.go
@@ -92,10 +92,59 @@ func TestSmokeRoutesAuthenticated(t *testing.T) {
 		t.Fatalf("UpdateAISummaryDone: %v", err)
 	}
 
+	// Fixtures for the write probes. Destructive writes target a dedicated
+	// second row so they don't delete what the read probes need.
+	//   feed 1: tag "smoke-seed" (DELETE /feeds/1/tags removes it)
+	//   feed 2: DELETE /feeds/2 unsubscribes it
+	if err := st.AddFeedTag(user.ID, feedID, "smoke-seed"); err != nil {
+		t.Fatalf("AddFeedTag: %v", err)
+	}
+	feed2, err := st.AddFeed("https://example.com/feed2", "Feed Two", "second feed")
+	if err != nil {
+		t.Fatalf("AddFeed feed2: %v", err)
+	}
+	if err := st.SubscribeUserToFeed(user.ID, feed2); err != nil {
+		t.Fatalf("SubscribeUserToFeed feed2: %v", err)
+	}
+	ruleID, err := st.AddFilterRule(&storage.FilterRule{UserID: user.ID, Axis: "author", Value: "seed", Score: 50})
+	if err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	group1, err := st.CreateArticleGroup(user.ID, "Smoke Group One")
+	if err != nil {
+		t.Fatalf("CreateArticleGroup g1: %v", err)
+	}
+	if err := st.AddArticleToGroup(group1, articleID); err != nil {
+		t.Fatalf("AddArticleToGroup: %v", err)
+	}
+	group2, err := st.CreateArticleGroup(user.ID, "Smoke Group Two")
+	if err != nil {
+		t.Fatalf("CreateArticleGroup g2: %v", err)
+	}
+	nl1, err := st.CreateNewsletter(&storage.Newsletter{UserID: user.ID, Name: "NL One", Schedule: "daily", Config: storage.NewsletterConfig{MaxArticles: 10}})
+	if err != nil {
+		t.Fatalf("CreateNewsletter nl1: %v", err)
+	}
+	nl2, err := st.CreateNewsletter(&storage.Newsletter{UserID: user.ID, Name: "NL Two", Schedule: "daily", Config: storage.NewsletterConfig{MaxArticles: 10}})
+	if err != nil {
+		t.Fatalf("CreateNewsletter nl2: %v", err)
+	}
+	if err := st.SetFeverCredential(user.ID, "smoke-api-key"); err != nil {
+		t.Fatalf("SetFeverCredential: %v", err)
+	}
+	// "curation" prompts for the reset probes: user-scoped and global (id 0).
+	if err := st.SetUserPrompt(user.ID, "curation", "seed user prompt", nil, nil); err != nil {
+		t.Fatalf("SetUserPrompt user: %v", err)
+	}
+	if err := st.SetUserPrompt(0, "curation", "seed global prompt", nil, nil); err != nil {
+		t.Fatalf("SetUserPrompt global: %v", err)
+	}
+
 	// Confirm the deterministic ids the manifest examples assume.
-	if user.ID != 1 || feedID != 1 || articleID != 1 || sumID != 1 {
-		t.Fatalf("fixture ids not deterministic: user=%d feed=%d article=%d summary=%d (want all 1)",
-			user.ID, feedID, articleID, sumID)
+	if user.ID != 1 || feedID != 1 || articleID != 1 || sumID != 1 ||
+		feed2 != 2 || ruleID != 1 || group1 != 1 || group2 != 2 || nl1 != 1 || nl2 != 2 {
+		t.Fatalf("fixture ids not deterministic: user=%d feed=%d feed2=%d article=%d summary=%d rule=%d group1=%d group2=%d nl1=%d nl2=%d",
+			user.ID, feedID, feed2, articleID, sumID, ruleID, group1, group2, nl1, nl2)
 	}
 
 	validator, token := newTestValidator(t)
@@ -106,24 +155,45 @@ func TestSmokeRoutesAuthenticated(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	report, err := smoke.Run(context.Background(), mux.Registry().Manifest(), smoke.RunOptions{
-		BaseURL: srv.URL,
-		Target:  smoke.Preview,
-		Cookie:  "test_jwt=" + token,
-		// Writes are smoke.Write()-skipped (no payloads/CSRF wired yet); this is
-		// the authed reads pass. Converting writes to real probes is follow-up.
-		IncludeWrites: false,
+	ctx := context.Background()
+	manifest := mux.Registry().Manifest()
+	cookie := "test_jwt=" + token
+
+	// Pass 1: reads, concurrently. Concurrency is the point -- it re-exercises
+	// the path that surfaced the template-init race -- so leave it at the
+	// default and don't probe writes here (mutating routes are skipped).
+	reads, err := smoke.Run(ctx, manifest, smoke.RunOptions{
+		BaseURL: srv.URL, Target: smoke.Preview, Cookie: cookie, IncludeWrites: false,
 	})
 	if err != nil {
-		t.Fatalf("smoke.Run: %v", err)
+		t.Fatalf("smoke.Run reads: %v", err)
 	}
 
-	pass, fail, skip := report.Counts()
-	t.Logf("smoke authed run: %d pass, %d fail, %d skip (of %d routes)", pass, fail, skip, len(mux.Registry().Manifest().Routes))
-	if pass == 0 {
-		t.Fatalf("no routes passed -- the harness likely isn't reaching the server")
+	// Pass 2: writes, serially. Restrict the manifest to mutating routes and run
+	// at concurrency 1 so destructive probes can't race each other or a
+	// dependent probe. The manifest is sorted (pattern, then method), so for a
+	// shared entity a DELETE sorts before its POST -- e.g. DELETE then POST
+	// /settings/fever both succeed.
+	writeManifest := smoke.Manifest{}
+	for _, r := range manifest.Routes {
+		if r.Effect == "mutating" {
+			writeManifest.Routes = append(writeManifest.Routes, r)
+		}
 	}
-	for _, res := range report.Failed() {
+	writes, err := smoke.Run(ctx, writeManifest, smoke.RunOptions{
+		BaseURL: srv.URL, Target: smoke.Preview, Cookie: cookie, IncludeWrites: true, Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatalf("smoke.Run writes: %v", err)
+	}
+
+	rp, rf, rs := reads.Counts()
+	wp, wf, ws := writes.Counts()
+	t.Logf("smoke authed: reads %d pass / %d fail / %d skip; writes %d pass / %d fail / %d skip", rp, rf, rs, wp, wf, ws)
+	if rp == 0 || wp == 0 {
+		t.Fatalf("no routes passed in a pass (reads pass=%d, writes pass=%d) -- harness likely not reaching the server", rp, wp)
+	}
+	for _, res := range append(reads.Failed(), writes.Failed()...) {
 		t.Errorf("FAIL %s %s -> status %d: %s", res.Method, res.Pattern, res.Status, res.Reason)
 	}
 }


### PR DESCRIPTION
Follow-up to #136. Phase 2a left mutating routes `smoke.Write()`-skipped. This turns them into **real probes**: the authed harness now sends actual `POST/PUT/PATCH/DELETE` with valid payloads and asserts non-5xx/4xx, exercising **25 write handlers** end-to-end against the real store.

herald has **no CSRF** on writes (confirmed -- no middleware, no token, no Origin check), so a valid body is all a probe needs.

## Changes

- **routes.go**: write routes carry `smoke.Form()` payloads. Destructive ops target a **dedicated fixture id (2)** so they don't delete what the read probes depend on (e.g. `DELETE /feeds/2`, `DELETE /newsletters/2`, `DELETE /groups/2`). The 5 that genuinely can't run in-process keep a **specific** `smoke.Skip()`:
  - `POST /feeds/discover`, `POST /feeds` -- upstream feed fetch
  - `POST /feeds/import` -- multipart OPML upload
  - `POST /newsletters/{id}/generate`, `POST /summary/generate` -- AI generation
- **smoke_run_test.go**: seeds the write fixtures (second feed, a feed tag, a filter rule, two article groups, two newsletters, a Fever credential, user + global "curation" prompts) and adds a **second probe pass over the mutating routes run serially** (concurrency 1) so destructive probes can't race each other or a dependent probe. Reads still run concurrently in pass 1 to keep exercising the template-init path.

## Result

`smolder gate` reports **all 64 routes covered** with real probes -- only the 6 network/AI/multipart/own-auth mutating routes skipped, each with a reason. Authed run: reads 30 pass / 0 fail; writes 25 pass / 0 fail. `-race` clean; stable across repeated runs.

## Minor finding (not fixed here)

`POST /filters/threshold` returns **500 on non-integer input** (it `strconv.Atoi`s `filter_threshold` and maps any `SetPreference` error to 500) -- should be a 400. Pre-existing, low severity (the UI always sends valid integers); filed as follow-up rather than mixed into this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)