### PR TITLE
Per-PR preview pipeline (phase 2b, unauth)

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,21 @@
+name: PR Cleanup
+
+# Tears down the per-PR preview created by pr-preview.yml when the PR closes.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: [self-hosted, linux, docker-web]
+    steps:
+      - name: Remove preview container, image, and database
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          docker rm -f herald-pr-${PR} 2>/dev/null || true
+          docker rmi ghcr.io/matthewjhunter/herald:pr-${PR} 2>/dev/null || true
+          # Drop the isolated preview database created in pr-preview.yml.
+          docker exec postgres psql -U postgres \
+            -c "DROP DATABASE IF EXISTS \"herald_pr_${PR}\" WITH (FORCE)" 2>/dev/null || true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   cleanup:
+    # See pr-preview.yml: inert until the runner exists and the preview is
+    # enabled, so a closed PR doesn't queue forever against a missing runner.
+    if: ${{ vars.HERALD_PREVIEW_ENABLED == 'true' }}
     runs-on: [self-hosted, linux, docker-web]
     steps:
       - name: Remove preview container, image, and database

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,115 @@
+name: PR Preview
+
+# Stands up a per-PR preview container of herald-web on the homelab docker-web
+# host and black-box smoke-probes it. This is the phase-2b complement to the
+# in-process smoke harness (TestSmokeRoutesAuthenticated): it catches the
+# regressions that only show up in a real deployment -- a broken Dockerfile, a
+# schema/migration that fails on a fresh database, a missing file in the image,
+# a boot-time wiring fault -- against the actual postgres backend production
+# uses.
+#
+# The preview points at the real webauth issuer for discovery but does NOT
+# configure a client_id/callback, so it never registers a per-PR OIDC client and
+# never completes a login. The smoke pass is therefore UNAUTHENTICATED: every
+# auth-gated route answers 302 (redirect to login = served, wired, no 5xx), and
+# the few public routes (/health, /static, the Fever endpoint, logout) answer
+# directly. That validates routing + boot + migrations + image without needing a
+# webauth test user. An authenticated pass (real login via a smokeauth harvester,
+# or a fake-OIDC sidecar) is a later increment; webauth supports RFC 7591 dynamic
+# registration, so per-PR clients are available when we add it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: [self-hosted, linux, docker-web]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build preview image
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: docker build -t ghcr.io/matthewjhunter/herald:pr-${PR} .
+
+      - name: Deploy preview container
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          docker rm -f herald-pr-${PR} 2>/dev/null || true
+
+          # Isolated per-PR database: a preview must never run its schema and
+          # idempotent migrations against the shared herald database that backs
+          # the live site. Create herald_pr_${PR} (pr-cleanup drops it on close)
+          # owned by the herald role. herald-web applies SchemaPostgres + the
+          # ALTER ... IF NOT EXISTS migrations against it at boot -- which is
+          # exactly the deploy-time path this preview is here to validate.
+          docker exec postgres psql -U postgres -tAc \
+            "SELECT 1 FROM pg_database WHERE datname='herald_pr_${PR}'" | grep -q 1 \
+            || docker exec postgres psql -U postgres \
+                 -c "CREATE DATABASE \"herald_pr_${PR}\" OWNER herald"
+
+          # Build the per-PR DSN from the deployed herald role password (read
+          # from the host env file, never echoed) and hand it to the container
+          # via HERALD_DB_DSN so it stays off the command line / docker inspect.
+          PW=$(grep -E '^POSTGRES_PASSWORD=' /opt/docker/herald/.env | cut -d= -f2-)
+          PR_DSN="postgres://herald:${PW}@postgres:5432/herald_pr_${PR}?sslmode=disable"
+
+          # Create on web, attach db, then start: herald-web connects to postgres
+          # at boot (schema runs first), and postgres lives on the db network.
+          # docker create takes one --network, so attach db before start --
+          # starting on web alone races the server's boot connect.
+          docker create \
+            --name herald-pr-${PR} \
+            --network web \
+            --restart unless-stopped \
+            --env-file /opt/docker/herald/.env \
+            -e HERALD_DB_DSN="${PR_DSN}" \
+            -e SMOKE_MANIFEST=1 \
+            -l "traefik.enable=true" \
+            -l "traefik.docker.network=web" \
+            -l "traefik.http.routers.herald-pr-${PR}.rule=Host(\`pr-${PR}.herald.infodancer.net\`)" \
+            -l "traefik.http.routers.herald-pr-${PR}.entrypoints=websecure" \
+            -l "traefik.http.routers.herald-pr-${PR}.tls=true" \
+            -l "traefik.http.routers.herald-pr-${PR}.tls.certresolver=letsencrypt" \
+            -l "traefik.http.services.herald-pr-${PR}.loadbalancer.server.port=8080" \
+            ghcr.io/matthewjhunter/herald:pr-${PR} \
+            herald-web -addr :8080 -webauth-issuer https://webauth.infodancer.net/t/infodancer
+          docker network connect db herald-pr-${PR}
+          docker start herald-pr-${PR}
+
+      - name: Smoke test routes (unauthenticated)
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Black-box round trip against the live preview: fetch the manifest the
+          # server exposes at /_smoke/manifest and probe every route directly on
+          # the web network (no Traefik/TLS/public DNS), failing on any 5xx (or a
+          # 4xx on a route we expect to serve). Reads only -- mutating routes are
+          # skipped without --include-writes, auth-gated routes answer 302.
+          base="http://herald-pr-${PR}:8080"
+          docker run --rm \
+            --network web \
+            -v "${GITHUB_WORKSPACE}":/src -w /src \
+            golang:1.26-alpine sh -c '
+              for _ in $(seq 1 60); do
+                wget -qO- "'"$base"'/health" >/dev/null 2>&1 && break
+                sleep 2
+              done
+              go tool smolder run --base "'"$base"'"
+            '
+
+      - name: Comment preview URL on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          url="https://pr-${PR}.herald.infodancer.net"
+          gh pr comment ${PR} --repo ${REPO} --body "Preview deployed: ${url}" --edit-last 2>/dev/null || \
+          gh pr comment ${PR} --repo ${REPO} --body "Preview deployed: ${url}"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,6 +28,11 @@ permissions:
 
 jobs:
   preview:
+    # Inert until the herald self-hosted runner exists on docker-web and the
+    # repo variable HERALD_PREVIEW_ENABLED is set to "true". Without this guard
+    # the job would queue forever against a missing runner, leaving every PR
+    # with a stuck check. Enable once the homelab runner play has been applied.
+    if: ${{ vars.HERALD_PREVIEW_ENABLED == 'true' }}
     runs-on: [self-hosted, linux, docker-web]
     steps:
       - uses: actions/checkout@v4

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -71,8 +71,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Merge: CLI flag wins over config file, config file wins over hardcoded default.
-	db := mergeString(*dbPath, mergeString(cfg.DB, "./herald.db"))
+	// Merge: CLI flag wins over env var, env over config file, config over the
+	// hardcoded default. HERALD_DB_DSN lets a deployment (e.g. the per-PR
+	// preview) supply the DSN without putting it on the command line.
+	db := mergeString(*dbPath, mergeString(os.Getenv("HERALD_DB_DSN"), mergeString(cfg.DB, "./herald.db")))
 	listenAddr := mergeString(*addr, mergeString(cfg.Addr, ":8080"))
 	issuerURL := mergeString(*webauthIssuer, cfg.Webauth.IssuerURL)
 	webauthBaseURL := mergeString(*webauthURL, cfg.Webauth.WebauthURL)

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -35,6 +35,13 @@ var embedded embed.FS
 func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string) *smoke.Mux {
 	mux := smoke.NewMux()
 
+	// Liveness probe — no auth, no DB. Used by the PR-preview pipeline to wait
+	// for the container to be serving before smoke-probing it.
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
 	// Static files — no auth required.
 	staticFS, _ := fs.Sub(embedded, "static")
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticFS)),

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -301,6 +301,12 @@
     },
     {
       "method": "GET",
+      "pattern": "/health",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "GET",
       "pattern": "/images/{imageID}",
       "effect": "read_only",
       "example_params": {


### PR DESCRIPTION
Phase 2b: stands up a **per-PR preview container** of herald-web on the homelab `docker-web` host and black-box smoke-probes it -- the deployment-fidelity complement to the in-process harness (#136/#137). Catches what only shows up in a real deploy: a broken Dockerfile, a schema/migration that fails on a fresh database, a missing file in the image, a boot-time wiring fault -- against the **postgres** backend production uses.

(Reopened as a fresh PR -- the original #138 was auto-closed when its stacked base branch was deleted on #137's merge. Same commits, now based on main.)

## How it works

`pr-preview.yml` (herald `[self-hosted, linux, docker-web]` runner): builds `ghcr.io/matthewjhunter/herald:pr-N`, creates an **isolated** `herald_pr_N` postgres DB owned by `herald` (herald-web runs `SchemaPostgres` + idempotent migrations against it at boot -- the exact deploy path validated), boots `herald-pr-N` on `web`+`db` (DSN via `HERALD_DB_DSN`, off argv), waits for `/health`, then `smolder run` against `http://herald-pr-N:8080` **directly on the docker network** (no public DNS/TLS needed). `pr-cleanup.yml` drops container/image/DB on close.

## Unauthenticated (this increment)

Points at the real webauth issuer for discovery but registers no per-PR OIDC client, so auth-gated routes answer **302 (served, no 5xx)** and **no webauth test user is needed**. Authed-handler logic is already covered in-process by #136/#137.

## Gated until infra is live

Both jobs carry `if: vars.HERALD_PREVIEW_ENABLED == 'true'`, so they stay **skipped** (neutral, never stuck-pending) until the herald self-hosted runner is registered on docker-web (homelab #58, merged -- playbook apply pending) and the variable is flipped.

## Repo changes

`GET /health` (auth/DB-free liveness, smoke-covered -> 65 routes); `HERALD_DB_DSN` env (flag > env > config > default); the two workflows.

## To activate (infra)

1. Apply the github-runner play on docker-web (homelab #58) with a herald registration token; ensure `github-runner-herald` can read `/opt/docker/herald/.env`.
2. Set repo variable `HERALD_PREVIEW_ENABLED=true`.
3. Optional (browsable URL only): `*.herald.infodancer.net` wildcard DNS -> docker-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)