### PR TITLE
Backfill site_url for feeds that only return 304

### DIFF
--- a/internal/feeds/fetcher.go
+++ b/internal/feeds/fetcher.go
@@ -374,6 +374,11 @@ func (f *Fetcher) FetchAllFeeds(ctx context.Context) (*FetchStats, error) {
 			if err := f.store.ClearFeedError(feed.ID); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update last_fetched for %s: %v\n", feed.URL, err)
 			}
+			// If site_url was never captured (pre-migration feeds), force a full
+			// fetch next cycle by clearing the cached conditional-request headers.
+			if feed.SiteURL == "" {
+				f.store.UpdateFeedCacheHeaders(feed.ID, "", "")
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- `site_url` (the feed's blog homepage link) is only written during a full HTTP 200 download, not on a 304 Not Modified response
- Feeds added before the `site_url` column migration all got the default empty string; since their ETags are cached, every subsequent fetch cycle returns 304 and skips the update entirely -- so 74 of 85 feeds had no site_url
- When a 304 comes back for a feed with an empty `site_url`, we now clear its conditional-request cache headers so the next cycle forces a full fetch; after that one download, `site_url` is set and normal 304 behavior resumes

No change to `SubscribeFeed` -- new feed subscriptions already capture `site_url` on the initial fetch.

## Test plan

- [ ] Deploy and confirm the next fetch cycle writes `site_url` for previously-empty feeds
- [ ] Confirm subsequent cycles return to 304 behavior for those feeds (cache headers restored after full fetch)
- [ ] Confirm feeds manage page shows linked titles after backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)