### PR TITLE
Two small fixes: 400 on invalid filter threshold, de-brand Majordomo from code

### DIFF
--- a/cmd/herald-mcp/main.go
+++ b/cmd/herald-mcp/main.go
@@ -1,9 +1,8 @@
 // herald-mcp is a standalone, read-only MCP server for the Herald content
 // engine. It connects directly to Herald's SQLite database, serving article
-// and feed tools over JSON-RPC stdio. Designed to run as a per-persona MCP
-// server alongside majordomo-mcp.
+// and feed tools over JSON-RPC stdio.
 //
-// It does no feed fetching or AI processing — that is the `herald daemon`'s
+// It does no feed fetching or AI processing -- that is the `herald daemon`'s
 // job. herald-mcp only reads the database the daemon populates.
 package main
 
@@ -21,7 +20,7 @@ import (
 
 func main() {
 	home, _ := os.UserHomeDir()
-	defaultDB := filepath.Join(home, ".local", "share", "majordomo", "mcp", "herald", "herald.db")
+	defaultDB := filepath.Join(home, ".local", "share", "herald", "herald.db")
 
 	dbPath := flag.String("db", defaultDB, "path to herald database")
 	ollamaURL := flag.String("ollama", "http://localhost:11434", "Ollama base URL")

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1803,6 +1803,11 @@ func (h *handlers) handleFilterThreshold(w http.ResponseWriter, r *http.Request)
 		v = "0"
 	}
 
+	if _, err := strconv.Atoi(v); err != nil {
+		h.renderError(w, http.StatusBadRequest, "filter_threshold must be an integer")
+		return
+	}
+
 	if err := h.engine.SetPreference(uid, "filter_threshold", v); err != nil {
 		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to save threshold: %v", err))
 		return

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -318,10 +318,9 @@ func processCmd() *cobra.Command {
 
 			result.HighInterest = len(highInterestArticles)
 
-			// Use Majordomo format for JSON output, traditional format for others
+			// Use structured cron output format for JSON, traditional format for others
 			if outputFormat == "json" {
-				// Output in Majordomo CommandOutput format
-				return formatter.OutputMajordomoResult(result, userID, highInterestArticles)
+				return formatter.OutputCronResult(result, userID, highInterestArticles)
 			}
 
 			// Output result summary (text/human formats)

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -318,7 +318,7 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
-// CommandOutput represents Majordomo cron command output
+// CommandOutput represents Herald cron command output
 type CommandOutput struct {
 	Text     string            `json:"text"`
 	Title    string            `json:"title,omitempty"`
@@ -328,10 +328,10 @@ type CommandOutput struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// OutputMajordomoResult outputs results for Majordomo cron integration
-func (f *Formatter) OutputMajordomoResult(result *FetchResult, userID int64, highInterestArticles []storage.Article) error {
+// OutputCronResult outputs results for Herald cron integration
+func (f *Formatter) OutputCronResult(result *FetchResult, userID int64, highInterestArticles []storage.Article) error {
 	if f.format != FormatJSON {
-		return fmt.Errorf("majordomo output only supports JSON format")
+		return fmt.Errorf("cron output only supports JSON format")
 	}
 
 	var text strings.Builder

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -202,13 +202,13 @@ func TestOutputHighInterestNotification_JSON(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_EmptyText(t *testing.T) {
+func TestOutputCronResult_EmptyText(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatJSON, &out, &errBuf)
 
 	result := &FetchResult{NewArticles: 5, ProcessedCount: 5, HighInterest: 0}
-	if err := f.OutputMajordomoResult(result, 1, nil); err != nil {
-		t.Fatalf("OutputMajordomoResult failed: %v", err)
+	if err := f.OutputCronResult(result, 1, nil); err != nil {
+		t.Fatalf("OutputCronResult failed: %v", err)
 	}
 
 	var decoded CommandOutput
@@ -224,7 +224,7 @@ func TestOutputMajordomoResult_EmptyText(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_WithArticles(t *testing.T) {
+func TestOutputCronResult_WithArticles(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatJSON, &out, &errBuf)
 
@@ -233,8 +233,8 @@ func TestOutputMajordomoResult_WithArticles(t *testing.T) {
 	}
 	result := &FetchResult{NewArticles: 3, ProcessedCount: 3, HighInterest: 1}
 
-	if err := f.OutputMajordomoResult(result, 1, articles); err != nil {
-		t.Fatalf("OutputMajordomoResult failed: %v", err)
+	if err := f.OutputCronResult(result, 1, articles); err != nil {
+		t.Fatalf("OutputCronResult failed: %v", err)
 	}
 
 	var decoded CommandOutput
@@ -253,12 +253,12 @@ func TestOutputMajordomoResult_WithArticles(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_NonJSON(t *testing.T) {
+func TestOutputCronResult_NonJSON(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatHuman, &out, &errBuf)
 
 	result := &FetchResult{}
-	err := f.OutputMajordomoResult(result, 1, nil)
+	err := f.OutputCronResult(result, 1, nil)
 	if err == nil {
 		t.Fatal("expected error for non-JSON format, got nil")
 	}


### PR DESCRIPTION
## Summary

- **Fix #162**: `handleFilterThreshold` now validates the input as an integer before calling `SetPreference`, returning 400 Bad Request with a user-readable message on invalid input. HTTP 500 is reserved for actual storage failures.
- **Fix #163**: All `Majordomo`/`majordomo` references removed from Go source. `OutputMajordomoResult` renamed to `OutputCronResult`; `CommandOutput` struct comment updated; call-site comments in `cmd/herald/main.go` rewritten; package comment and default DB path in `cmd/herald-mcp/main.go` updated (`~/.local/share/majordomo/...` -> `~/.local/share/herald/...`).

Closes #162, closes #163.

## Test plan

- [ ] `task build` passes
- [ ] `task test` passes (all 11 packages, including updated `TestOutputCronResult_*` tests)
- [ ] Submitting a non-integer filter threshold returns 400, not 500
- [ ] `grep -r majordomo --include='*.go'` returns nothing

Generated with [Claude Code](https://claude.com/claude-code)