### PR TITLE
Fix OIDC state mismatch: bump oidclient, reuse in-progress flows

### DIFF
--- a/cmd/herald-web/middleware.go
+++ b/cmd/herald-web/middleware.go
@@ -53,16 +53,14 @@ func (h *handlers) requireAuth(next http.Handler) http.Handler {
 			}
 			var loginURL string
 			if h.validator.FlowConfigured() {
-				verifier := oidclient.GenerateVerifier()
-				state, err := oidclient.GenerateNonce()
+				// Reuse any in-progress flow so concurrent unauthenticated
+				// requests don't overwrite each other's state and fail the
+				// callback with a state mismatch.
+				state, verifier, err := oidclient.GetOrCreateFlow(w, r, returnTo)
 				if err != nil {
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 					return
 				}
-				secure := oidclient.IsSecure(r)
-				oidclient.SetFlowCookie(w, oidclient.CookieVerifier, verifier, secure)
-				oidclient.SetFlowCookie(w, oidclient.CookieState, state, secure)
-				oidclient.SetFlowCookie(w, oidclient.CookieRedirect, returnTo, secure)
 				loginURL = h.validator.AuthorizeURL(state, verifier)
 			} else {
 				loginURL = h.validator.LoginURL(returnTo)

--- a/cmd/herald-web/middleware_test.go
+++ b/cmd/herald-web/middleware_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/infodancer/oidclient"
+)
+
+// Unauthenticated requests that already carry flow cookies must reuse that
+// flow: concurrent 401s (background polls racing a navigation) previously
+// each minted fresh state, overwriting the cookie the winning redirect's
+// callback depended on and failing with a state mismatch.
+func TestRequireAuth_ReusesExistingFlow(t *testing.T) {
+	tf := newTestFixtures(t)
+	validator := newTestValidatorWithOIDC(t, nil)
+	router := newRouter(tf.engine, validator, "", nil)
+
+	// First unauthenticated request starts a flow.
+	req1 := httptest.NewRequest("GET", "/", nil)
+	rr1 := httptest.NewRecorder()
+	router.ServeHTTP(rr1, req1)
+
+	if rr1.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want 302", rr1.Code)
+	}
+	loc1, err := url.Parse(rr1.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state1 := loc1.Query().Get("state")
+	if state1 == "" {
+		t.Fatalf("no state in authorize redirect: %s", loc1)
+	}
+	var flowCookies []*http.Cookie
+	for _, c := range rr1.Result().Cookies() {
+		if c.Name == oidclient.CookieState || c.Name == oidclient.CookieVerifier {
+			flowCookies = append(flowCookies, c)
+		}
+	}
+	if len(flowCookies) != 2 {
+		t.Fatalf("got %d flow cookies, want state and verifier", len(flowCookies))
+	}
+
+	// Second request carrying those cookies must redirect with the same state
+	// and leave the flow cookies alone.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range flowCookies {
+		req2.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
+	}
+	rr2 := httptest.NewRecorder()
+	router.ServeHTTP(rr2, req2)
+
+	if rr2.Code != http.StatusFound {
+		t.Fatalf("second request status: got %d, want 302", rr2.Code)
+	}
+	loc2, err := url.Parse(rr2.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse second redirect: %v", err)
+	}
+	if state2 := loc2.Query().Get("state"); state2 != state1 {
+		t.Errorf("second redirect state = %q, want reused %q", state2, state1)
+	}
+	for _, c := range rr2.Result().Cookies() {
+		if c.Name == oidclient.CookieState || c.Name == oidclient.CookieVerifier {
+			t.Errorf("reuse must not rewrite %s", c.Name)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/infodancer/oidclient v0.1.0
+	github.com/infodancer/oidclient v0.2.0
 	github.com/infodancer/smoke v0.1.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/matthewjhunter/go-embedding v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infodancer/oidclient v0.1.0 h1:RmmVwzf2G38yBnW4TUECn7dXB4lRdSJlQxif48ruWsY=
-github.com/infodancer/oidclient v0.1.0/go.mod h1:6vGWxWv4vVx0xQ0M0pyHuHjh+8Rbp3HKjcLXLC7/280=
+github.com/infodancer/oidclient v0.2.0 h1:eevkDcay9ayd7qdLg4SwbxSvhSOhe118uHryMff3+AI=
+github.com/infodancer/oidclient v0.2.0/go.mod h1:KIAcs6x7xlBKejE3blQc3kp4STlxDC55WtrCCdGbqeE=
 github.com/infodancer/smoke v0.1.0 h1:meBKkJHVtkFwV0NZ2YzOHTn9Fc+JG4flkRfrNd/30yU=
 github.com/infodancer/smoke v0.1.0/go.mod h1:zh5UdP94gj1koedPhrzaaXJbysCyv1x7NiJpWQiSloc=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
Companion to infodancer/oidclient#12, fixing the occasional "invalid state parameter" on /auth/callback.

- **Bump oidclient to v0.2.0**: flow cookies are now session-lifetime instead of 5 minutes, so a webauth login page left open no longer outlives its state cookie. This matters more after infodancer/webauth#72, which lets a stale login form succeed at webauth -- previously it failed there first.
- **requireAuth reuses an in-progress flow** via the new GetOrCreateFlow instead of minting fresh state/verifier on every unauthenticated request. Herald polls (/sidebar every 5 min, summary every 3s), so several 401s can race when the JWT expires; each used to overwrite the state the winning redirect's callback depended on.

New middleware test pins the reuse behavior: a second unauthenticated request carrying the first's flow cookies redirects with the same state and leaves the cookies alone.

`task check` (build, test -race, lint, vulncheck) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)