### PR TITLE
herald-web: adopt oidclient NewLazy so an IdP outage cannot prevent boot

### DIFF
--- a/cmd/herald-web/degraded_test.go
+++ b/cmd/herald-web/degraded_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/infodancer/oidclient"
+)
+
+// An unreachable IdP must cost sign-in only, never site boot: the router
+// must come up, /health must serve, and auth-dependent endpoints must
+// degrade to 503 rather than crash or redirect to an empty authorize URL.
+// Regression guard for the 2026-06-12 outage pattern (issue #165).
+func TestRouterDegradesWhileIdPUnreachable(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(idp.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	validator, err := oidclient.NewLazy(ctx, oidclient.Config{
+		IssuerURL:   idp.URL,
+		CookieName:  "test_jwt",
+		ClientID:    "herald",
+		CallbackURL: "https://herald.example.com/auth/callback",
+	})
+	if err != nil {
+		t.Fatalf("NewLazy with the IdP down must not fail: %v", err)
+	}
+
+	router := newRouter(tf.engine, validator, "", nil)
+
+	cases := []struct {
+		method, path string
+		want         int
+	}{
+		{"GET", "/health", http.StatusOK},
+		{"GET", "/", http.StatusServiceUnavailable},
+		{"GET", "/articles", http.StatusServiceUnavailable},
+		{"GET", "/auth/callback?code=x&state=y", http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+		if rr.Code != tc.want {
+			t.Errorf("%s %s = %d, want %d", tc.method, tc.path, rr.Code, tc.want)
+		}
+		if loc := rr.Header().Get("Location"); rr.Code == http.StatusServiceUnavailable && loc != "" {
+			t.Errorf("%s %s: degraded response must not redirect (Location=%q)", tc.method, tc.path, loc)
+		}
+	}
+}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -435,6 +435,14 @@ func (h *handlers) handleLogout(w http.ResponseWriter, r *http.Request) {
 // It validates the state nonce, exchanges the code for an access token via PKCE,
 // sets the JWT as an HttpOnly cookie, and redirects to the original URL.
 func (h *handlers) handleCallback(w http.ResponseWriter, r *http.Request) {
+	// A lazy client whose discovery is still pending cannot exchange the
+	// code; degrade this endpoint rather than 502ing mid-flow (#165).
+	if !h.validator.Ready() {
+		log.Printf("herald-web: callback received before provider discovery completed")
+		http.Error(w, "authentication temporarily unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	code := r.URL.Query().Get("code")
 	stateParam := r.URL.Query().Get("state")
 

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -87,22 +87,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// NewLazy boots even when webauth is unreachable: discovery retries in the
+	// background and auth endpoints degrade to 503 until the provider is
+	// ready. An IdP outage must cost sign-in only, never site boot (#165; the
+	// 2026-06-12 osg/sf outage was a crash loop from eager discovery).
 	ctx := context.Background()
-	validator, err := oidclient.New(ctx, oidclient.Config{
+	validator, err := oidclient.NewLazy(ctx, oidclient.Config{
 		IssuerURL:   issuerURL,
 		CookieName:  cookie,
 		WebauthURL:  webauthBaseURL,
 		ClientID:    clientID,
 		ClientName:  "Herald",
 		CallbackURL: callbackURL,
+		Logf:        log.Printf,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "herald-web: %v\n", err)
 		os.Exit(1)
-	}
-	if validator.ClientID() != clientID {
-		log.Printf("herald-web: registered with IdP as client_id=%s (configured=%s ignored — provider supports RFC 7591 dynamic registration)",
-			validator.ClientID(), clientID)
 	}
 
 	engine, err := herald.NewEngine(herald.EngineConfig{

--- a/cmd/herald-web/middleware.go
+++ b/cmd/herald-web/middleware.go
@@ -45,6 +45,13 @@ func (h *handlers) requireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims, err := h.validator.ValidateCookie(r)
 		if err != nil {
+			// While the lazy OIDC client has not completed discovery it can
+			// neither validate cookies nor build an authorize URL; degrade to
+			// 503 rather than bouncing users to a broken IdP (#165).
+			if !h.validator.Ready() {
+				http.Error(w, "sign-in temporarily unavailable -- please try again shortly", http.StatusServiceUnavailable)
+				return
+			}
 			// For HTMX partial requests, the fragment URL (e.g. /sidebar) is not a
 			// meaningful post-login destination — redirect to the home page instead.
 			returnTo := r.URL.RequestURI()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/infodancer/oidclient v0.2.0
+	github.com/infodancer/oidclient v0.3.1
 	github.com/infodancer/smoke v0.1.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/matthewjhunter/go-embedding v0.4.6
@@ -24,7 +24,7 @@ require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
+	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhP
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
-github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -44,8 +44,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infodancer/oidclient v0.2.0 h1:eevkDcay9ayd7qdLg4SwbxSvhSOhe118uHryMff3+AI=
-github.com/infodancer/oidclient v0.2.0/go.mod h1:KIAcs6x7xlBKejE3blQc3kp4STlxDC55WtrCCdGbqeE=
+github.com/infodancer/oidclient v0.3.1 h1:xaQIcVAFAKgOvoZy8DArQyy9t0pxbhMKySwDeykJRnM=
+github.com/infodancer/oidclient v0.3.1/go.mod h1:jSK2NXUBlH+ntfz4eD+4hL/I2+U+7A7vMhxUugt5MrU=
 github.com/infodancer/smoke v0.1.0 h1:meBKkJHVtkFwV0NZ2YzOHTn9Fc+JG4flkRfrNd/30yU=
 github.com/infodancer/smoke v0.1.0/go.mod h1:zh5UdP94gj1koedPhrzaaXJbysCyv1x7NiJpWQiSloc=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
Closes #165.

herald-web exited at startup if OIDC discovery against webauth failed, which turns any IdP outage or misconfiguration into a crash loop and full site downtime -- the same pattern as the 2026-06-12 osg/sf outage. osg and sf already carry the equivalent fix in production.

- Bump oidclient v0.2.0 -> v0.3.1 (adds NewLazy, Ready(), ErrNotReady).
- main.go: NewLazy with Logf wired to log.Printf; the server now boots immediately and discovery retries in the background with exponential backoff.
- requireAuth: when cookie validation fails and the client is not ready, respond 503 instead of redirecting to an empty authorize URL.
- handleCallback: 503 guard while discovery is pending, matching the library's own CallbackHandler.
- New test: router built against an unreachable IdP serves /health 200 while auth-gated routes and the callback degrade to 503 with no redirect.

`task check` passes (test, vet, fmt, lint, vulncheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)