### PR TITLE
Screen each article once: move the security verdict onto the article (#141)

### DIFF
--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -298,10 +298,13 @@ func processCmd() *cobra.Command {
 				return err
 			}
 
-			// The `process` command runs the staged pipeline over the user's
-			// pending articles.
+			// The `process` command runs the global security pass (screens any
+			// unscreened articles once) followed by the per-user pipeline.
 			stage := newPipelineStage(store, processor, groupMatcher, formatter, userID)
-			if _, err := stage.Run(ctx); err != nil {
+			if _, err := stage.RunSecurity(ctx); err != nil {
+				return err
+			}
+			if err := stage.Run(ctx); err != nil {
 				return err
 			}
 
@@ -481,19 +484,27 @@ func doFetch(ctx context.Context) error {
 		formatter.Warning("skipping embedding backfill and group matching")
 	}
 
-	// Run the staged pipeline for each subscribing user. It drives every stage
-	// from its own state-driven, newest-first query, so this cycle's freshly
-	// fetched articles (now enriched with full text and cached images) are
-	// processed ahead of older backlog, and anything left pending from prior
-	// cycles drains the same way. Self-skips when the AI backend is unavailable.
-	totalProcessed := 0
+	// Security screening is global: each article is screened once and the verdict
+	// is shared by every subscriber (#141), so run it once per cycle before the
+	// per-user pipelines rather than re-screening per user. One breaker check,
+	// not one per user (#111).
+	securityStage := newPipelineStage(store, processor, groupMatcher, formatter, cfg.DefaultUserID)
+	totalProcessed, err := securityStage.RunSecurity(ctx)
+	if err != nil {
+		formatter.Warning("security pass failed: %v", err)
+	}
+
+	// Run the per-user pipeline for each subscribing user. It drives every stage
+	// from its own state-driven, newest-first query, reading the article-level
+	// security verdict to decide what to summarize/curate, so this cycle's freshly
+	// screened articles are processed ahead of older backlog, and anything left
+	// pending from prior cycles drains the same way. Self-skips when the AI
+	// backend is unavailable.
 	for _, userID := range allUserIDs {
 		stage := newPipelineStage(store, processor, groupMatcher, formatter, userID)
-		processed, err := stage.Run(ctx)
-		if err != nil {
+		if err := stage.Run(ctx); err != nil {
 			formatter.Warning("pipeline failed for user %d: %v", userID, err)
 		}
-		totalProcessed += processed
 	}
 
 	fetchResult.ProcessedCount = totalProcessed

--- a/engine_summary_test.go
+++ b/engine_summary_test.go
@@ -62,7 +62,11 @@ func TestGenerateAISummary(t *testing.T) {
 	mk := func(guid string, interest, security float64) int64 {
 		id, _ := store.AddArticle(&storage.Article{FeedID: feedID, GUID: guid, Title: guid,
 			URL: "https://example.com/" + guid, Content: "<p>body " + guid + "</p>", PublishedDate: &now})
-		if err := store.UpdateReadState(uid, id, false, &interest, &security, nil, nil); err != nil {
+		// Security verdict is article-level (#141); interest stays per-user.
+		if err := store.ScreenArticleSecurity(id, security, "", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.UpdateReadState(uid, id, false, &interest, nil, nil, nil); err != nil {
 			t.Fatal(err)
 		}
 		return id
@@ -237,8 +241,9 @@ func TestGenerateForConfig(t *testing.T) {
 	mk := func(feedID int64, guid string) int64 {
 		id, _ := store.AddArticle(&storage.Article{FeedID: feedID, GUID: guid, Title: guid,
 			URL: "https://example.com/" + guid, Content: "<p>body " + guid + "</p>", PublishedDate: &now})
-		i, s := 8.0, 9.0
-		store.UpdateReadState(uid, id, false, &i, &s, nil, nil) //nolint:errcheck
+		i := 8.0
+		store.ScreenArticleSecurity(id, 9.0, "", false)          //nolint:errcheck
+		store.UpdateReadState(uid, id, false, &i, nil, nil, nil) //nolint:errcheck
 		return id
 	}
 	a1 := mk(feedA, "a1")

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -84,9 +84,14 @@ func newPromptLoaderSafe(store, config any) *PromptLoader {
 	}
 }
 
-// SecurityCheck analyzes content for security threats (prompt injection, malicious content).
-func (p *AIProcessor) SecurityCheck(ctx context.Context, userID int64, title, content string) (*SecurityResult, error) {
-	promptTemplate, err := p.promptLoader.GetPrompt(userID, PromptTypeSecurity)
+// SecurityCheck analyzes content for security threats (prompt injection,
+// malicious content). The verdict is a property of the article, shared by every
+// subscriber (#141), so it always uses the global security prompt/model/
+// temperature (the user_id=0 admin override, then config, then default) — never
+// a per-user prompt. Only curation (relevance) is per-user.
+func (p *AIProcessor) SecurityCheck(ctx context.Context, title, content string) (*SecurityResult, error) {
+	const globalUser = int64(0)
+	promptTemplate, err := p.promptLoader.GetPrompt(globalUser, PromptTypeSecurity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load security prompt: %w", err)
 	}
@@ -100,8 +105,8 @@ func (p *AIProcessor) SecurityCheck(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("failed to render security prompt: %w", err)
 	}
 
-	temperature := p.promptLoader.GetTemperature(userID, PromptTypeSecurity)
-	model := p.promptLoader.GetModel(userID, PromptTypeSecurity)
+	temperature := p.promptLoader.GetTemperature(globalUser, PromptTypeSecurity)
+	model := p.promptLoader.GetModel(globalUser, PromptTypeSecurity)
 	if model == "" {
 		model = p.securityModel
 	}

--- a/internal/pipeline/clusterstage_test.go
+++ b/internal/pipeline/clusterstage_test.go
@@ -136,7 +136,7 @@ func TestClusterRecentRespectsToggle(t *testing.T) {
 		embedArt(t, store, a, []float32{1, 0, 0})
 		embedArt(t, store, b, []float32{0.99, 0.05, 0})
 		for _, art := range []storage.Article{a, b} {
-			if err := store.MarkSecurityScored(1, art.ID, 9, "ok", false); err != nil {
+			if err := store.ScreenArticleSecurity(art.ID, 9, "ok", false); err != nil {
 				t.Fatal(err)
 			}
 			if err := store.SetInterestScore(1, art.ID, 8); err != nil {

--- a/internal/pipeline/embed_test.go
+++ b/internal/pipeline/embed_test.go
@@ -37,7 +37,7 @@ func TestEmbedStage(t *testing.T) {
 		emb := &fakeEmbedder{model: "m", embedFn: func(string) ([]float32, error) { return []float32{1, 2, 3}, nil }}
 		withEmbedder(st, emb)
 		a := seed(t, store, feedID, "a", "body")
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -14,37 +14,48 @@ const clusterCohortLimit = 500
 // drainBatch is how many articles each stage pulls per query.
 const drainBatch = 100
 
-// Run executes the full staged pipeline for the user: it drives each stage from
-// its own state-driven query, in order, so any pending article advances one
-// stage at a time. An article fetched this cycle flows through all five stages
-// in a single call — security marks it scored, the summarize query then sees it,
-// then curate, then embed, then cluster — and every query is newest-first, so
-// fresh articles are processed ahead of older backlog. Work left by prior cycles
-// (stranded by a transient failure or a backend that was down) drains the same
-// way. The whole run is skipped when the LLM backend is unavailable; that check
-// plus the per-stage skips keep an outage from spinning.
-// Run returns the number of articles that newly passed the security screen this
-// call — the daemon's "processed" metric.
-func (s *Stage) Run(ctx context.Context) (int, error) {
+// RunSecurity screens every not-yet-screened article exactly once, globally. The
+// security verdict is a property of the content, shared by all subscribers
+// (#141), so this runs once per cycle rather than once per user — and it checks
+// the breaker a single time, draining the global queue newest-first. Self-skips
+// with one log line when the backend is down, instead of one blocked call per
+// article (#111). Returns the number of articles that newly passed the screen
+// this call — the daemon's "processed" metric.
+func (s *Stage) RunSecurity(ctx context.Context) (int, error) {
 	if !s.AI.BackendAvailable() {
-		s.Formatter.Warning("pipeline: skipping run for user %d — AI backend unavailable (breaker open)", s.UserID)
+		s.Formatter.Warning("pipeline: skipping security pass — AI backend unavailable (breaker open)")
 		return 0, nil
 	}
-
 	processed := 0
-	if err := s.drain(
-		func(limit int) ([]storage.Article, error) { return s.Store.GetUnscoredArticlesForUser(s.UserID, limit) },
+	err := s.drain(
+		func(limit int) ([]storage.Article, error) { return s.Store.GetUnscreenedArticles(limit) },
 		func(arts []storage.Article) { processed += len(s.Security(ctx, arts)) },
-	); err != nil {
-		return processed, err
+	)
+	return processed, err
+}
+
+// Run executes the per-user pipeline: it drives each stage from its own
+// state-driven query, in order, so any pending article advances one stage at a
+// time. Security screening is NOT here — it is the global RunSecurity pass,
+// which runs once per cycle before the per-user pipelines. This pipeline starts
+// at summarize, reading the article-level security verdict to decide which
+// articles it processes for this user. Every query is newest-first, so fresh
+// articles are processed ahead of older backlog; work left by prior cycles
+// drains the same way. The whole run is skipped when the LLM backend is
+// unavailable.
+func (s *Stage) Run(ctx context.Context) error {
+	if !s.AI.BackendAvailable() {
+		s.Formatter.Warning("pipeline: skipping run for user %d — AI backend unavailable (breaker open)", s.UserID)
+		return nil
 	}
+
 	if err := s.drain(
 		func(limit int) ([]storage.Article, error) {
 			return s.Store.GetUnsummarizedScoredArticles(s.UserID, s.Cfg.Thresholds.SecurityScore, limit)
 		},
 		func(arts []storage.Article) { s.Summarize(ctx, arts) },
 	); err != nil {
-		return processed, err
+		return err
 	}
 	if err := s.drain(
 		func(limit int) ([]storage.Article, error) {
@@ -52,7 +63,7 @@ func (s *Stage) Run(ctx context.Context) (int, error) {
 		},
 		func(arts []storage.Article) { s.Curate(ctx, arts) },
 	); err != nil {
-		return processed, err
+		return err
 	}
 	if s.Embedder != nil {
 		if err := s.drain(
@@ -61,11 +72,11 @@ func (s *Stage) Run(ctx context.Context) (int, error) {
 			},
 			func(arts []storage.Article) { s.Embed(ctx, arts) },
 		); err != nil {
-			return processed, err
+			return err
 		}
 	}
 
-	return processed, s.clusterRecent(ctx)
+	return s.clusterRecent(ctx)
 }
 
 // drain repeatedly fetches a batch and processes the articles it has not yet

--- a/internal/pipeline/orchestrate_test.go
+++ b/internal/pipeline/orchestrate_test.go
@@ -34,19 +34,23 @@ func TestRunEndToEnd(t *testing.T) {
 	a := seed(t, store, feedID, "a", strings.Repeat("x", 500))
 	b := seed(t, store, feedID, "b", strings.Repeat("y", 500))
 
-	// Two unscored articles flow through every stage in a single Run call.
-	processed, err := st.Run(context.Background())
+	// The global security pass screens both, then the per-user pipeline advances
+	// them through every stage.
+	processed, err := st.RunSecurity(context.Background())
 	if err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("RunSecurity: %v", err)
 	}
 	if processed != 2 {
 		t.Fatalf("expected 2 articles processed, got %d", processed)
 	}
+	if err := st.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 
-	// Everything advanced: scored, summarized, embedded, and (identical default
+	// Everything advanced: screened, summarized, embedded, and (identical default
 	// vectors) grouped together.
-	if unscored, _ := store.GetUnscoredArticlesForUser(1, 10); len(unscored) != 0 {
-		t.Fatalf("expected all articles scored, still unscored: %v", ids(unscored))
+	if unscreened, _ := store.GetUnscreenedArticles(10); len(unscreened) != 0 {
+		t.Fatalf("expected all articles screened, still unscreened: %v", ids(unscreened))
 	}
 	if cur, _ := store.GetUnscoredCurationArticles(1, 7.0, 10); len(cur) != 0 {
 		t.Fatalf("expected all articles curated, still pending: %v", ids(cur))
@@ -71,12 +75,15 @@ func TestRunDrainsBacklog(t *testing.T) {
 		arts = append(arts, seed(t, store, feedID, fmt.Sprintf("a%d", i), strings.Repeat("x", 500)))
 	}
 
-	if _, err := st.Run(context.Background()); err != nil {
+	if _, err := st.RunSecurity(context.Background()); err != nil {
+		t.Fatalf("RunSecurity: %v", err)
+	}
+	if err := st.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if unscored, _ := store.GetUnscoredArticlesForUser(1, 10); len(unscored) != 0 {
-		t.Fatalf("backlog not drained, still unscored: %v", ids(unscored))
+	if unscreened, _ := store.GetUnscreenedArticles(10); len(unscreened) != 0 {
+		t.Fatalf("backlog not drained, still unscreened: %v", ids(unscreened))
 	}
 	for _, a := range arts {
 		if sum, _ := store.GetArticleSummary(1, a.ID); sum == nil {
@@ -94,12 +101,12 @@ func TestRunTerminatesOnPersistentFailure(t *testing.T) {
 	withRealEmbed(st)
 
 	a := seed(t, store, feedID, "a", strings.Repeat("x", 500))
-	if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+	if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 		t.Fatal(err)
 	}
 
 	done := make(chan error, 1)
-	go func() { _, err := st.Run(context.Background()); done <- err }()
+	go func() { done <- st.Run(context.Background()) }()
 	select {
 	case err := <-done:
 		if err != nil {
@@ -120,11 +127,11 @@ func TestRunSkipsWhenBreakerOpen(t *testing.T) {
 	withRealEmbed(st)
 
 	seed(t, store, feedID, "a", strings.Repeat("x", 500))
-	if _, err := st.Run(context.Background()); err != nil {
-		t.Fatalf("Run: %v", err)
+	if _, err := st.RunSecurity(context.Background()); err != nil {
+		t.Fatalf("RunSecurity: %v", err)
 	}
-	if unscored, _ := store.GetUnscoredArticlesForUser(1, 10); len(unscored) != 1 {
-		t.Fatalf("breaker open should leave the article untouched, got %v", ids(unscored))
+	if unscreened, _ := store.GetUnscreenedArticles(10); len(unscreened) != 1 {
+		t.Fatalf("breaker open should leave the article untouched, got %v", ids(unscreened))
 	}
 	if fake.secCalls != 0 {
 		t.Fatalf("expected no security calls with breaker open, got %d", fake.secCalls)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -17,7 +17,7 @@ import (
 // lets a stage skip itself with a single log line when the circuit breaker is
 // open, instead of attempting (and logging) one blocked call per article.
 type AI interface {
-	SecurityCheck(ctx context.Context, userID int64, title, content string) (*ai.SecurityResult, error)
+	SecurityCheck(ctx context.Context, title, content string) (*ai.SecurityResult, error)
 	SummarizeArticle(ctx context.Context, userID int64, title, content string, maxSummaryLength int) (string, error)
 	CurateArticle(ctx context.Context, userID int64, title, content string, keywords []string) (*ai.CurationResult, error)
 	GenerateGroupSummary(ctx context.Context, userID int64, topic string, articles []ai.GroupSummaryInput) (*ai.GroupSummaryResult, error)

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -9,20 +9,21 @@ import (
 	"github.com/matthewjhunter/herald/internal/storage"
 )
 
-// Security screens each article and records the verdict. It is the gate for the
-// whole pipeline: only articles that clear the full security threshold are
-// returned (for summarization, scoring, embedding, and clustering). Articles
+// Security screens each article and records the verdict on the article itself
+// (#141): maliciousness is a property of the content, so each article is
+// screened once and the verdict is shared by every subscriber. It is the gate
+// for the whole pipeline: only articles that clear the full security threshold
+// are returned (for summarization, scoring, embedding, and clustering). Articles
 // with no content or too little content are marked skipped; hard-blocked and
-// medium-flagged articles are marked terminal; a model-failure increments the
-// retry budget unless the backend was simply unavailable (#90, #100).
+// medium-flagged articles are recorded with their score (and so excluded from
+// the passing set); a model-failure increments the per-article retry budget
+// unless the backend was simply unavailable (#90, #100).
 //
-// Passing articles are recorded with MarkSecurityScored, which sets ai_scored
-// and the security score but leaves interest_score NULL, so the curation stage
-// can pick them up. The summarize/score/embed/cluster stages never see a
-// blocked article, preserving the gate established in #90.
+// This stage runs in the global, once-per-cycle security pass (RunSecurity), not
+// in the per-user pipeline — there is no user_id in the verdict.
 func (s *Stage) Security(ctx context.Context, in []storage.Article) []storage.Article {
 	if !s.AI.BackendAvailable() {
-		s.Formatter.Warning("pipeline: skipping security stage for user %d — AI backend unavailable (breaker open)", s.UserID)
+		s.Formatter.Warning("pipeline: skipping security stage — AI backend unavailable (breaker open)")
 		return nil
 	}
 	return s.mapArticles(ctx, in, s.securityOne)
@@ -32,24 +33,20 @@ func (s *Stage) securityOne(ctx context.Context, article storage.Article) *stora
 	content := articleContent(article)
 	if content == "" {
 		s.Formatter.Warning("skipping article %d %q: no content", article.ID, article.Title)
-		// Mark scored with a zero interest score and NULL security score so the
-		// article leaves the queue without polluting security metrics.
-		zeroInterest := 0.0
-		reason := "no content"
-		s.Store.UpdateReadState(s.UserID, article.ID, false, &zeroInterest, nil, &reason, nil) //nolint:errcheck
+		// Mark screened-but-skipped (NULL score) so it leaves the queue without
+		// polluting security metrics and is distinguishable from "not screened".
+		s.Store.SkipArticleSecurity(article.ID, "no content") //nolint:errcheck
 		return nil
 	}
 
 	minLen := s.Cfg.Summarization.MinArticleLength
 	if minLen > 0 && len(content) < minLen {
 		s.Formatter.Warning("skipping article %d: content too short (%d < %d)", article.ID, len(content), minLen)
-		zeroInterest := 0.0
-		reason := fmt.Sprintf("content too short (%d < %d)", len(content), minLen)
-		s.Store.UpdateReadState(s.UserID, article.ID, false, &zeroInterest, nil, &reason, nil) //nolint:errcheck
+		s.Store.SkipArticleSecurity(article.ID, fmt.Sprintf("content too short (%d < %d)", len(content), minLen)) //nolint:errcheck
 		return nil
 	}
 
-	secResult, err := s.AI.SecurityCheck(ctx, s.UserID, article.Title, content)
+	secResult, err := s.AI.SecurityCheck(ctx, article.Title, content)
 	if err != nil {
 		s.Formatter.Warning("security check failed for article %d: %v", article.ID, err)
 		// Only a genuine model-response failure counts against the retry budget;
@@ -57,7 +54,7 @@ func (s *Stage) securityOne(ctx context.Context, article storage.Article) *stora
 		// without incrementing and let a later cycle retry once the backend
 		// recovers (#100).
 		if !errors.Is(err, ai.ErrBackendUnavailable) {
-			s.Store.IncrementAIRetries(s.UserID, article.ID) //nolint:errcheck
+			s.Store.IncrementArticleSecurityAttempts(article.ID) //nolint:errcheck
 		}
 		return nil
 	}
@@ -68,28 +65,23 @@ func (s *Stage) securityOne(ctx context.Context, article storage.Article) *stora
 	}
 
 	if !secResult.Safe || secResult.Score < mediumScore {
-		// Hard block: below the lower threshold entirely.
-		secScore := secResult.Score
-		interestScore := 0.0
-		s.Store.UpdateReadState(s.UserID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, nil) //nolint:errcheck
-		s.Formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
+		// Hard block: below the lower threshold entirely. Record the verdict; the
+		// score gates it out of every downstream (passing) query.
+		s.Store.ScreenArticleSecurity(article.ID, secResult.Score, secResult.Reasoning, false) //nolint:errcheck
+		s.Formatter.OutputProcessingStatus(article.ID, article.Title, 0, secResult.Score, false)
 		return nil
 	}
 
 	if secResult.Score < s.Cfg.Thresholds.SecurityScore {
-		// Medium: clears the lower threshold but not the full one. Let through
-		// without AI processing; flag for audit.
-		secScore := secResult.Score
-		interestScore := 0.0
-		flagged := true
-		s.Store.UpdateReadState(s.UserID, article.ID, false, &interestScore, &secScore, &secResult.Reasoning, &flagged) //nolint:errcheck
-		s.Formatter.OutputProcessingStatus(article.ID, article.Title, interestScore, secScore, false)
+		// Medium: clears the lower threshold but not the full one. Flag for audit.
+		s.Store.ScreenArticleSecurity(article.ID, secResult.Score, secResult.Reasoning, true) //nolint:errcheck
+		s.Formatter.OutputProcessingStatus(article.ID, article.Title, 0, secResult.Score, false)
 		return nil
 	}
 
-	// Passed. Record the security verdict but leave interest_score NULL so the
-	// curation stage scores it.
-	if err := s.Store.MarkSecurityScored(s.UserID, article.ID, secResult.Score, secResult.Reasoning, false); err != nil {
+	// Passed. Record the verdict on the article; the per-user curation stage
+	// picks it up via the security threshold and assigns each user's interest.
+	if err := s.Store.ScreenArticleSecurity(article.ID, secResult.Score, secResult.Reasoning, false); err != nil {
 		s.Formatter.Warning("failed to record security verdict for article %d: %v", article.ID, err)
 		return nil
 	}
@@ -167,13 +159,13 @@ func (s *Stage) Curate(ctx context.Context, in []storage.Article) []storage.Arti
 		s.Formatter.Warning("pipeline: skipping curation stage for user %d — AI backend unavailable (breaker open)", s.UserID)
 		return nil
 	}
-	// The security verdict lives in read_state, not on the in-memory Article, so
-	// fetch it once for the batch to report alongside the interest score (#119).
+	// The security verdict lives on the article, not on the in-memory Article
+	// struct, so fetch it once for the batch to report alongside interest (#119).
 	batchIDs := make([]int64, len(in))
 	for i, a := range in {
 		batchIDs[i] = a.ID
 	}
-	secScores, err := s.Store.GetSecurityScores(s.UserID, batchIDs)
+	secScores, err := s.Store.GetArticleSecurityScores(batchIDs)
 	if err != nil {
 		s.Formatter.Warning("pipeline: could not load security scores for curation reporting: %v", err)
 		secScores = nil

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -48,7 +48,7 @@ func (f *fakeAI) RefineGroupTopic(_ context.Context, _ int64, summary string) (s
 	return "refined topic", nil
 }
 
-func (f *fakeAI) SecurityCheck(_ context.Context, _ int64, title, content string) (*ai.SecurityResult, error) {
+func (f *fakeAI) SecurityCheck(_ context.Context, title, content string) (*ai.SecurityResult, error) {
 	f.mu.Lock()
 	f.secCalls++
 	f.mu.Unlock()
@@ -158,7 +158,7 @@ func TestSecurityStageGatesAndMarks(t *testing.T) {
 		t.Fatalf("expected article %d awaiting curation, got %v", pass.ID, ids(cur))
 	}
 	// All five left the unscored (security) queue: pass is scored, the rest terminal.
-	unscored, _ := store.GetUnscoredArticlesForUser(1, 10)
+	unscored, _ := store.GetUnscreenedArticles(10)
 	if len(unscored) != 0 {
 		t.Fatalf("expected unscored queue empty, got %v", ids(unscored))
 	}
@@ -177,7 +177,7 @@ func TestSecurityRetryBudget(t *testing.T) {
 		for range 4 {
 			st.Security(context.Background(), []storage.Article{art})
 		}
-		unscored, _ := store.GetUnscoredArticlesForUser(1, 10)
+		unscored, _ := store.GetUnscreenedArticles(10)
 		if len(unscored) != 1 {
 			t.Fatalf("backend-unavailable article should still be retryable, got %v", ids(unscored))
 		}
@@ -192,7 +192,7 @@ func TestSecurityRetryBudget(t *testing.T) {
 		for range 3 {
 			st.Security(context.Background(), []storage.Article{art})
 		}
-		unscored, _ := store.GetUnscoredArticlesForUser(1, 10)
+		unscored, _ := store.GetUnscreenedArticles(10)
 		if len(unscored) != 0 {
 			t.Fatalf("article should drop out after 3 verdict failures, got %v", ids(unscored))
 		}
@@ -211,7 +211,7 @@ func TestSecurityStageSkipsWhenBreakerOpen(t *testing.T) {
 	if fake.secCalls != 0 {
 		t.Fatalf("expected zero security calls with breaker open, got %d", fake.secCalls)
 	}
-	unscored, _ := store.GetUnscoredArticlesForUser(1, 10)
+	unscored, _ := store.GetUnscreenedArticles(10)
 	if len(unscored) != 1 {
 		t.Fatalf("article should remain unscored after a skipped stage, got %v", ids(unscored))
 	}
@@ -261,7 +261,7 @@ func TestSummarizeStage(t *testing.T) {
 	st, store, feedID := newHarness(t, &fakeAI{available: true})
 	mustPass := func(a storage.Article) {
 		// Put the article into the security-passed state the summarize stage expects.
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -334,7 +334,7 @@ func TestCurateStage(t *testing.T) {
 		}}
 		st, store, feedID := newHarness(t, fake)
 		a := seed(t, store, feedID, "x", "body text")
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -361,7 +361,7 @@ func TestCurateStage(t *testing.T) {
 		var buf bytes.Buffer
 		st.Formatter = output.NewFormatterWithWriters(output.FormatJSON, &buf, io.Discard)
 		a := seed(t, store, feedID, "x", "body text")
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -396,7 +396,7 @@ func TestCurateStage(t *testing.T) {
 		var errBuf bytes.Buffer
 		st.Formatter = output.NewFormatterWithWriters(output.FormatJSON, io.Discard, &errBuf)
 		a := seed(t, store, feedID, "headline here", "body text")
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -419,7 +419,7 @@ func TestCurateStage(t *testing.T) {
 		}}
 		st, store, feedID := newHarness(t, fake)
 		a := seed(t, store, feedID, "x", "body text")
-		if err := store.MarkSecurityScored(1, a.ID, 9, "ok", false); err != nil {
+		if err := store.ScreenArticleSecurity(a.ID, 9, "ok", false); err != nil {
 			t.Fatal(err)
 		}
 		out := st.Curate(context.Background(), []storage.Article{a})

--- a/internal/storage/ai_summary.go
+++ b/internal/storage/ai_summary.go
@@ -140,7 +140,7 @@ func getUnreadArticlesForSummary(db *tracedDB, userID int64, minSecurity, minInt
 		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
 		WHERE uf.user_id = ?
 		  AND rs.read = ?
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND rs.interest_score >= ?
 		ORDER BY COALESCE(a.published_date, a.fetched_date) DESC
 		LIMIT ?`, userID, false, minSecurity, minInterest, limit)

--- a/internal/storage/ai_summary_test.go
+++ b/internal/storage/ai_summary_test.go
@@ -13,7 +13,11 @@ func seedScored(t *testing.T, store Store, feedID, userID int64, guid string, re
 	if err != nil {
 		t.Fatalf("AddArticle: %v", err)
 	}
-	if err := store.UpdateReadState(userID, id, false, &interest, &security, nil, nil); err != nil {
+	// Security verdict is article-level (#141); interest stays per-user.
+	if err := store.ScreenArticleSecurity(id, security, "", false); err != nil {
+		t.Fatalf("ScreenArticleSecurity: %v", err)
+	}
+	if err := store.UpdateReadState(userID, id, false, &interest, nil, nil, nil); err != nil {
 		t.Fatalf("UpdateReadState scores: %v", err)
 	}
 	if read {

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -286,7 +286,8 @@ func migrateArticles(ctx context.Context, src *tracedDB, dst Store, dstDB *trace
 		       COALESCE(content,''), COALESCE(summary,''), COALESCE(author,''),
 		       published_date, fetched_date,
 		       COALESCE(linked_url,''), COALESCE(linked_content,''),
-		       full_text_fetched, images_cached
+		       full_text_fetched, images_cached,
+		       security_score, COALESCE(security_reason,''), security_flagged, security_screened_at
 		FROM articles ORDER BY id`)
 	if err != nil {
 		return err
@@ -305,6 +306,10 @@ func migrateArticles(ctx context.Context, src *tracedDB, dst Store, dstDB *trace
 		linkedContent    string
 		fullTextFetched  bool
 		imagesCached     bool
+		securityScore    sql.NullFloat64
+		securityReason   string
+		securityFlagged  bool
+		securityScreened sql.NullTime
 	}
 
 	var articles []articleRow
@@ -316,6 +321,7 @@ func migrateArticles(ctx context.Context, src *tracedDB, dst Store, dstDB *trace
 			&a.publishedDate, &a.fetchedDate,
 			&a.linkedURL, &a.linkedContent,
 			&a.fullTextFetched, &a.imagesCached,
+			&a.securityScore, &a.securityReason, &a.securityFlagged, &a.securityScreened,
 		); err != nil {
 			return fmt.Errorf("scan article: %w", err)
 		}
@@ -373,6 +379,18 @@ func migrateArticles(ctx context.Context, src *tracedDB, dst Store, dstDB *trace
 		if a.imagesCached {
 			if err := dst.MarkArticleImagesCached(dstID); err != nil {
 				return fmt.Errorf("MarkArticleImagesCached %d: %w", dstID, err)
+			}
+		}
+		// Carry the article-level security verdict (#141) so the destination does
+		// not re-screen. A screened article with a score gets the verdict; one
+		// screened without a score was a deliberate skip (no content / too short).
+		if a.securityScreened.Valid {
+			if a.securityScore.Valid {
+				if err := dst.ScreenArticleSecurity(dstID, a.securityScore.Float64, a.securityReason, a.securityFlagged); err != nil {
+					return fmt.Errorf("ScreenArticleSecurity %d: %w", dstID, err)
+				}
+			} else if err := dst.SkipArticleSecurity(dstID, a.securityReason); err != nil {
+				return fmt.Errorf("SkipArticleSecurity %d: %w", dstID, err)
 			}
 		}
 		stats.Articles++

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -120,6 +120,39 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 		)`,
 		"CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_tags_unique ON feed_tags(user_id, feed_id, lower(tag))",
 		"CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, lower(tag))",
+		// Move the security verdict from per-user read_state onto the article
+		// itself (#141): each article is screened once and the verdict is shared
+		// by all subscribers. security_screened_at is the "have we screened this"
+		// marker, also disambiguating "screened but skipped" (set, score NULL)
+		// from "not yet screened" (NULL) — the conflation #123 flagged.
+		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS security_score DOUBLE PRECISION",
+		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS security_reason TEXT",
+		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS security_flagged BOOLEAN NOT NULL DEFAULT FALSE",
+		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS security_screened_at TIMESTAMPTZ",
+		"ALTER TABLE articles ADD COLUMN IF NOT EXISTS security_attempts INTEGER NOT NULL DEFAULT 0",
+		"CREATE INDEX IF NOT EXISTS idx_articles_unscreened ON articles(published_date DESC) WHERE security_screened_at IS NULL",
+		// Backfill: copy each article's verdict from the existing per-user
+		// read_state, picking the lowest user_id with a non-NULL score. Guarded on
+		// security_screened_at IS NULL so it is idempotent.
+		`UPDATE articles a
+		 SET security_score    = v.security_score,
+		     security_reason   = v.security_reason,
+		     security_flagged  = COALESCE(v.security_flagged, FALSE),
+		     security_screened_at = NOW()
+		 FROM (
+		     SELECT DISTINCT ON (article_id) article_id, security_score, security_reason, security_flagged
+		     FROM read_state
+		     WHERE security_score IS NOT NULL
+		     ORDER BY article_id, user_id
+		 ) v
+		 WHERE a.id = v.article_id AND a.security_screened_at IS NULL`,
+		// Articles a user marked ai_scored but with NULL security (the #123
+		// "screened but skipped" case): mark screened, leave the score NULL.
+		`UPDATE articles a
+		 SET security_screened_at = NOW()
+		 WHERE a.security_screened_at IS NULL
+		   AND EXISTS (SELECT 1 FROM read_state rs
+		         WHERE rs.article_id = a.id AND rs.ai_scored = TRUE)`,
 	}
 	for _, m := range pgMigrations {
 		if _, err := db.Exec(m); err != nil {
@@ -503,13 +536,13 @@ func (s *PostgresStore) GetScoreStats(userID int64) (*ScoreStatsResult, error) {
 		SELECT
 			f.id,
 			COALESCE(uf.user_title, f.title),
-			COUNT(*) FILTER (WHERE rs.ai_scored IS TRUE),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 4.0 AND rs.security_score < 7.0),
-			COUNT(*) FILTER (WHERE rs.security_score IS NOT NULL AND rs.security_score < 4.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score >= 8.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score >= 5.0 AND rs.interest_score < 8.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score IS NOT NULL AND rs.interest_score < 5.0)
+			COUNT(*) FILTER (WHERE a.security_screened_at IS NOT NULL),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 4.0 AND a.security_score < 7.0),
+			COUNT(*) FILTER (WHERE a.security_score IS NOT NULL AND a.security_score < 4.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score >= 8.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score >= 5.0 AND rs.interest_score < 8.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score IS NOT NULL AND rs.interest_score < 5.0)
 		FROM feeds f
 		JOIN user_feeds uf ON uf.feed_id = f.id AND uf.user_id = ?
 		JOIN articles a ON a.feed_id = f.id
@@ -559,23 +592,30 @@ func (s *PostgresStore) IncrementAIRetries(userID, articleID int64) error {
 	return nil
 }
 
-// ResetScores clears AI scores so articles are reprocessed by the pipeline.
+// ResetScores clears the security verdict on the user's subscribed articles so
+// the pipeline re-screens (and re-curates) them. The verdict is article-level
+// now (#141): this resets the shared article rows for the user's feeds, plus the
+// user's own interest scores. If securityOnly, only articles below belowScore are
+// reset. Returns the number of article rows reset.
 func (s *PostgresStore) ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error) {
-	var result sql.Result
-	var err error
-	if securityOnly {
-		result, err = s.db.Exec(
-			`UPDATE read_state SET ai_scored = FALSE, ai_retries = 0, interest_score = NULL, security_score = NULL, security_reason = NULL
-			 WHERE user_id = ? AND security_score IS NOT NULL AND security_score < ?`,
-			userID, belowScore,
-		)
-	} else {
-		result, err = s.db.Exec(
-			`UPDATE read_state SET ai_scored = FALSE, ai_retries = 0, interest_score = NULL, security_score = NULL, security_reason = NULL
-			 WHERE user_id = ?`,
-			userID,
-		)
+	if !securityOnly {
+		if _, err := s.db.Exec(
+			`UPDATE read_state SET ai_scored = FALSE, ai_retries = 0, interest_score = NULL
+			 WHERE user_id = ?`, userID,
+		); err != nil {
+			return 0, fmt.Errorf("reset scores (read_state): %w", err)
+		}
 	}
+	query := `UPDATE articles
+		 SET security_score = NULL, security_reason = NULL, security_flagged = FALSE,
+		     security_screened_at = NULL, security_attempts = 0
+		 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = ?)`
+	args := []any{userID}
+	if securityOnly {
+		query += ` AND security_score IS NOT NULL AND security_score < ?`
+		args = append(args, belowScore)
+	}
+	result, err := s.db.Exec(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reset scores: %w", err)
 	}
@@ -843,7 +883,7 @@ func (s *PostgresStore) GetUnreadArticlesForUser(userID int64, limit, offset int
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(rs.security_flagged, FALSE) AS security_flagged
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -872,7 +912,7 @@ func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, off
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(rs.security_flagged, FALSE) AS security_flagged
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -896,24 +936,9 @@ func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, off
 	return scanArticlesWithFlags(rows)
 }
 
-func (s *PostgresStore) GetUnscoredArticlesForUser(userID int64, limit int) ([]Article, error) {
-	rows, err := s.db.Query(`
-		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
-		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.ai_scored = FALSE)
-		  AND COALESCE(rs.ai_retries, 0) < 3
-		ORDER BY a.published_date DESC
-		LIMIT ?`, userID, userID, limit)
-	if err != nil {
-		return nil, fmt.Errorf("get unscored articles for user: %w", err)
-	}
-	defer rows.Close()
-	return scanArticles(rows)
-}
-
+// GetUnscoredArticleCount counts the user's articles still in the AI funnel:
+// not yet security-screened (within budget) or screened-pass but not yet
+// interest-scored for this user. See the SQLite implementation (#141).
 func (s *PostgresStore) GetUnscoredArticleCount(userID int64) (int, error) {
 	var count int
 	err := s.db.QueryRow(`
@@ -921,8 +946,11 @@ func (s *PostgresStore) GetUnscoredArticleCount(userID int64) (int, error) {
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.ai_scored = FALSE)
-		  AND COALESCE(rs.ai_retries, 0) < 3`,
+		WHERE uf.user_id = ?
+		  AND (
+		    (a.security_screened_at IS NULL AND a.security_attempts < 3)
+		    OR (a.security_score >= 7.0 AND rs.interest_score IS NULL)
+		  )`,
 		userID, userID,
 	).Scan(&count)
 	if err != nil {
@@ -937,11 +965,9 @@ func (s *PostgresStore) GetUnsummarizedScoredArticles(userID int64, securityThre
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
 		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = uf.user_id
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = TRUE
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND asumm.article_id IS NULL
 		ORDER BY a.published_date DESC
 		LIMIT ?`, userID, securityThreshold, limit)
@@ -969,23 +995,66 @@ func (s *PostgresStore) SetInterestScore(userID, articleID int64, interestScore 
 	return nil
 }
 
-// MarkSecurityScored records the security verdict and marks ai_scored without
-// writing an interest score. See the SQLite implementation.
-func (s *PostgresStore) MarkSecurityScored(userID, articleID int64, securityScore float64, securityReason string, securityFlagged bool) error {
+// ScreenArticleSecurity records the security verdict on the article itself
+// (#141). See the SQLite implementation.
+func (s *PostgresStore) ScreenArticleSecurity(articleID int64, securityScore float64, securityReason string, securityFlagged bool) error {
 	_, err := s.db.Exec(
-		`INSERT INTO read_state (user_id, article_id, read, security_score, security_reason, security_flagged, ai_scored)
-		 VALUES (?, ?, FALSE, ?, ?, ?, TRUE)
-		 ON CONFLICT(user_id, article_id) DO UPDATE SET
-		   security_score = excluded.security_score,
-		   security_reason = excluded.security_reason,
-		   security_flagged = excluded.security_flagged,
-		   ai_scored = TRUE`,
-		userID, articleID, securityScore, securityReason, securityFlagged,
+		`UPDATE articles
+		 SET security_score = ?, security_reason = ?, security_flagged = ?,
+		     security_screened_at = NOW()
+		 WHERE id = ?`,
+		securityScore, securityReason, securityFlagged, articleID,
 	)
 	if err != nil {
-		return fmt.Errorf("mark security scored: %w", err)
+		return fmt.Errorf("screen article security: %w", err)
 	}
 	return nil
+}
+
+// SkipArticleSecurity marks an article screened without a score (no content /
+// too short). See the SQLite implementation.
+func (s *PostgresStore) SkipArticleSecurity(articleID int64, reason string) error {
+	_, err := s.db.Exec(
+		`UPDATE articles
+		 SET security_reason = ?, security_screened_at = NOW()
+		 WHERE id = ?`,
+		reason, articleID,
+	)
+	if err != nil {
+		return fmt.Errorf("skip article security: %w", err)
+	}
+	return nil
+}
+
+// IncrementArticleSecurityAttempts bumps the per-article security retry counter.
+// See the SQLite implementation.
+func (s *PostgresStore) IncrementArticleSecurityAttempts(articleID int64) error {
+	_, err := s.db.Exec(
+		`UPDATE articles SET security_attempts = security_attempts + 1 WHERE id = ?`,
+		articleID,
+	)
+	if err != nil {
+		return fmt.Errorf("increment article security attempts: %w", err)
+	}
+	return nil
+}
+
+// GetUnscreenedArticles returns articles not yet security-screened, within the
+// retry budget, newest first. Global (not user-scoped). See the SQLite version.
+func (s *PostgresStore) GetUnscreenedArticles(limit int) ([]Article, error) {
+	rows, err := s.db.Query(`
+		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+		       a.author, a.published_date, a.fetched_date
+		FROM articles a
+		WHERE a.security_screened_at IS NULL
+		  AND a.security_attempts < 3
+		ORDER BY a.published_date DESC
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get unscreened articles: %w", err)
+	}
+	defer rows.Close()
+	return scanArticles(rows)
 }
 
 // GetUnscoredCurationArticles returns articles that passed the security screen
@@ -997,10 +1066,9 @@ func (s *PostgresStore) GetUnscoredCurationArticles(userID int64, securityThresh
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
+		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = TRUE
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND rs.interest_score IS NULL
 		ORDER BY a.published_date DESC
 		LIMIT ?`, userID, securityThreshold, limit)
@@ -1020,12 +1088,10 @@ func (s *PostgresStore) GetUngroupedEmbeddedArticles(userID int64, model string,
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = uf.user_id
 		JOIN article_embeddings ae ON ae.article_id = a.id
 		    AND ae.embedding_model = ? AND ae.status = ?
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = TRUE
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND COALESCE(a.published_date, a.fetched_date) >= ?
 		  AND NOT EXISTS (
 		      SELECT 1 FROM article_group_members agm
@@ -1434,12 +1500,12 @@ func (s *PostgresStore) GetProcessingStats(userID int64) (*ProcessingStats, erro
 	err := s.db.QueryRow(`
 		SELECT
 			COUNT(*),
-			COALESCE(SUM(CASE WHEN rs.ai_scored = TRUE THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = FALSE) AND COALESCE(rs.ai_retries, 0) < 3 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = FALSE) AND COALESCE(rs.ai_retries, 0) >= 3 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.security_score >= 7 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.security_score IS NOT NULL AND rs.security_score < 7 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.ai_scored = TRUE AND rs.security_score IS NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NOT NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NULL AND a.security_attempts < 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NULL AND a.security_attempts >= 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_score >= 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_score IS NOT NULL AND a.security_score < 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NOT NULL AND a.security_score IS NULL THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN rs.interest_score IS NOT NULL THEN 1 ELSE 0 END), 0)
 		FROM articles a
 		JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
@@ -1632,23 +1698,22 @@ func (s *PostgresStore) GetArticleInterestScores(userID int64, articleIDs []int6
 	return scores, rows.Err()
 }
 
-// GetSecurityScores returns the persisted security_score for each of the given
-// articles (user-scoped), skipping any with a NULL score. The curate stage uses
-// it to report the verdict the security stage wrote, since that score is not
-// carried on the in-memory Article (#119).
-func (s *PostgresStore) GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error) {
+// GetArticleSecurityScores returns the persisted security_score for each of the
+// given articles, skipping any with a NULL score. Not user-scoped — the verdict
+// lives on the article (#141). The curate stage uses it to report the verdict
+// alongside the interest score (#119).
+func (s *PostgresStore) GetArticleSecurityScores(articleIDs []int64) (map[int64]float64, error) {
 	if len(articleIDs) == 0 {
 		return map[int64]float64{}, nil
 	}
 	placeholders := make([]string, len(articleIDs))
-	args := make([]any, 0, len(articleIDs)+1)
-	args = append(args, userID)
+	args := make([]any, 0, len(articleIDs))
 	for i, id := range articleIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
-	query := `SELECT article_id, security_score FROM read_state
-		WHERE user_id = ? AND article_id IN (` + strings.Join(placeholders, ",") + `)
+	query := `SELECT id, security_score FROM articles
+		WHERE id IN (` + strings.Join(placeholders, ",") + `)
 		AND security_score IS NOT NULL`
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
@@ -3021,7 +3086,7 @@ func (s *PostgresStore) GetNewsletterArticles(userID int64, config *NewsletterCo
 		args = append(args, config.MinInterestScore)
 	}
 	if config.MinSecurityScore > 0 {
-		query += ` AND rs.security_score >= ?`
+		query += ` AND a.security_score >= ?`
 		args = append(args, config.MinSecurityScore)
 	}
 	if len(config.IncludeFeeds) > 0 {

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -32,11 +32,22 @@ CREATE TABLE IF NOT EXISTS articles (
     linked_content TEXT NOT NULL DEFAULT '',
     full_text_fetched BOOLEAN NOT NULL DEFAULT 0,
     images_cached BOOLEAN NOT NULL DEFAULT 0,
+    -- Security verdict lives on the article, not per-user: maliciousness is a
+    -- property of the content, so each article is screened once and the verdict
+    -- is shared by every subscriber. security_screened_at distinguishes "screened
+    -- but skipped" (set, score NULL) from "not yet screened" (NULL).
+    security_score REAL,
+    security_reason TEXT,
+    security_flagged BOOLEAN NOT NULL DEFAULT 0,
+    security_screened_at DATETIME,
+    security_attempts INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE,
     UNIQUE(feed_id, guid)
 );
 
 CREATE INDEX IF NOT EXISTS idx_articles_published ON articles(published_date DESC);
+-- Drives the global security pass: newest unscreened articles first.
+CREATE INDEX IF NOT EXISTS idx_articles_unscreened ON articles(published_date DESC) WHERE security_screened_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -37,11 +37,22 @@ CREATE TABLE IF NOT EXISTS articles (
     linked_content    TEXT NOT NULL DEFAULT '',
     full_text_fetched BOOLEAN NOT NULL DEFAULT FALSE,
     images_cached     BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Security verdict lives on the article, not per-user: maliciousness is a
+    -- property of the content, so each article is screened once and the verdict
+    -- is shared by every subscriber. security_screened_at distinguishes "screened
+    -- but skipped" (set, score NULL) from "not yet screened" (NULL).
+    security_score    DOUBLE PRECISION,
+    security_reason   TEXT,
+    security_flagged  BOOLEAN NOT NULL DEFAULT FALSE,
+    security_screened_at TIMESTAMPTZ,
+    security_attempts INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE,
     UNIQUE(feed_id, guid)
 );
 
 CREATE INDEX IF NOT EXISTS idx_articles_published ON articles(published_date DESC);
+-- Drives the global security pass: newest unscreened articles first.
+CREATE INDEX IF NOT EXISTS idx_articles_unscreened ON articles(published_date DESC) WHERE security_screened_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS users (
     id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/internal/storage/security_perarticle_test.go
+++ b/internal/storage/security_perarticle_test.go
@@ -1,0 +1,186 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The security verdict moved from per-user read_state onto the article itself
+// (#141). These tests cover the behaviours that move introduced: a one-time
+// backfill from the legacy per-user rows, a single shared verdict across
+// subscribers, and a skip marker distinct from "never screened".
+
+// TestSecurityBackfillFromReadState verifies the migration copies each article's
+// verdict from the legacy per-user read_state onto the article, picking the
+// lowest user_id's score, and marks #123-style "ai_scored but NULL security"
+// rows as screened (so they are not re-queued) while leaving the score NULL.
+func TestSecurityBackfillFromReadState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backfill.db")
+
+	s1, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	feedID, _ := s1.AddFeed("https://example.com/feed", "Feed", "")
+	now := time.Now()
+	passID, _ := s1.AddArticle(&Article{FeedID: feedID, GUID: "pass", Title: "pass",
+		URL: "https://example.com/pass", PublishedDate: &now})
+	medID, _ := s1.AddArticle(&Article{FeedID: feedID, GUID: "med", Title: "med",
+		URL: "https://example.com/med", PublishedDate: &now})
+	skipID, _ := s1.AddArticle(&Article{FeedID: feedID, GUID: "skip", Title: "skip",
+		URL: "https://example.com/skip", PublishedDate: &now})
+
+	// Simulate legacy per-user verdicts the old pipeline wrote into read_state.
+	// User 2 disagrees on the score for passID; the backfill must take user 1's
+	// (the lowest user_id). The fresh schema's article columns are still NULL, so
+	// this exercises the backfill on the second open below.
+	exec := func(q string, args ...any) {
+		if _, err := s1.db.Exec(q, args...); err != nil {
+			t.Fatalf("seed legacy read_state: %v", err)
+		}
+	}
+	exec(`INSERT INTO read_state (user_id, article_id, security_score, security_reason, security_flagged, ai_scored)
+	      VALUES (1, ?, 8.5, 'legacy pass', 0, 1)`, passID)
+	exec(`INSERT INTO read_state (user_id, article_id, security_score, security_reason, security_flagged, ai_scored)
+	      VALUES (2, ?, 4.0, 'other user', 0, 1)`, passID)
+	exec(`INSERT INTO read_state (user_id, article_id, security_score, security_reason, security_flagged, ai_scored)
+	      VALUES (1, ?, 5.0, 'legacy medium', 1, 1)`, medID)
+	exec(`INSERT INTO read_state (user_id, article_id, security_score, ai_scored)
+	      VALUES (1, ?, NULL, 1)`, skipID)
+	s1.Close()
+
+	// Reopen: the additive migration runs the backfill.
+	s2, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer s2.Close()
+
+	type verdict struct {
+		score    *float64
+		reason   *string
+		flagged  bool
+		screened bool
+	}
+	get := func(id int64) verdict {
+		var v verdict
+		if err := s2.db.QueryRow(
+			`SELECT security_score, security_reason, security_flagged, security_screened_at IS NOT NULL
+			 FROM articles WHERE id = ?`, id,
+		).Scan(&v.score, &v.reason, &v.flagged, &v.screened); err != nil {
+			t.Fatalf("read back %d: %v", id, err)
+		}
+		return v
+	}
+
+	pass := get(passID)
+	if pass.score == nil || *pass.score != 8.5 {
+		t.Errorf("pass score = %v, want 8.5 (lowest user_id's verdict)", pass.score)
+	}
+	if pass.reason == nil || *pass.reason != "legacy pass" {
+		t.Errorf("pass reason = %v, want 'legacy pass'", pass.reason)
+	}
+	if !pass.screened {
+		t.Error("pass should be marked screened")
+	}
+
+	med := get(medID)
+	if med.score == nil || *med.score != 5.0 || !med.flagged {
+		t.Errorf("med verdict = (%v, flagged=%v), want (5.0, flagged=true)", med.score, med.flagged)
+	}
+
+	// #123 case: ai_scored but never given a score. Marked screened, score NULL.
+	skip := get(skipID)
+	if !skip.screened {
+		t.Error("skipped-but-ai_scored article should be marked screened (#123)")
+	}
+	if skip.score != nil {
+		t.Errorf("skipped article score = %v, want NULL", *skip.score)
+	}
+
+	// Backfilled articles are no longer in the unscreened queue.
+	if un, _ := s2.GetUnscreenedArticles(10); len(un) != 0 {
+		t.Errorf("expected nothing unscreened after backfill, got %v", articleIDs(un))
+	}
+}
+
+// TestSecurityVerdictSharedAcrossUsers proves a single screen is shared by every
+// subscriber: after one ScreenArticleSecurity call, the article is gone from the
+// (global) unscreened queue and appears in BOTH users' curation queues.
+func TestSecurityVerdictSharedAcrossUsers(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SubscribeUserToFeed(2, feedID); err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now()
+		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "shared", Title: "shared",
+			URL: "https://example.com/shared", PublishedDate: &now})
+
+		// One screen, no user_id.
+		if err := store.ScreenArticleSecurity(id, 8.0, "ok", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity: %v", err)
+		}
+
+		if un, _ := store.GetUnscreenedArticles(10); len(un) != 0 {
+			t.Fatalf("article should be screened once, still unscreened: %v", articleIDs(un))
+		}
+		for _, uid := range []int64{1, 2} {
+			cur, err := store.GetUnscoredCurationArticles(uid, 7.0, 10)
+			if err != nil {
+				t.Fatalf("GetUnscoredCurationArticles user %d: %v", uid, err)
+			}
+			if len(cur) != 1 || cur[0].ID != id {
+				t.Fatalf("user %d should see the shared verdict awaiting curation, got %v", uid, articleIDs(cur))
+			}
+		}
+
+		scores, err := store.GetArticleSecurityScores([]int64{id})
+		if err != nil {
+			t.Fatalf("GetArticleSecurityScores: %v", err)
+		}
+		if scores[id] != 8.0 {
+			t.Errorf("GetArticleSecurityScores = %v, want 8.0", scores[id])
+		}
+	})
+}
+
+// TestSkipArticleSecurityMarksScreened verifies the skip marker: a skipped
+// article leaves the unscreened queue (won't be re-screened) but keeps a NULL
+// score (excluded from every passing query), distinct from a never-screened one.
+func TestSkipArticleSecurityMarksScreened(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now()
+		skipped, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "skip", Title: "skip",
+			URL: "https://example.com/skip", PublishedDate: &now})
+		fresh, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "fresh", Title: "fresh",
+			URL: "https://example.com/fresh", PublishedDate: &now})
+
+		if err := store.SkipArticleSecurity(skipped, "no content"); err != nil {
+			t.Fatalf("SkipArticleSecurity: %v", err)
+		}
+
+		// Only the still-fresh article remains unscreened.
+		un, _ := store.GetUnscreenedArticles(10)
+		if len(un) != 1 || un[0].ID != fresh {
+			t.Fatalf("expected only %d unscreened, got %v", fresh, articleIDs(un))
+		}
+
+		// The skipped article has no score, so it never reaches a passing query.
+		scores, _ := store.GetArticleSecurityScores([]int64{skipped})
+		if _, ok := scores[skipped]; ok {
+			t.Error("skipped article must not have a security score")
+		}
+		if cur, _ := store.GetUnscoredCurationArticles(1, 7.0, 10); len(cur) != 0 {
+			t.Errorf("skipped article must not await curation, got %v", articleIDs(cur))
+		}
+	})
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -357,6 +357,45 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 			FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
 		)`,
 		"CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, tag)",
+		// Move the security verdict from per-user read_state onto the article
+		// itself (#141): maliciousness is a property of the content, so each
+		// article is screened once and the verdict is shared by all subscribers.
+		// security_screened_at is the "have we screened this" marker, which also
+		// disambiguates "screened but skipped" (set, score NULL) from "not yet
+		// screened" (NULL) — the conflation #123 flagged.
+		"ALTER TABLE articles ADD COLUMN security_score REAL",
+		"ALTER TABLE articles ADD COLUMN security_reason TEXT",
+		"ALTER TABLE articles ADD COLUMN security_flagged BOOLEAN NOT NULL DEFAULT 0",
+		"ALTER TABLE articles ADD COLUMN security_screened_at DATETIME",
+		"ALTER TABLE articles ADD COLUMN security_attempts INTEGER NOT NULL DEFAULT 0",
+		"CREATE INDEX IF NOT EXISTS idx_articles_unscreened ON articles(published_date DESC) WHERE security_screened_at IS NULL",
+		// Backfill: copy each article's verdict from the existing per-user
+		// read_state. Pick the lowest user_id that holds a non-NULL score
+		// (deterministic; in practice every user screened to the same verdict).
+		// Guarded on security_screened_at IS NULL so it is idempotent and a no-op
+		// on subsequent startups.
+		`UPDATE articles
+		 SET security_score = (SELECT rs.security_score FROM read_state rs
+		         WHERE rs.article_id = articles.id AND rs.security_score IS NOT NULL
+		         ORDER BY rs.user_id LIMIT 1),
+		     security_reason = (SELECT rs.security_reason FROM read_state rs
+		         WHERE rs.article_id = articles.id AND rs.security_score IS NOT NULL
+		         ORDER BY rs.user_id LIMIT 1),
+		     security_flagged = COALESCE((SELECT rs.security_flagged FROM read_state rs
+		         WHERE rs.article_id = articles.id AND rs.security_score IS NOT NULL
+		         ORDER BY rs.user_id LIMIT 1), 0),
+		     security_screened_at = CURRENT_TIMESTAMP
+		 WHERE security_screened_at IS NULL
+		   AND EXISTS (SELECT 1 FROM read_state rs
+		         WHERE rs.article_id = articles.id AND rs.security_score IS NOT NULL)`,
+		// Articles a user marked ai_scored but with NULL security (the #123
+		// "screened but skipped: too short / no content" case): mark screened so
+		// they are not re-queued, leaving the score NULL.
+		`UPDATE articles
+		 SET security_screened_at = CURRENT_TIMESTAMP
+		 WHERE security_screened_at IS NULL
+		   AND EXISTS (SELECT 1 FROM read_state rs
+		         WHERE rs.article_id = articles.id AND rs.ai_scored = 1)`,
 	}
 	for _, m := range migrations {
 		db.Exec(m) // ignore "duplicate column" errors
@@ -1071,29 +1110,74 @@ func (s *SQLiteStore) UpdateReadState(userID, articleID int64, read bool, intere
 	return nil
 }
 
-// MarkSecurityScored records the security verdict for an article and marks it
-// ai_scored, WITHOUT writing an interest score. The staged pipeline runs the
-// security screen and interest scoring as separate passes: a passing article is
-// marked here (interest_score stays NULL) so the curation stage can pick it up
-// via GetUnscoredCurationArticles. interest_score is never touched on conflict,
-// so re-running the security stage cannot clobber a score the curator already
-// wrote. (Hard-blocked and medium-flagged articles are terminal and still go
-// through UpdateReadState with interest_score=0.)
-func (s *SQLiteStore) MarkSecurityScored(userID, articleID int64, securityScore float64, securityReason string, securityFlagged bool) error {
+// ScreenArticleSecurity records the security verdict on the article itself
+// (#141). The verdict is a property of the content, so it is screened once and
+// shared by every subscriber — no user_id. security_screened_at marks the
+// article screened so the global security pass does not re-queue it; the
+// per-user curation stage reads security_score to gate which articles it scores.
+func (s *SQLiteStore) ScreenArticleSecurity(articleID int64, securityScore float64, securityReason string, securityFlagged bool) error {
 	_, err := s.db.Exec(
-		`INSERT INTO read_state (user_id, article_id, read, security_score, security_reason, security_flagged, ai_scored)
-		 VALUES (?, ?, 0, ?, ?, ?, 1)
-		 ON CONFLICT(user_id, article_id) DO UPDATE SET
-		   security_score = excluded.security_score,
-		   security_reason = excluded.security_reason,
-		   security_flagged = excluded.security_flagged,
-		   ai_scored = 1`,
-		userID, articleID, securityScore, securityReason, securityFlagged,
+		`UPDATE articles
+		 SET security_score = ?, security_reason = ?, security_flagged = ?,
+		     security_screened_at = CURRENT_TIMESTAMP
+		 WHERE id = ?`,
+		securityScore, securityReason, securityFlagged, articleID,
 	)
 	if err != nil {
-		return fmt.Errorf("mark security scored: %w", err)
+		return fmt.Errorf("screen article security: %w", err)
 	}
 	return nil
+}
+
+// SkipArticleSecurity marks an article screened without a score: the security
+// stage deliberately skipped it (no content / too short). Recording the reason
+// with a NULL score keeps "screened but skipped" distinct from "not yet
+// screened" (security_screened_at IS NULL) — the conflation #123 flagged.
+func (s *SQLiteStore) SkipArticleSecurity(articleID int64, reason string) error {
+	_, err := s.db.Exec(
+		`UPDATE articles
+		 SET security_reason = ?, security_screened_at = CURRENT_TIMESTAMP
+		 WHERE id = ?`,
+		reason, articleID,
+	)
+	if err != nil {
+		return fmt.Errorf("skip article security: %w", err)
+	}
+	return nil
+}
+
+// IncrementArticleSecurityAttempts bumps the per-article security retry counter.
+// The global security pass skips articles whose attempts have hit the cap, so a
+// model that keeps failing on one article cannot re-screen it every cycle.
+func (s *SQLiteStore) IncrementArticleSecurityAttempts(articleID int64) error {
+	_, err := s.db.Exec(
+		`UPDATE articles SET security_attempts = security_attempts + 1 WHERE id = ?`,
+		articleID,
+	)
+	if err != nil {
+		return fmt.Errorf("increment article security attempts: %w", err)
+	}
+	return nil
+}
+
+// GetUnscreenedArticles returns articles that have not yet been security-screened
+// (security_screened_at IS NULL) and are still within the retry budget, newest
+// first. It is global — not scoped to a user — because the security verdict is
+// shared. This is the input to the once-per-cycle security pass.
+func (s *SQLiteStore) GetUnscreenedArticles(limit int) ([]Article, error) {
+	rows, err := s.db.Query(`
+		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+		       a.author, a.published_date, a.fetched_date
+		FROM articles a
+		WHERE a.security_screened_at IS NULL
+		  AND a.security_attempts < 3
+		ORDER BY a.published_date DESC
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get unscreened articles: %w", err)
+	}
+	defer rows.Close()
+	return scanArticles(rows)
 }
 
 // SetInterestScore records the interest score from the curation stage WITHOUT
@@ -1122,13 +1206,13 @@ func (s *SQLiteStore) GetScoreStats(userID int64) (*ScoreStatsResult, error) {
 		SELECT
 			f.id,
 			COALESCE(uf.user_title, f.title),
-			COUNT(*) FILTER (WHERE rs.ai_scored = 1),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 4.0 AND rs.security_score < 7.0),
-			COUNT(*) FILTER (WHERE rs.security_score IS NOT NULL AND rs.security_score < 4.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score >= 8.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score >= 5.0 AND rs.interest_score < 8.0),
-			COUNT(*) FILTER (WHERE rs.security_score >= 7.0 AND rs.interest_score IS NOT NULL AND rs.interest_score < 5.0)
+			COUNT(*) FILTER (WHERE a.security_screened_at IS NOT NULL),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 4.0 AND a.security_score < 7.0),
+			COUNT(*) FILTER (WHERE a.security_score IS NOT NULL AND a.security_score < 4.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score >= 8.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score >= 5.0 AND rs.interest_score < 8.0),
+			COUNT(*) FILTER (WHERE a.security_score >= 7.0 AND rs.interest_score IS NOT NULL AND rs.interest_score < 5.0)
 		FROM feeds f
 		JOIN user_feeds uf ON uf.feed_id = f.id AND uf.user_id = ?
 		JOIN articles a ON a.feed_id = f.id
@@ -1178,26 +1262,32 @@ func (s *SQLiteStore) IncrementAIRetries(userID, articleID int64) error {
 	return nil
 }
 
-// ResetScores clears AI scores so articles are reprocessed by the pipeline.
-// If securityOnly is true, only articles that failed the security check are reset.
-// belowScore filters to articles with security_score < belowScore (use 10.0 to reset all).
-// Returns the number of rows affected.
+// ResetScores clears the security verdict on the user's subscribed articles so
+// the pipeline re-screens (and re-curates) them. The verdict is article-level
+// now (#141), so this resets the shared article rows for the feeds this user
+// subscribes to, plus the user's own interest scores. If securityOnly is true,
+// only articles whose security_score is below belowScore are reset (use 10.0 to
+// reset all). Returns the number of article rows reset.
 func (s *SQLiteStore) ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error) {
-	var result sql.Result
-	var err error
-	if securityOnly {
-		result, err = s.db.Exec(
-			`UPDATE read_state SET ai_scored = 0, ai_retries = 0, interest_score = NULL, security_score = NULL, security_reason = NULL
-			 WHERE user_id = ? AND security_score IS NOT NULL AND security_score < ?`,
-			userID, belowScore,
-		)
-	} else {
-		result, err = s.db.Exec(
-			`UPDATE read_state SET ai_scored = 0, ai_retries = 0, interest_score = NULL, security_score = NULL, security_reason = NULL
-			 WHERE user_id = ?`,
-			userID,
-		)
+	if !securityOnly {
+		// Full reset also clears this user's interest scores so curation re-runs.
+		if _, err := s.db.Exec(
+			`UPDATE read_state SET ai_scored = 0, ai_retries = 0, interest_score = NULL
+			 WHERE user_id = ?`, userID,
+		); err != nil {
+			return 0, fmt.Errorf("reset scores (read_state): %w", err)
+		}
 	}
+	query := `UPDATE articles
+		 SET security_score = NULL, security_reason = NULL, security_flagged = 0,
+		     security_screened_at = NULL, security_attempts = 0
+		 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = ?)`
+	args := []any{userID}
+	if securityOnly {
+		query += ` AND security_score IS NOT NULL AND security_score < ?`
+		args = append(args, belowScore)
+	}
+	result, err := s.db.Exec(query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("reset scores: %w", err)
 	}
@@ -1378,20 +1468,21 @@ func (s *SQLiteStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 }
 
 // GetProcessingStats returns an aggregate snapshot of the AI pipeline state for a
-// user's articles (not broken down by feed). Counts mirror the daemon's own
-// work-selection predicates: "pending" uses ai_retries < 3 (the retry budget the
-// pipeline honours) and "stuck" is everything that has exhausted it.
+// user's articles (not broken down by feed). The security funnel is article-level
+// now (#141): "pending"/"stuck" mirror the global security pass's work-selection
+// (security_attempts < 3 = within budget; >= 3 = exhausted), while "curated"
+// stays per-user (interest_score on the user's read_state).
 func (s *SQLiteStore) GetProcessingStats(userID int64) (*ProcessingStats, error) {
 	var p ProcessingStats
 	err := s.db.QueryRow(`
 		SELECT
 			COUNT(*),
-			COALESCE(SUM(CASE WHEN rs.ai_scored = 1 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = 0) AND COALESCE(rs.ai_retries, 0) < 3 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN (rs.article_id IS NULL OR rs.ai_scored = 0) AND COALESCE(rs.ai_retries, 0) >= 3 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.security_score >= 7 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.security_score IS NOT NULL AND rs.security_score < 7 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN rs.ai_scored = 1 AND rs.security_score IS NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NOT NULL THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NULL AND a.security_attempts < 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NULL AND a.security_attempts >= 3 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_score >= 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_score IS NOT NULL AND a.security_score < 7 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN a.security_screened_at IS NOT NULL AND a.security_score IS NULL THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN rs.interest_score IS NOT NULL THEN 1 ELSE 0 END), 0)
 		FROM articles a
 		JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
@@ -1563,23 +1654,23 @@ func (s *SQLiteStore) GetArticleInterestScores(userID int64, articleIDs []int64)
 	return scores, rows.Err()
 }
 
-// GetSecurityScores returns the persisted security_score for each of the given
-// articles (user-scoped), skipping any with a NULL score. The curate stage uses
-// it to report the verdict the security stage wrote, since that score is not
-// carried on the in-memory Article (#119).
-func (s *SQLiteStore) GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error) {
+// GetArticleSecurityScores returns the persisted security_score for each of the
+// given articles, skipping any with a NULL score. The verdict lives on the
+// article (#141), so this is not user-scoped. The curate stage uses it to report
+// the verdict alongside the interest score, since the score is not carried on
+// the in-memory Article (#119).
+func (s *SQLiteStore) GetArticleSecurityScores(articleIDs []int64) (map[int64]float64, error) {
 	if len(articleIDs) == 0 {
 		return map[int64]float64{}, nil
 	}
 	placeholders := make([]string, len(articleIDs))
-	args := make([]any, 0, len(articleIDs)+1)
-	args = append(args, userID)
+	args := make([]any, 0, len(articleIDs))
 	for i, id := range articleIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
-	query := `SELECT article_id, security_score FROM read_state
-		WHERE user_id = ? AND article_id IN (` + strings.Join(placeholders, ",") + `)
+	query := `SELECT id, security_score FROM articles
+		WHERE id IN (` + strings.Join(placeholders, ",") + `)
 		AND security_score IS NOT NULL`
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
@@ -2197,6 +2288,10 @@ func (s *SQLiteStore) UpdateArticleLinkedContent(articleID int64, linkedURL, lin
 
 // GetUnscoredArticleCount returns the number of articles from the user's
 // subscribed feeds that have no read_state entry (pending security/interest scoring).
+// GetUnscoredArticleCount counts the user's articles still in the AI funnel:
+// not yet security-screened (within the retry budget), or screened-pass but not
+// yet interest-scored for this user. Security is article-level now (#141), so
+// the pending-screening half is shared across users; curation stays per-user.
 func (s *SQLiteStore) GetUnscoredArticleCount(userID int64) (int, error) {
 	var count int
 	err := s.db.QueryRow(`
@@ -2204,8 +2299,11 @@ func (s *SQLiteStore) GetUnscoredArticleCount(userID int64) (int, error) {
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.ai_scored = 0)
-		  AND COALESCE(rs.ai_retries, 0) < 3`,
+		WHERE uf.user_id = ?
+		  AND (
+		    (a.security_screened_at IS NULL AND a.security_attempts < 3)
+		    OR (a.security_score >= 7.0 AND rs.interest_score IS NULL)
+		  )`,
 		userID, userID,
 	).Scan(&count)
 	if err != nil {
@@ -2232,38 +2330,6 @@ func (s *SQLiteStore) GetUnsummarizedArticleCount(userID int64) (int, error) {
 	return count, nil
 }
 
-// GetUnscoredArticlesForUser returns articles from the user's subscribed feeds
-// that have no read_state entry (never been scored by the AI pipeline).
-func (s *SQLiteStore) GetUnscoredArticlesForUser(userID int64, limit int) ([]Article, error) {
-	query := `
-		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
-		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.ai_scored = 0)
-		  AND COALESCE(rs.ai_retries, 0) < 3
-		ORDER BY a.published_date DESC
-		LIMIT ?
-	`
-	rows, err := s.db.Query(query, userID, userID, limit)
-	if err != nil {
-		return nil, fmt.Errorf("get unscored articles for user: %w", err)
-	}
-	defer rows.Close()
-
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate); err != nil {
-			return nil, fmt.Errorf("scan article: %w", err)
-		}
-		articles = append(articles, a)
-	}
-	return articles, rows.Err()
-}
-
 // GetUnsummarizedScoredArticles returns articles that have been AI-scored with
 // a passing security score but lack a cached AI summary. Used by the daemon's
 // summary backfill pass to re-attempt summarization that failed transiently
@@ -2274,11 +2340,9 @@ func (s *SQLiteStore) GetUnsummarizedScoredArticles(userID int64, securityThresh
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
 		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = uf.user_id
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = 1
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND asumm.article_id IS NULL
 		ORDER BY a.published_date DESC
 		LIMIT ?
@@ -2312,10 +2376,9 @@ func (s *SQLiteStore) GetUnscoredCurationArticles(userID int64, securityThreshol
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
+		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = uf.user_id
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = 1
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND rs.interest_score IS NULL
 		ORDER BY a.published_date DESC
 		LIMIT ?`, userID, securityThreshold, limit)
@@ -2340,12 +2403,10 @@ func (s *SQLiteStore) GetUngroupedEmbeddedArticles(userID int64, model string, s
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = uf.user_id
 		JOIN article_embeddings ae ON ae.article_id = a.id
 		    AND ae.embedding_model = ? AND ae.status = ?
 		WHERE uf.user_id = ?
-		  AND rs.ai_scored = 1
-		  AND rs.security_score >= ?
+		  AND a.security_score >= ?
 		  AND COALESCE(a.published_date, a.fetched_date) >= ?
 		  AND NOT EXISTS (
 		      SELECT 1 FROM article_group_members agm
@@ -2367,7 +2428,7 @@ func (s *SQLiteStore) GetUnreadArticlesForUser(userID int64, limit, offset int, 
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(rs.security_flagged, 0) AS security_flagged
+		       COALESCE(a.security_flagged, 0) AS security_flagged
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -2409,7 +2470,7 @@ func (s *SQLiteStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offse
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(rs.security_flagged, 0) AS security_flagged
+		       COALESCE(a.security_flagged, 0) AS security_flagged
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -3466,7 +3527,7 @@ func (s *SQLiteStore) GetNewsletterArticles(userID int64, config *NewsletterConf
 		args = append(args, config.MinInterestScore)
 	}
 	if config.MinSecurityScore > 0 {
-		query += ` AND rs.security_score >= ?`
+		query += ` AND a.security_score >= ?`
 		args = append(args, config.MinSecurityScore)
 	}
 	if len(config.IncludeFeeds) > 0 {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1651,41 +1651,42 @@ func TestAIRetryLimit(t *testing.T) {
 		URL: "https://example.com/retry", PublishedDate: &now,
 	})
 
-	// Article should initially appear as unscored.
-	unscored, err := store.GetUnscoredArticlesForUser(1, 100)
+	// Article should initially appear as unscreened (security verdict is
+	// article-level now, #141).
+	unscreened, err := store.GetUnscreenedArticles(100)
 	if err != nil {
-		t.Fatalf("GetUnscoredArticlesForUser: %v", err)
+		t.Fatalf("GetUnscreenedArticles: %v", err)
 	}
-	if len(unscored) != 1 {
-		t.Fatalf("expected 1 unscored article, got %d", len(unscored))
+	if len(unscreened) != 1 {
+		t.Fatalf("expected 1 unscreened article, got %d", len(unscreened))
 	}
 
-	// Increment retries up to the limit (3).
+	// Exhaust the per-article security retry budget (3).
 	for i := range 3 {
-		if err := store.IncrementAIRetries(1, articleID); err != nil {
-			t.Fatalf("IncrementAIRetries call %d: %v", i+1, err)
+		if err := store.IncrementArticleSecurityAttempts(articleID); err != nil {
+			t.Fatalf("IncrementArticleSecurityAttempts call %d: %v", i+1, err)
 		}
 	}
 
-	// After 3 retries, article should no longer appear as unscored.
-	unscored, err = store.GetUnscoredArticlesForUser(1, 100)
+	// After 3 attempts, the article drops out of the security queue.
+	unscreened, err = store.GetUnscreenedArticles(100)
 	if err != nil {
-		t.Fatalf("GetUnscoredArticlesForUser after retries: %v", err)
+		t.Fatalf("GetUnscreenedArticles after retries: %v", err)
 	}
-	if len(unscored) != 0 {
-		t.Errorf("expected 0 unscored articles after 3 retries, got %d", len(unscored))
+	if len(unscreened) != 0 {
+		t.Errorf("expected 0 unscreened articles after 3 attempts, got %d", len(unscreened))
 	}
 
-	// Count should also reflect the exhausted article.
+	// The pending-AI count reflects the exhausted article too.
 	count, err := store.GetUnscoredArticleCount(1)
 	if err != nil {
 		t.Fatalf("GetUnscoredArticleCount: %v", err)
 	}
 	if count != 0 {
-		t.Errorf("expected unscored count 0 after 3 retries, got %d", count)
+		t.Errorf("expected unscored count 0 after 3 attempts, got %d", count)
 	}
 
-	// ResetScores should clear retries and make the article reappear.
+	// ResetScores clears the attempts and makes the article reappear.
 	n, err := store.ResetScores(1, false, 10.0)
 	if err != nil {
 		t.Fatalf("ResetScores: %v", err)
@@ -1693,12 +1694,12 @@ func TestAIRetryLimit(t *testing.T) {
 	if n != 1 {
 		t.Errorf("expected 1 row reset, got %d", n)
 	}
-	unscored, err = store.GetUnscoredArticlesForUser(1, 100)
+	unscreened, err = store.GetUnscreenedArticles(100)
 	if err != nil {
-		t.Fatalf("GetUnscoredArticlesForUser after reset: %v", err)
+		t.Fatalf("GetUnscreenedArticles after reset: %v", err)
 	}
-	if len(unscored) != 1 {
-		t.Errorf("expected 1 unscored article after reset, got %d", len(unscored))
+	if len(unscreened) != 1 {
+		t.Errorf("expected 1 unscreened article after reset, got %d", len(unscreened))
 	}
 }
 
@@ -1715,8 +1716,7 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		FeedID: feedID, GUID: "a1", Title: "Has summary",
 		URL: "https://example.com/1", PublishedDate: &now,
 	})
-	score, sec := 8.0, 10.0
-	store.UpdateReadState(1, a1, false, &score, &sec, nil, nil)
+	store.ScreenArticleSecurity(a1, 10.0, "", false)
 	store.UpdateArticleAISummary(1, a1, "an existing summary")
 
 	// Article 2: scored, passed security, NO summary — included.
@@ -1724,15 +1724,14 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		FeedID: feedID, GUID: "a2", Title: "Missing summary",
 		URL: "https://example.com/2", PublishedDate: &now,
 	})
-	store.UpdateReadState(1, a2, false, &score, &sec, nil, nil)
+	store.ScreenArticleSecurity(a2, 10.0, "", false)
 
 	// Article 3: scored, FAILED security — excluded (security_score < threshold).
 	a3, _ := store.AddArticle(&Article{
 		FeedID: feedID, GUID: "a3", Title: "Failed security",
 		URL: "https://example.com/3", PublishedDate: &now,
 	})
-	zero, low := 0.0, 3.0
-	store.UpdateReadState(1, a3, false, &zero, &low, nil, nil)
+	store.ScreenArticleSecurity(a3, 3.0, "", false)
 
 	// Article 4: never scored — excluded (no read_state).
 	store.AddArticle(&Article{
@@ -1745,7 +1744,7 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		FeedID: feedID, GUID: "a5", Title: "Skipped — too short to compress",
 		URL: "https://example.com/5", PublishedDate: &now,
 	})
-	store.UpdateReadState(1, a5, false, &score, &sec, nil, nil)
+	store.ScreenArticleSecurity(a5, 10.0, "", false)
 	if err := store.MarkSummarizationSkipped(1, a5, "summary longer than content"); err != nil {
 		t.Fatalf("MarkSummarizationSkipped: %v", err)
 	}
@@ -2618,15 +2617,18 @@ func TestMarkSecurityScoredAndCurationQueue(t *testing.T) {
 		scored := mk("scored") // fully scored (interest set) → excluded
 		_ = mk("unscored")     // no read_state at all → excluded
 
-		if err := store.MarkSecurityScored(1, passed, 8.0, "fine", false); err != nil {
-			t.Fatalf("MarkSecurityScored: %v", err)
+		if err := store.ScreenArticleSecurity(passed, 8.0, "fine", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity: %v", err)
 		}
-		if err := store.MarkSecurityScored(1, lowSec, 5.0, "borderline", false); err != nil {
-			t.Fatalf("MarkSecurityScored low: %v", err)
+		if err := store.ScreenArticleSecurity(lowSec, 5.0, "borderline", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity low: %v", err)
 		}
-		interest, sec := 6.0, 8.0
-		if err := store.UpdateReadState(1, scored, false, &interest, &sec, nil, nil); err != nil {
-			t.Fatalf("UpdateReadState: %v", err)
+		// "scored": security-passed and already interest-scored for this user.
+		if err := store.ScreenArticleSecurity(scored, 8.0, "fine", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity scored: %v", err)
+		}
+		if err := store.SetInterestScore(1, scored, 6.0); err != nil {
+			t.Fatalf("SetInterestScore: %v", err)
 		}
 
 		got, err := store.GetUnscoredCurationArticles(1, 7.0, 10)
@@ -2637,20 +2639,21 @@ func TestMarkSecurityScoredAndCurationQueue(t *testing.T) {
 			t.Fatalf("expected only article %d awaiting curation, got %v", passed, articleIDs(got))
 		}
 
-		// Security-scored article must have left the unscored (security) queue.
-		unscored, _ := store.GetUnscoredArticlesForUser(1, 10)
-		for _, a := range unscored {
+		// Screened article must have left the (global) security queue.
+		unscreened, _ := store.GetUnscreenedArticles(10)
+		for _, a := range unscreened {
 			if a.ID == passed {
-				t.Fatal("security-scored article should not be in the unscored queue")
+				t.Fatal("screened article should not be in the unscreened queue")
 			}
 		}
 
-		// Curate it, then re-screen: the interest score must survive (ON CONFLICT
-		// does not touch interest_score) and it must drop out of the curation queue.
-		curScore := 7.5
-		store.UpdateReadState(1, passed, false, &curScore, &sec, nil, nil) //nolint:errcheck
-		if err := store.MarkSecurityScored(1, passed, 8.0, "re-screened", false); err != nil {
-			t.Fatalf("MarkSecurityScored re-run: %v", err)
+		// Curate it, then re-screen: the interest score must survive (security and
+		// interest live in different tables now) and it must drop out of curation.
+		if err := store.SetInterestScore(1, passed, 7.5); err != nil {
+			t.Fatalf("SetInterestScore passed: %v", err)
+		}
+		if err := store.ScreenArticleSecurity(passed, 8.0, "re-screened", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity re-run: %v", err)
 		}
 		after, _ := store.GetUnscoredCurationArticles(1, 7.0, 10)
 		if len(after) != 0 {
@@ -2672,8 +2675,8 @@ func TestSetInterestScorePreservesSecurity(t *testing.T) {
 		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "x", Title: "x",
 			URL: "https://example.com/x", PublishedDate: &now})
 
-		if err := store.MarkSecurityScored(1, id, 8.0, "ok", false); err != nil {
-			t.Fatalf("MarkSecurityScored: %v", err)
+		if err := store.ScreenArticleSecurity(id, 8.0, "ok", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity: %v", err)
 		}
 		if err := store.SetInterestScore(1, id, 6.0); err != nil {
 			t.Fatalf("SetInterestScore: %v", err)
@@ -2715,7 +2718,7 @@ func TestGetUngroupedEmbeddedArticles(t *testing.T) {
 		mk := func(guid string, pub time.Time) int64 {
 			id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: guid, Title: guid,
 				URL: "https://example.com/" + guid, PublishedDate: &pub})
-			store.MarkSecurityScored(1, id, 9, "ok", false) //nolint:errcheck
+			store.ScreenArticleSecurity(id, 9, "ok", false) //nolint:errcheck
 			return id
 		}
 
@@ -2744,10 +2747,7 @@ func TestGetUngroupedEmbeddedArticles(t *testing.T) {
 		blocked := mk("blocked", now)
 		store.StoreArticleEmbedding(blocked, vec, model) //nolint:errcheck
 		// Overwrite the passing verdict with a failing one.
-		zero := 0.0
-		secScore := 2.0
-		reason := "blocked"
-		store.UpdateReadState(1, blocked, false, &zero, &secScore, &reason, nil) //nolint:errcheck
+		store.ScreenArticleSecurity(blocked, 2.0, "blocked", false) //nolint:errcheck
 
 		since := now.Add(-48 * time.Hour)
 		got, err := store.GetUngroupedEmbeddedArticles(1, model, 7.0, since, 10)
@@ -2791,8 +2791,8 @@ func TestGetProcessingStats(t *testing.T) {
 
 	add("a1") // untouched -> pending
 
-	a2 := add("a2") // scored, security pass, curated, summarized
-	if err := store.MarkSecurityScored(1, a2, 8, "ok", false); err != nil {
+	a2 := add("a2") // screened, security pass, curated, summarized
+	if err := store.ScreenArticleSecurity(a2, 8, "ok", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.SetInterestScore(1, a2, 7); err != nil {
@@ -2802,17 +2802,17 @@ func TestGetProcessingStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a3 := add("a3") // scored, security rejected, summarize-skipped
-	if err := store.MarkSecurityScored(1, a3, 3, "unsafe", false); err != nil {
+	a3 := add("a3") // screened, security rejected, summarize-skipped
+	if err := store.ScreenArticleSecurity(a3, 3, "unsafe", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.MarkSummarizationSkipped(1, a3, "too short"); err != nil {
 		t.Fatal(err)
 	}
 
-	a4 := add("a4") // unscored with retries maxed -> stuck
+	a4 := add("a4") // unscreened with security attempts maxed -> stuck
 	for range 3 {
-		if err := store.IncrementAIRetries(1, a4); err != nil {
+		if err := store.IncrementArticleSecurityAttempts(a4); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -86,7 +86,13 @@ type Store interface {
 	// Read state
 	UpdateStarred(userID, articleID int64, starred bool) error
 	UpdateReadState(userID, articleID int64, read bool, interestScore, securityScore *float64, securityReason *string, securityFlagged *bool) error
-	MarkSecurityScored(userID, articleID int64, securityScore float64, securityReason string, securityFlagged bool) error
+	// Security verdict lives on the article (#141): screened once, shared by all
+	// subscribers. ScreenArticleSecurity/SkipArticleSecurity record the verdict;
+	// GetUnscreenedArticles drives the global once-per-cycle security pass.
+	ScreenArticleSecurity(articleID int64, securityScore float64, securityReason string, securityFlagged bool) error
+	SkipArticleSecurity(articleID int64, reason string) error
+	IncrementArticleSecurityAttempts(articleID int64) error
+	GetUnscreenedArticles(limit int) ([]Article, error)
 	SetInterestScore(userID, articleID int64, interestScore float64) error
 	IncrementAIRetries(userID, articleID int64) error
 	ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error)
@@ -116,7 +122,6 @@ type Store interface {
 	GetArticlesByInterestScore(userID int64, threshold float64, limit, offset int, filterThreshold *int) ([]Article, []float64, error)
 	GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int) ([]Article, error)
 	GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int) ([]Article, error)
-	GetUnscoredArticlesForUser(userID int64, limit int) ([]Article, error)
 	GetUnscoredArticleCount(userID int64) (int, error)
 	GetUnsummarizedArticleCount(userID int64) (int, error)
 	GetUnsummarizedScoredArticles(userID int64, securityThreshold float64, limit int) ([]Article, error)
@@ -166,7 +171,7 @@ type Store interface {
 	AddArticleToGroup(groupID, articleID int64) error
 	GetGroupArticles(groupID int64) ([]Article, error)
 	GetArticleInterestScores(userID int64, articleIDs []int64) (map[int64]float64, error)
-	GetSecurityScores(userID int64, articleIDs []int64) (map[int64]float64, error)
+	GetArticleSecurityScores(articleIDs []int64) (map[int64]float64, error)
 	UpdateGroupSummary(groupID int64, headline, summary string, articleCount int, maxInterestScore *float64) error
 	GetGroupSummary(groupID int64) (*GroupSummary, error)
 	GetUserGroups(userID int64) ([]ArticleGroup, error)


### PR DESCRIPTION
Closes #141. Part of epic #149. Also resolves the conflation in #123 and reduces the security-stage log-spam shape from #111.

## What

Security screening was stored per-user in `read_state`, so the same article was screened once per subscriber and inference cost scaled with users x articles. Maliciousness is a property of the content, not the reader, so this moves the verdict onto the `articles` table: each article is screened exactly once and the result is shared by every subscriber.

## Open-issue scan (the article-pipeline shape factored in)

- **#123** (ai_scored with NULL security): the new `security_screened_at` marker makes "screened but skipped" (set, NULL score) distinct from "not yet screened" (NULL) -- closeable as a side effect.
- **#111** (breaker log-spam): security is now a single global pass that checks the breaker once per cycle instead of once per user x article.
- **#112** (favicon negative-cache): same "don't retry permanently-failing work every cycle" shape -- the `security_attempts` budget plays the favicon negative-cache role for screening.
- **#93** (AI eval harness): screening now uses a single global security prompt, so the harness targets one prompt rather than per-user variants.

## Changes

**Storage** -- new article columns (`security_score`, `security_reason`, `security_flagged`, `security_screened_at`, `security_attempts`) on both SQLite and Postgres, with an idempotent additive migration that backfills from the legacy per-user `read_state` (lowest `user_id`'s score wins). `MarkSecurityScored`/`GetSecurityScores` replaced by article-level `ScreenArticleSecurity`/`SkipArticleSecurity`/`IncrementArticleSecurityAttempts`/`GetArticleSecurityScores`/`GetUnscreenedArticles`. Every surfacing/selection query gates on `articles.security_score`. The cross-DB migration tool carries the verdict.

**Pipeline** -- security is a global once-per-cycle pass (`Stage.RunSecurity`) over the shared unscreened queue; the per-user pipeline starts at summarize and reads the article-level verdict. Per-article retry budget (`security_attempts < 3`) replaces the per-user `ai_retries` gate for screening.

**AI** -- `SecurityCheck` always uses the global security prompt/model/temperature (user_id=0 -> config -> default), never per-user.

## Behavior change to flag

A **custom per-user security prompt** no longer takes effect -- screening is global and objective now. Only curation (relevance) remains per-user. Called out because anyone with a per-user security prompt override today would see it stop applying.

## Tests

- New `security_perarticle_test.go`: migration **backfill** from legacy `read_state` (incl. the #123 skip case), **verdict shared across two subscribers**, and the **skip marker** semantics.
- Updated storage/pipeline tests for the article-level API; `GetProcessingStats` funnel now sources security from the article (assertions unchanged).
- `go test -race ./...`, `go vet`, `golangci-lint`, `govulncheck` all clean. Postgres migration/backfill path exercised by the `eachStore` postgres subtests in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)