### PR TITLE
Let the subscribe form accept scheme-less feed URLs

### DIFF
--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -535,6 +535,14 @@ func TestHandleFeedsManage(t *testing.T) {
 	if strings.Contains(body, ">Unscored<") {
 		t.Error("feeds page should no longer use the misleading Unscored header")
 	}
+	// type="url" triggers browser validation that rejects scheme-less input
+	// like "example.com/feed.xml" before the server can add the prefix.
+	if strings.Contains(body, `type="url"`) {
+		t.Error(`subscribe form must not use type="url"; the server handles scheme-less URLs`)
+	}
+	if !strings.Contains(body, `inputmode="url"`) {
+		t.Error(`subscribe URL input should keep inputmode="url" for mobile keyboards`)
+	}
 }
 
 func TestHandleSettings(t *testing.T) {

--- a/cmd/herald-web/templates/feeds_manage.html
+++ b/cmd/herald-web/templates/feeds_manage.html
@@ -75,7 +75,10 @@
         <form hx-post="/feeds/discover" hx-target="#subscribe-result" hx-swap="innerHTML"
               hx-on::after-request="if(event.detail.successful) this.reset();">
             <div class="grid">
-                <input type="url" name="url" placeholder="https://example.com/ or https://example.com/feed.xml" required>
+                {{/* Not type="url": browser validation would reject scheme-less
+                     input, but the server tries https:// then http:// itself. */}}
+                <input type="text" inputmode="url" autocomplete="url" name="url"
+                       placeholder="example.com/ or https://example.com/feed.xml" required>
                 <input type="text" name="title" placeholder="Title (optional)">
                 <button type="submit">Subscribe</button>
             </div>


### PR DESCRIPTION
Adding a feed without an http/https prefix errored. The backend already handles scheme-less input -- `feedURLCandidates` tries `https://` then `http://` for both `SubscribeFeed` and `DiscoverFeeds` -- but the subscribe form's `type="url"` input made the browser reject "example.com/feed.xml" with a validation error before the request was ever sent.

Changed the input to `type="text"` (keeping `inputmode="url"` and `autocomplete="url"` for mobile keyboards and autofill) and updated the placeholder to show that the scheme is optional. Added a regression assertion to `TestHandleFeedsManage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)