### PR TITLE
Discover feeds linked via anchor tags, not just <link rel=alternate>

### DIFF
--- a/internal/feeds/discovery.go
+++ b/internal/feeds/discovery.go
@@ -37,6 +37,16 @@ var feedContentTypes = []string{
 	"application/json",
 }
 
+// feedHrefHints are substrings in an anchor href that suggest it points to a
+// feed. Anchor candidates are always verified by fetching and parsing, so loose
+// hints here only cost an extra probe at worst.
+var feedHrefHints = []string{"rss", "atom", "feed", ".xml", ".rdf"}
+
+// maxFeedProbes bounds how many anchor candidates are fetched and parsed during
+// fallback discovery, so a page littered with feed-like links can't trigger a
+// large fan-out of requests.
+const maxFeedProbes = 15
+
 // commonFeedPaths are probed when HTML autodiscovery finds nothing.
 var commonFeedPaths = []string{
 	"/feed",
@@ -79,12 +89,7 @@ func (f *Fetcher) DiscoverFeeds(ctx context.Context, pageURL string) ([]Discover
 	// If Content-Type suggests a feed, try to parse it directly.
 	if isFeedContentType(resp.Header.Get("Content-Type")) {
 		if parsed, parseErr := f.parser.ParseString(string(body)); parseErr == nil {
-			df := DiscoveredFeed{URL: pageURL, Title: parsed.Title}
-			if parsed.FeedType == "atom" {
-				df.Type = "atom"
-			} else {
-				df.Type = "rss"
-			}
+			df := DiscoveredFeed{URL: pageURL, Title: parsed.Title, Type: feedKind(parsed.FeedType)}
 			return []DiscoveredFeed{df}, nil
 		}
 	}
@@ -96,11 +101,53 @@ func (f *Fetcher) DiscoverFeeds(ctx context.Context, pageURL string) ([]Discover
 		return discovered, nil
 	}
 
+	// Secondary: scan anchor links for feed-like hrefs and verify them. Some
+	// sites (notably SPA blogs such as Paizo's) link feeds with <a> tags in the
+	// body rather than the standard <link rel="alternate"> in <head>.
+	if candidates := extractFeedAnchors(body, base); len(candidates) > 0 {
+		if found := f.verifyFeedCandidates(ctx, candidates); len(found) > 0 {
+			return found, nil
+		}
+	}
+
 	// Fallback: probe common feed paths under the same host.
 	if base != nil {
 		return f.probeFeedPaths(ctx, base), nil
 	}
 	return nil, nil
+}
+
+// verifyFeedCandidates fetches each candidate URL and returns those that parse
+// as feeds. At most maxFeedProbes candidates are tried.
+func (f *Fetcher) verifyFeedCandidates(ctx context.Context, candidates []string) []DiscoveredFeed {
+	var found []DiscoveredFeed
+	for i, candidate := range candidates {
+		if i >= maxFeedProbes {
+			break
+		}
+		result, err := f.FetchFeed(ctx, storage.Feed{URL: candidate})
+		if err != nil || result.NotModified || result.Feed == nil {
+			continue
+		}
+		found = append(found, DiscoveredFeed{
+			URL:   candidate,
+			Title: result.Feed.Title,
+			Type:  feedKind(result.Feed.FeedType),
+		})
+	}
+	return found
+}
+
+// feedKind maps a gofeed FeedType to Herald's feed kind label.
+func feedKind(feedType string) string {
+	switch feedType {
+	case "atom":
+		return "atom"
+	case "json":
+		return "json"
+	default:
+		return "rss"
+	}
 }
 
 // probeFeedPaths tries well-known feed URL paths under the site root and
@@ -114,13 +161,11 @@ func (f *Fetcher) probeFeedPaths(ctx context.Context, base *url.URL) []Discovere
 		if err != nil || result.NotModified || result.Feed == nil {
 			continue
 		}
-		df := DiscoveredFeed{URL: candidate, Title: result.Feed.Title}
-		if result.Feed.FeedType == "atom" {
-			df.Type = "atom"
-		} else {
-			df.Type = "rss"
-		}
-		found = append(found, df)
+		found = append(found, DiscoveredFeed{
+			URL:   candidate,
+			Title: result.Feed.Title,
+			Type:  feedKind(result.Feed.FeedType),
+		})
 	}
 	return found
 }
@@ -187,6 +232,57 @@ func extractFeedLinks(body []byte, base *url.URL) []DiscoveredFeed {
 	}
 	walk(doc)
 	return discovered
+}
+
+// extractFeedAnchors parses the HTML body and returns candidate feed URLs found
+// in anchor (<a>) hrefs whose value hints at a feed (see feedHrefHints). It is a
+// fallback for pages that omit the standard <link rel="alternate"> autodiscovery
+// tags. Hrefs are resolved against base, deduplicated, and returned in document
+// order. Candidates are not guaranteed to be feeds; callers must verify them.
+func extractFeedAnchors(body []byte, base *url.URL) []string {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil
+	}
+
+	var candidates []string
+	seen := make(map[string]bool)
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := strings.TrimSpace(nodeAttrs(n.Attr)["href"])
+			if href != "" && looksLikeFeedHref(href) {
+				resolved := href
+				if base != nil {
+					if ref, err := base.Parse(href); err == nil {
+						resolved = ref.String()
+					}
+				}
+				if !seen[resolved] {
+					seen[resolved] = true
+					candidates = append(candidates, resolved)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return candidates
+}
+
+// looksLikeFeedHref reports whether an anchor href contains a hint that it may
+// point to a feed.
+func looksLikeFeedHref(href string) bool {
+	lower := strings.ToLower(href)
+	for _, hint := range feedHrefHints {
+		if strings.Contains(lower, hint) {
+			return true
+		}
+	}
+	return false
 }
 
 // nodeAttrs converts a slice of html.Attribute into a map for easy lookup.

--- a/internal/feeds/discovery_test.go
+++ b/internal/feeds/discovery_test.go
@@ -60,6 +60,67 @@ func TestDiscoverFeeds_HTMLLinks(t *testing.T) {
 	}
 }
 
+func TestDiscoverFeeds_AnchorLinks(t *testing.T) {
+	// Some sites (e.g. Paizo's Nuxt blog) advertise feeds only via <a> tags in
+	// the body, not the standard <link rel="alternate"> in <head>. The page
+	// links feeds with a query-string scheme under a subpath, which the
+	// common-path probe would never find.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery == "feed=rss" {
+			w.Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
+			fmt.Fprint(w, testRSS)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<!DOCTYPE html><html><head><title>Blog</title></head>
+<body>
+    <a href="/blog/?feed=rss">RSS</a>
+    <a href="/about">About</a>
+</body></html>`)
+	}))
+	defer srv.Close()
+
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	fetcher := NewFetcher(store)
+	results, err := fetcher.DiscoverFeeds(context.Background(), srv.URL+"/blog/")
+	if err != nil {
+		t.Fatalf("DiscoverFeeds: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 feed from anchor discovery, got %d", len(results))
+	}
+	want := srv.URL + "/blog/?feed=rss"
+	if results[0].URL != want {
+		t.Errorf("URL=%q, want %q", results[0].URL, want)
+	}
+	if results[0].Type != "rss" {
+		t.Errorf("Type=%q, want rss", results[0].Type)
+	}
+}
+
+func TestExtractFeedAnchors(t *testing.T) {
+	body := []byte(`<html><body>
+    <a href="/blog/?feed=atom">Atom</a>
+    <a href="/blog/?feed=rss">RSS</a>
+    <a href="/feed.xml">XML</a>
+    <a href="/about">About</a>
+    <a href="https://example.com/news">News</a>
+    <a href="/blog/?feed=rss">RSS dupe</a>
+</body></html>`)
+	got := extractFeedAnchors(body, nil)
+	want := []string{"/blog/?feed=atom", "/blog/?feed=rss", "/feed.xml"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestDiscoverFeeds_RelativeURLResolution(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")


### PR DESCRIPTION
## Problem

`herald` could not discover feeds from https://paizo.com/blog/. Paizo's Nuxt SPA does not use the RSS autodiscovery standard -- it has no `<link rel="alternate">` tags in `<head>`. Instead it links its feeds as ordinary body anchors:

```html
<a href="/blog/?feed=atom">  <a href="/blog/?feed=rss">  <a href="/blog/?feed=json">
```

Discovery only inspected `<link>` tags (and stopped at `<body>`), and the fallback `probeFeedPaths` only tries root-relative paths (`/feed`, `/rss`, `/index.xml`, ...), none of which match a query-string scheme under `/blog/`. So discovery returned nothing.

## Fix

Add a secondary discovery pass, ordered between `<link>` autodiscovery and the common-path probe:

1. `extractFeedAnchors` walks the whole document for `<a>` hrefs hinting at a feed (`rss`/`atom`/`feed`/`.xml`/`.rdf`), resolved and deduped in document order.
2. `verifyFeedCandidates` fetches and parses each candidate so loose hints are safe (non-feeds are filtered out), capped at `maxFeedProbes = 15` to bound fan-out.
3. Factored the gofeed `FeedType` -> kind mapping into `feedKind`, which now also labels JSON feeds correctly (previously collapsed to `"rss"`).

## Verification

- New tests: `TestDiscoverFeeds_AnchorLinks` (end-to-end reproduction) and `TestExtractFeedAnchors` (ordering/dedup/filter).
- Live check against paizo.com now returns all three feeds with correct types (rss/atom/json).
- `go build ./...`, `go test -race ./...`, and `golangci-lint run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)