### PR TITLE
Multiuser readiness + public-service hardening (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Security and editorial judgment are different problems that benefit from differe
 - Vector-based article clustering across sources using cosine similarity
 - Per-user interest keywords, thresholds, and read state
 - Customizable AI prompts with 3-tier fallback: database → config → embedded defaults
-- Article summarization with per-user caching
+- Article summarization, cached once per article and shared by all users
 - Conditional feed fetching (ETag / Last-Modified) to minimize bandwidth
 - Formatted notification output for high-interest articles
 - MCP server for AI persona access (26 tools)

--- a/cmd/herald-mcp/main.go
+++ b/cmd/herald-mcp/main.go
@@ -1,9 +1,8 @@
 // herald-mcp is a standalone, read-only MCP server for the Herald content
 // engine. It connects directly to Herald's SQLite database, serving article
-// and feed tools over JSON-RPC stdio. Designed to run as a per-persona MCP
-// server alongside majordomo-mcp.
+// and feed tools over JSON-RPC stdio.
 //
-// It does no feed fetching or AI processing — that is the `herald daemon`'s
+// It does no feed fetching or AI processing -- that is the `herald daemon`'s
 // job. herald-mcp only reads the database the daemon populates.
 package main
 
@@ -21,7 +20,7 @@ import (
 
 func main() {
 	home, _ := os.UserHomeDir()
-	defaultDB := filepath.Join(home, ".local", "share", "majordomo", "mcp", "herald", "herald.db")
+	defaultDB := filepath.Join(home, ".local", "share", "herald", "herald.db")
 
 	dbPath := flag.String("db", defaultDB, "path to herald database")
 	ollamaURL := flag.String("ollama", "http://localhost:11434", "Ollama base URL")

--- a/cmd/herald-mcp/server.go
+++ b/cmd/herald-mcp/server.go
@@ -456,7 +456,8 @@ func registerTools(s *mcp.Server, hs *heraldServer) {
 		if input.RuleID == 0 {
 			return errResult("rule_id parameter is required")
 		}
-		if err := hs.engine.UpdateFilterRule(input.RuleID, input.Score); err != nil {
+		userID := hs.resolveUser(ptrStr(input.Speaker))
+		if err := hs.engine.UpdateFilterRule(userID, input.RuleID, input.Score); err != nil {
 			return errResult("%v", err)
 		}
 		log.Printf("filter_rule_update: id=%d score=%d", input.RuleID, input.Score)
@@ -470,7 +471,8 @@ func registerTools(s *mcp.Server, hs *heraldServer) {
 		if input.RuleID == 0 {
 			return errResult("rule_id parameter is required")
 		}
-		if err := hs.engine.DeleteFilterRule(input.RuleID); err != nil {
+		userID := hs.resolveUser(ptrStr(input.Speaker))
+		if err := hs.engine.DeleteFilterRule(userID, input.RuleID); err != nil {
 			return errResult("%v", err)
 		}
 		log.Printf("filter_rule_delete: id=%d", input.RuleID)

--- a/cmd/herald-mcp/server.go
+++ b/cmd/herald-mcp/server.go
@@ -246,7 +246,8 @@ func registerTools(s *mcp.Server, hs *heraldServer) {
 		if input.GroupID == 0 {
 			return errResult("group_id parameter is required")
 		}
-		group, err := hs.engine.GetGroupArticles(input.GroupID)
+		userID := hs.resolveUser(ptrStr(input.Speaker))
+		group, err := hs.engine.GetGroupArticles(userID, input.GroupID)
 		if err != nil {
 			return errResult("%v", err)
 		}

--- a/cmd/herald-mcp/server_test.go
+++ b/cmd/herald-mcp/server_test.go
@@ -6,13 +6,24 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/matthewjhunter/herald"
+	"github.com/matthewjhunter/herald/internal/feeds"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// TestMain installs a permissive dial control for the entire test binary so
+// that httptest.NewServer (which binds to 127.0.0.1) is reachable from the
+// SSRF-guarded HTTP client.
+func TestMain(m *testing.M) {
+	restore := feeds.UsePermissiveDialForTesting()
+	defer restore()
+	os.Exit(m.Run())
+}
 
 const testRSS = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">

--- a/cmd/herald-mcp/server_test.go
+++ b/cmd/herald-mcp/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/matthewjhunter/herald"
@@ -533,11 +534,16 @@ func TestPromptsListDefaults(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &prompts); err != nil {
 		t.Fatalf("unmarshal prompts: %v", err)
 	}
-	if len(prompts) != 4 {
-		t.Fatalf("got %d prompt types, want 4", len(prompts))
+	// The summarization prompt is global (#162) and hidden from non-admin
+	// users, leaving 3 customizable types.
+	if len(prompts) != 3 {
+		t.Fatalf("got %d prompt types, want 3", len(prompts))
 	}
 
 	for _, p := range prompts {
+		if p.Type == "summarization" {
+			t.Error("summarization prompt must not be listed for a regular user")
+		}
 		if p.Status != "default" {
 			t.Errorf("prompt %q status = %q, want %q", p.Type, p.Status, "default")
 		}
@@ -625,7 +631,7 @@ func TestPromptSetTemperatureOnly(t *testing.T) {
 
 	// Set only temperature (template should be preserved from default)
 	result := mustCallTool(t, session, "prompt_set", map[string]any{
-		"prompt_type": "summarization",
+		"prompt_type": "curation",
 		"temperature": temp,
 	})
 	if result.IsError {
@@ -634,7 +640,7 @@ func TestPromptSetTemperatureOnly(t *testing.T) {
 
 	// Verify template is non-empty (default preserved) and temperature is set
 	result = mustCallTool(t, session, "prompt_get", map[string]any{
-		"prompt_type": "summarization",
+		"prompt_type": "curation",
 	})
 	text := resultText(t, result)
 	var detail herald.PromptDetail
@@ -644,6 +650,22 @@ func TestPromptSetTemperatureOnly(t *testing.T) {
 	}
 	if detail.Temperature != temp {
 		t.Errorf("temperature = %v, want %v", detail.Temperature, temp)
+	}
+}
+
+func TestPromptSetSummarizationRejectedForUser(t *testing.T) {
+	// The summarization prompt is global (#162): a regular user's prompt_set
+	// must be rejected.
+	_, session := newTestSession(t)
+	result := mustCallTool(t, session, "prompt_set", map[string]any{
+		"prompt_type": "summarization",
+		"template":    "Summarize: {{.Content}}",
+	})
+	if !result.IsError {
+		t.Fatal("expected prompt_set to reject the summarization prompt for a regular user")
+	}
+	if text := resultText(t, result); !strings.Contains(text, "global") {
+		t.Errorf("expected a global-prompt error, got %q", text)
 	}
 }
 

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1311,14 +1311,16 @@ func (h *handlers) handleFeedTagRemove(w http.ResponseWriter, r *http.Request) {
 	h.renderFeedTagsCell(w, uid, feedID)
 }
 
-// handleArticleImage serves a cached article image by its ID.
+// handleArticleImage serves a cached article image by its ID. Only users
+// subscribed to the owning article's feed can fetch it (#162).
 func (h *handlers) handleArticleImage(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
 	imageID, err := strconv.ParseInt(r.PathValue("imageID"), 10, 64)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	img, err := h.engine.GetArticleImage(imageID)
+	img, err := h.engine.GetArticleImageForUser(uid, imageID)
 	if err != nil || img == nil {
 		http.NotFound(w, r)
 		return

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1803,6 +1803,11 @@ func (h *handlers) handleFilterThreshold(w http.ResponseWriter, r *http.Request)
 		v = "0"
 	}
 
+	if _, err := strconv.Atoi(v); err != nil {
+		h.renderError(w, http.StatusBadRequest, "filter_threshold must be an integer")
+		return
+	}
+
 	if err := h.engine.SetPreference(uid, "filter_threshold", v); err != nil {
 		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to save threshold: %v", err))
 		return

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -680,7 +680,7 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 
 	// Load group summary banner when viewing a group
 	if groupID > 0 {
-		if group, err := h.engine.GetGroupArticles(groupID); err == nil && group != nil {
+		if group, err := h.engine.GetGroupArticles(uid, groupID); err == nil && group != nil {
 			data.GroupHeadline = group.Headline
 			data.GroupSummary = group.Summary
 		}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1049,6 +1049,11 @@ func (h *handlers) handleNewsletterGenerate(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "invalid id", http.StatusBadRequest)
 		return
 	}
+	nl, err := h.engine.GetNewsletter(id)
+	if err != nil || nl.UserID != uid {
+		h.renderError(w, http.StatusNotFound, "Digest not found")
+		return
+	}
 	if !h.engine.AISummaryEnabled() {
 		fmt.Fprint(w, `<span class="secondary">AI summary not configured.</span>`)
 		return

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -1801,8 +1801,8 @@ func (h *handlers) handleFilterDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.engine.DeleteFilterRule(ruleID); err != nil {
-		h.renderError(w, http.StatusInternalServerError, "Failed to delete rule")
+	if err := h.engine.DeleteFilterRule(uid, ruleID); err != nil {
+		h.renderError(w, http.StatusNotFound, "Rule not found")
 		return
 	}
 

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -76,8 +76,13 @@ type promptUIEntry struct {
 	AvailableModels []string
 }
 
-// promptTypeOrder defines the display order for prompt types in the UI.
-var promptTypeOrder = []string{"curation", "summarization", "group_summary", "newsletter"}
+// userPromptTypeOrder and adminPromptTypeOrder define the display order for
+// prompt types in the UI. The summarization prompt is global (#162) — the
+// summary is shared per-article — so only the admin page shows it.
+var (
+	userPromptTypeOrder  = []string{"curation", "group_summary", "newsletter"}
+	adminPromptTypeOrder = []string{"curation", "summarization", "group_summary", "newsletter"}
+)
 
 var promptLabels = map[string]string{
 	"curation":      "Article Curation",
@@ -86,11 +91,12 @@ var promptLabels = map[string]string{
 	"newsletter":    "Newsletter",
 }
 
-// loadPromptEntries builds the UI entry list for a given userID.
-func (h *handlers) loadPromptEntries(userID int64) []promptUIEntry {
+// loadPromptEntries builds the UI entry list for a given userID and prompt
+// type list (userPromptTypeOrder or adminPromptTypeOrder).
+func (h *handlers) loadPromptEntries(userID int64, promptTypes []string) []promptUIEntry {
 	models, _ := h.engine.ListModels(context.Background())
 	var entries []promptUIEntry
-	for _, pt := range promptTypeOrder {
+	for _, pt := range promptTypes {
 		detail, err := h.engine.GetPrompt(userID, pt)
 		if err != nil {
 			continue
@@ -622,7 +628,7 @@ func (h *handlers) handleSettingsSync(w http.ResponseWriter, r *http.Request) {
 func (h *handlers) handleSettingsPrompts(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
 	data := settingsPromptsData{
-		Prompts: h.loadPromptEntries(uid),
+		Prompts: h.loadPromptEntries(uid, userPromptTypeOrder),
 		IsAdmin: h.isAdminCtx(r.Context()),
 	}
 	h.renderPage(w, r, "settings_prompts.html", data)
@@ -1664,7 +1670,7 @@ type adminPromptsData struct {
 
 func (h *handlers) handleAdminPrompts(w http.ResponseWriter, r *http.Request) {
 	data := adminPromptsData{
-		Prompts: h.loadPromptEntries(0),
+		Prompts: h.loadPromptEntries(0, adminPromptTypeOrder),
 	}
 	h.renderPage(w, r, "admin_prompts.html", data)
 }

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -177,7 +177,7 @@ func (h *handlers) parseTemplates() {
 	shared := []string{"base.html", "nav.html", "settings_subnav.html", "feed_sidebar.html", "article_list.html", "article_row.html", "article_view.html", "search_results.html", "ai_summary_list.html", "ai_summary_detail.html", "error.html"}
 
 	// Pages that get their own template tree.
-	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "stats.html", "status.html", "newsletters_manage.html"}
+	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "admin_users.html", "stats.html", "status.html", "newsletters_manage.html"}
 
 	built := make(map[string]*template.Template, len(pages))
 	for _, page := range pages {
@@ -1998,4 +1998,42 @@ func (h *handlers) handleOPMLTokenGenerate(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprint(w, syncURL)
+}
+
+// --- Admin user management handlers ---
+
+type adminUsersData struct {
+	Users []herald.User
+}
+
+func (h *handlers) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.engine.ListUsers()
+	if err != nil {
+		log.Printf("herald-web: list users failed: %v", err)
+		h.renderError(w, http.StatusInternalServerError, "Failed to load users")
+		return
+	}
+	h.renderPage(w, r, "admin_users.html", adminUsersData{Users: users})
+}
+
+func (h *handlers) handleAdminUserDelete(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("userID")
+	userID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid user ID")
+		return
+	}
+
+	if err := h.engine.DeleteUser(userID); err != nil {
+		log.Printf("herald-web: delete user %d failed: %v", userID, err)
+		if strings.HasPrefix(err.Error(), "refusing to delete reserved user") {
+			h.renderError(w, http.StatusBadRequest, err.Error())
+		} else {
+			h.renderError(w, http.StatusInternalServerError, "Failed to delete user")
+		}
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/admin/users")
+	http.Redirect(w, r, "/admin/users", http.StatusSeeOther)
 }

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -411,8 +411,12 @@ func formatDate(t *time.Time) string {
 }
 
 const (
-	maxPageLimit = 500
-	maxOffset    = 1000000
+	maxPageLimit      = 500
+	maxOffset         = 1000000
+	maxFeedURLLen     = 2048
+	maxTitleLen       = 512
+	maxPromptLen      = 20000
+	maxFilterValueLen = 512
 )
 
 // parseIntParam parses an integer query parameter. If maxVal > 0 and the
@@ -1077,6 +1081,14 @@ func (h *handlers) handleFeedDiscover(w http.ResponseWriter, r *http.Request) {
 		h.renderDiscoverResult(w, rawURL, nil, "Feed URL is required")
 		return
 	}
+	if len(rawURL) > maxFeedURLLen {
+		h.renderDiscoverResult(w, rawURL, nil, "Feed URL is too long")
+		return
+	}
+	if len(title) > maxTitleLen {
+		h.renderDiscoverResult(w, rawURL, nil, "Feed title is too long")
+		return
+	}
 
 	// Happy path: URL is already a valid feed.
 	if err := h.engine.SubscribeFeed(uid, rawURL, title); err == nil {
@@ -1090,8 +1102,9 @@ func (h *handlers) handleFeedDiscover(w http.ResponseWriter, r *http.Request) {
 
 	discovered, err := h.engine.DiscoverFeeds(ctx, rawURL)
 	if err != nil {
+		log.Printf("herald-web: feed discover failed for %q: %v", rawURL, err)
 		h.renderDiscoverResult(w, rawURL, nil,
-			fmt.Sprintf("Could not reach %s: %v", rawURL, err))
+			"Could not reach that URL. Check the address and try again.")
 		return
 	}
 	if len(discovered) == 0 {
@@ -1143,9 +1156,18 @@ func (h *handlers) handleFeedSubscribe(w http.ResponseWriter, r *http.Request) {
 		h.renderError(w, http.StatusBadRequest, "Feed URL is required")
 		return
 	}
+	if len(url) > maxFeedURLLen {
+		h.renderError(w, http.StatusBadRequest, "Feed URL is too long")
+		return
+	}
+	if len(title) > maxTitleLen {
+		h.renderError(w, http.StatusBadRequest, "Feed title is too long")
+		return
+	}
 
 	if err := h.engine.SubscribeFeed(uid, url, title); err != nil {
-		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to subscribe: %v", err))
+		log.Printf("herald-web: subscribe failed for user %d: %v", uid, err)
+		h.renderError(w, http.StatusBadRequest, "Could not subscribe to that feed. Check the URL and try again.")
 		return
 	}
 
@@ -1313,7 +1335,8 @@ func (h *handlers) handleOPMLImport(w http.ResponseWriter, r *http.Request) {
 	defer f.Close()
 
 	if err := h.engine.ImportOPMLReader(f, uid); err != nil {
-		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to import OPML: %v", err))
+		log.Printf("herald-web: OPML import failed for user %d: %v", uid, err)
+		h.renderError(w, http.StatusBadRequest, "Failed to import OPML. Check that the file is valid.")
 		return
 	}
 
@@ -1408,6 +1431,10 @@ func (h *handlers) handleUserPromptSave(w http.ResponseWriter, r *http.Request) 
 		h.renderError(w, http.StatusBadRequest, "Prompt template cannot be empty")
 		return
 	}
+	if len(tmpl) > maxPromptLen {
+		h.renderError(w, http.StatusBadRequest, "Prompt template is too long")
+		return
+	}
 
 	var modelPtr *string
 	if m := strings.TrimSpace(r.FormValue("model")); m != "" {
@@ -1415,7 +1442,8 @@ func (h *handlers) handleUserPromptSave(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.engine.SetPrompt(uid, promptType, tmpl, nil, modelPtr); err != nil {
-		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to save prompt: %v", err))
+		log.Printf("herald-web: save prompt failed for user %d type %q: %v", uid, promptType, err)
+		h.renderError(w, http.StatusBadRequest, "Failed to save prompt.")
 		return
 	}
 
@@ -1438,7 +1466,8 @@ func (h *handlers) handleUserPromptReset(w http.ResponseWriter, r *http.Request)
 	promptType := r.PathValue("promptType")
 
 	if err := h.engine.ResetPrompt(uid, promptType); err != nil {
-		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to reset prompt: %v", err))
+		log.Printf("herald-web: reset prompt failed for user %d type %q: %v", uid, promptType, err)
+		h.renderError(w, http.StatusBadRequest, "Failed to reset prompt.")
 		return
 	}
 
@@ -1639,6 +1668,10 @@ func (h *handlers) handleAdminPromptSave(w http.ResponseWriter, r *http.Request)
 		h.renderError(w, http.StatusBadRequest, "Prompt template cannot be empty")
 		return
 	}
+	if len(tmpl) > maxPromptLen {
+		h.renderError(w, http.StatusBadRequest, "Prompt template is too long")
+		return
+	}
 
 	var modelPtr *string
 	if m := strings.TrimSpace(r.FormValue("model")); m != "" {
@@ -1646,7 +1679,8 @@ func (h *handlers) handleAdminPromptSave(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := h.engine.SetPrompt(0, promptType, tmpl, nil, modelPtr); err != nil {
-		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to save global prompt: %v", err))
+		log.Printf("herald-web: save global prompt failed for type %q: %v", promptType, err)
+		h.renderError(w, http.StatusBadRequest, "Failed to save global prompt.")
 		return
 	}
 
@@ -1659,7 +1693,8 @@ func (h *handlers) handleAdminPromptReset(w http.ResponseWriter, r *http.Request
 	promptType := r.PathValue("promptType")
 
 	if err := h.engine.ResetPrompt(0, promptType); err != nil {
-		h.renderError(w, http.StatusBadRequest, fmt.Sprintf("Failed to reset global prompt: %v", err))
+		log.Printf("herald-web: reset global prompt failed for type %q: %v", promptType, err)
+		h.renderError(w, http.StatusBadRequest, "Failed to reset global prompt.")
 		return
 	}
 
@@ -1724,6 +1759,11 @@ func (h *handlers) handleFilterAdd(w http.ResponseWriter, r *http.Request) {
 	scoreStr := r.FormValue("score")
 	feedIDStr := r.FormValue("feed_id")
 
+	if len(value) > maxFilterValueLen {
+		h.renderError(w, http.StatusBadRequest, "Filter value is too long")
+		return
+	}
+
 	score, err := strconv.Atoi(scoreStr)
 	if err != nil {
 		h.renderError(w, http.StatusBadRequest, "Invalid score")
@@ -1743,7 +1783,8 @@ func (h *handlers) handleFilterAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := h.engine.AddFilterRule(uid, rule); err != nil {
-		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to add rule: %v", err))
+		log.Printf("herald-web: add filter rule failed for user %d: %v", uid, err)
+		h.renderError(w, http.StatusBadRequest, "Could not add filter rule. Check the values and try again.")
 		return
 	}
 
@@ -1780,7 +1821,8 @@ func (h *handlers) handleFilterThreshold(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := h.engine.SetPreference(uid, "filter_threshold", v); err != nil {
-		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to save threshold: %v", err))
+		log.Printf("herald-web: save filter_threshold failed for user %d: %v", uid, err)
+		h.renderError(w, http.StatusInternalServerError, "Failed to save threshold.")
 		return
 	}
 

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -410,7 +410,15 @@ func formatDate(t *time.Time) string {
 	}
 }
 
-func parseIntParam(r *http.Request, name string, defaultVal int) int {
+const (
+	maxPageLimit = 500
+	maxOffset    = 1000000
+)
+
+// parseIntParam parses an integer query parameter. If maxVal > 0 and the
+// parsed value exceeds it, maxVal is returned. Negative or unparseable values
+// fall back to defaultVal.
+func parseIntParam(r *http.Request, name string, defaultVal, maxVal int) int {
 	s := r.URL.Query().Get(name)
 	if s == "" {
 		return defaultVal
@@ -418,6 +426,9 @@ func parseIntParam(r *http.Request, name string, defaultVal int) int {
 	v, err := strconv.Atoi(s)
 	if err != nil || v < 0 {
 		return defaultVal
+	}
+	if maxVal > 0 && v > maxVal {
+		return maxVal
 	}
 	return v
 }
@@ -576,8 +587,8 @@ func (h *handlers) handleSettingsPrompts(w http.ResponseWriter, r *http.Request)
 
 func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
-	limit := parseIntParam(r, "limit", 30)
-	offset := parseIntParam(r, "offset", 0)
+	limit := parseIntParam(r, "limit", 30, maxPageLimit)
+	offset := parseIntParam(r, "offset", 0, maxOffset)
 	feedID := parseInt64Param(r, "feed_id")
 	groupID := parseInt64Param(r, "group_id")
 	starred := r.URL.Query().Get("starred") == "1"
@@ -663,8 +674,8 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 func (h *handlers) handleSearch(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
 	query := r.URL.Query().Get("q")
-	limit := parseIntParam(r, "limit", 30)
-	offset := parseIntParam(r, "offset", 0)
+	limit := parseIntParam(r, "limit", 30, maxPageLimit)
+	offset := parseIntParam(r, "offset", 0, maxOffset)
 
 	if query == "" {
 		h.renderFragment(w, "search_results", searchResultsData{})

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -1957,7 +1958,8 @@ func (h *handlers) handleOPMLSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stored, err := h.engine.GetUserPreference(userID, "opml_sync_token")
-	if err != nil || stored == "" || stored != token {
+	if err != nil || stored == "" ||
+		subtle.ConstantTimeCompare([]byte(stored), []byte(token)) != 1 {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -1295,3 +1295,130 @@ func TestSecurityHeaders(t *testing.T) {
 		}
 	}
 }
+
+// newAdminFixtures builds test fixtures where the test user has admin access.
+func newAdminFixtures(t *testing.T) *testFixtures {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	engine, err := herald.NewEngine(herald.EngineConfig{DBPath: dbPath, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	st, err := storage.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+
+	user, err := engine.GetOrProvisionOIDCUser("test-sub-1", "Tester", "tester@example.com")
+	if err != nil {
+		t.Fatalf("GetOrProvisionOIDCUser: %v", err)
+	}
+
+	validator, issueToken := newTestValidatorIssuer(t)
+	jwtToken := issueToken("test-sub-1", "tester@example.com", "Tester")
+	// Grant admin by listing the test user's email in adminUsers.
+	router := newRouter(engine, validator, "", []string{"tester@example.com"})
+
+	t.Cleanup(func() {
+		engine.Close()
+		st.Close()
+	})
+
+	return &testFixtures{
+		router:     router,
+		engine:     engine,
+		store:      st,
+		userID:     user.ID,
+		jwtToken:   jwtToken,
+		issueToken: issueToken,
+	}
+}
+
+// TestHandleAdminUsers_NonAdminForbidden confirms that a non-admin request to
+// GET /admin/users gets 403.
+func TestHandleAdminUsers_NonAdminForbidden(t *testing.T) {
+	tf := newTestFixtures(t) // no admin email in router
+	rr := authedRequest(t, tf, "GET", "/admin/users", nil)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("GET /admin/users non-admin: got %d, want 403", rr.Code)
+	}
+}
+
+// TestHandleAdminUserDelete_NonAdminForbidden confirms that a non-admin DELETE
+// is rejected with 403 and the user row is not removed.
+func TestHandleAdminUserDelete_NonAdminForbidden(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	// Provision a second user to try to delete.
+	target, err := tf.engine.GetOrProvisionOIDCUser("target-sub", "Target", "target@example.com")
+	if err != nil {
+		t.Fatalf("GetOrProvisionOIDCUser target: %v", err)
+	}
+
+	rr := authedRequest(t, tf, "DELETE", "/admin/users/"+itoa(target.ID), nil)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("DELETE /admin/users/{id} non-admin: got %d, want 403", rr.Code)
+	}
+
+	// Confirm the user still exists.
+	users, err := tf.engine.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	found := false
+	for _, u := range users {
+		if u.ID == target.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("target user should still exist after rejected non-admin delete")
+	}
+}
+
+// TestHandleAdminUserDelete_AdminSuccess confirms that an admin can delete a
+// non-reserved user and that the user is gone afterwards.
+func TestHandleAdminUserDelete_AdminSuccess(t *testing.T) {
+	tf := newAdminFixtures(t)
+
+	// Provision a target user (will get id > 1 because tf.userID is 1).
+	target, err := tf.engine.GetOrProvisionOIDCUser("target-sub", "Target", "target@example.com")
+	if err != nil {
+		t.Fatalf("GetOrProvisionOIDCUser target: %v", err)
+	}
+	if target.ID == tf.userID {
+		t.Fatalf("test assumption broken: target and admin are the same user")
+	}
+
+	rr := authedRequest(t, tf, "DELETE", "/admin/users/"+itoa(target.ID), nil)
+	// Expect a redirect (303) or 200 -- the handler sets HX-Redirect then 303.
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusOK {
+		t.Errorf("DELETE /admin/users/{id} admin: got %d, want 303 or 200", rr.Code)
+	}
+
+	// Confirm the target user is gone.
+	users, err := tf.engine.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	for _, u := range users {
+		if u.ID == target.ID {
+			t.Errorf("target user %d still exists after admin delete", target.ID)
+		}
+	}
+}
+
+// TestHandleAdminUserDelete_ReservedUserRejected confirms that deleting the
+// default/reserved user returns 400.
+func TestHandleAdminUserDelete_ReservedUserRejected(t *testing.T) {
+	tf := newAdminFixtures(t)
+
+	// tf.userID is user 1, which is the DefaultUserID (reserved).
+	rr := authedRequest(t, tf, "DELETE", "/admin/users/"+itoa(tf.userID), nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("DELETE reserved user: got %d, want 400", rr.Code)
+	}
+}

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -1216,3 +1216,82 @@ func TestHandleStarToggle_SubscriptionGated(t *testing.T) {
 		t.Errorf("expected article %d starred for the subscriber, got %v", tf.articleID, starred)
 	}
 }
+
+// --- Plan 007: input validation and security headers ---
+
+// TestPromptSaveLengthCap asserts that a prompt template exceeding maxPromptLen
+// gets a 400 and is not persisted.
+func TestPromptSaveLengthCap(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	// "curation" is a valid user-settable prompt type.
+	overlong := strings.Repeat("x", maxPromptLen+1)
+	rr := authedRequestForm(t, tf, "POST", "/settings/prompts/curation", url.Values{
+		"template": {overlong},
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("overlong prompt: got %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+
+	// A prompt at exactly the limit must be accepted.
+	atLimit := strings.Repeat("x", maxPromptLen)
+	rr = authedRequestForm(t, tf, "POST", "/settings/prompts/curation", url.Values{
+		"template": {atLimit},
+	})
+	if rr.Code != http.StatusOK {
+		t.Errorf("at-limit prompt: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+// TestSubscribeGenericError asserts that a feed-subscribe failure returns 400
+// and does not expose raw error detail (dial strings, DNS, etc.) to the client.
+func TestSubscribeGenericError(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	// 127.0.0.1:1 is an unreachable loopback address that the SSRF dial guard
+	// or TCP stack will reject immediately. We don't care which layer rejects
+	// it -- we just want the error to be generic in the response body.
+	// Route is POST /feeds (not /feeds/subscribe).
+	rr := authedRequestForm(t, tf, "POST", "/feeds", url.Values{
+		"url": {"http://127.0.0.1:1/feed.xml"},
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("failed subscribe: got %d, want 400", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, leak := range []string{"dial", "lookup", "connection refused", "connect:", "127.0.0.1"} {
+		if strings.Contains(strings.ToLower(body), leak) {
+			t.Errorf("response body leaks internal detail %q: %s", leak, body)
+		}
+	}
+}
+
+// TestSecurityHeaders asserts that every authenticated response carries the
+// required security headers when the securityHeaders middleware is applied.
+func TestSecurityHeaders(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	// securityHeaders is wired in main.go but not in newRouter. Wrap manually
+	// here to test the middleware in isolation.
+	wrapped := securityHeaders(tf.router)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "test_jwt", Value: tf.jwtToken})
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /: got %d, want 200", rr.Code)
+	}
+
+	want := map[string]string{
+		"X-Content-Type-Options":  "nosniff",
+		"X-Frame-Options":         "DENY",
+		"Content-Security-Policy": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'",
+	}
+	for header, wantVal := range want {
+		if got := rr.Header().Get(header); got != wantVal {
+			t.Errorf("%s: got %q, want %q", header, got, wantVal)
+		}
+	}
+}

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -1104,3 +1104,103 @@ func TestHandleNewsletterGenerate_Owner(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// --- Subscription gating tests (#162) ---
+
+func TestHandleArticleView_SubscriptionGated(t *testing.T) {
+	tf := newTestFixtures(t)
+	_, otherToken := secondTestUser(t, tf)
+
+	path := "/articles/" + itoa(tf.articleID)
+
+	// A non-subscriber cannot read the article.
+	rr := authedRequestAs(t, tf, otherToken, "GET", path)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("non-subscriber view: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	// The subscriber can.
+	rr = authedRequest(t, tf, "GET", path, map[string]string{"HX-Request": "true"})
+	if rr.Code != http.StatusOK {
+		t.Errorf("subscriber view: got %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	// Unknown IDs 404 for everyone.
+	rr = authedRequest(t, tf, "GET", "/articles/999999", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("unknown article: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleArticleImage_SubscriptionGated(t *testing.T) {
+	tf := newTestFixtures(t)
+	_, otherToken := secondTestUser(t, tf)
+
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	imageID, err := tf.store.StoreArticleImage(tf.articleID, "https://example.com/img.png", png, "image/png", 1, 1)
+	if err != nil {
+		t.Fatalf("StoreArticleImage: %v", err)
+	}
+	path := "/images/" + itoa(imageID)
+
+	// A non-subscriber cannot fetch the image.
+	rr := authedRequestAs(t, tf, otherToken, "GET", path)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("non-subscriber image: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	// The subscriber gets the bytes with the stored MIME type.
+	rr = authedRequest(t, tf, "GET", path, nil)
+	if rr.Code != http.StatusOK {
+		t.Errorf("subscriber image: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+
+	// Unknown IDs 404 for everyone.
+	rr = authedRequest(t, tf, "GET", "/images/999999", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("unknown image: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleStarToggle_SubscriptionGated(t *testing.T) {
+	tf := newTestFixtures(t)
+	otherID, otherToken := secondTestUser(t, tf)
+
+	path := "/articles/" + itoa(tf.articleID) + "/star"
+
+	// A non-subscriber cannot star the article (no form body: the handler
+	// defaults to starring, and the engine rejects before any write).
+	rr := authedRequestAs(t, tf, otherToken, "POST", path)
+	if rr.Code == http.StatusOK {
+		t.Errorf("non-subscriber star: got %d, want an error status", rr.Code)
+	}
+
+	// Prove no starred row was written: subscribe B afterwards (which would
+	// make any starred row visible) and check the starred list is empty.
+	if err := tf.store.SubscribeUserToFeed(otherID, tf.feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed: %v", err)
+	}
+	starred, err := tf.store.GetStarredArticles(otherID, 10, 0, nil)
+	if err != nil {
+		t.Fatalf("GetStarredArticles: %v", err)
+	}
+	if len(starred) != 0 {
+		t.Errorf("rejected star must not write a row, got %d starred", len(starred))
+	}
+
+	// The subscriber can star.
+	rr = authedRequestForm(t, tf, "POST", path, url.Values{"starred": {"true"}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("subscriber star: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	starred, err = tf.store.GetStarredArticles(tf.userID, 10, 0, nil)
+	if err != nil {
+		t.Fatalf("GetStarredArticles A: %v", err)
+	}
+	if len(starred) != 1 || starred[0].ID != tf.articleID {
+		t.Errorf("expected article %d starred for the subscriber, got %v", tf.articleID, starred)
+	}
+}

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -707,19 +707,31 @@ func TestBestDate(t *testing.T) {
 }
 
 func TestParseIntParam(t *testing.T) {
-	req := httptest.NewRequest("GET", "/?limit=25&bad=abc&neg=-5", nil)
+	req := httptest.NewRequest("GET", "/?limit=25&bad=abc&neg=-5&huge=9999", nil)
 
-	if v := parseIntParam(req, "limit", 10); v != 25 {
+	// Basic cases (no cap)
+	if v := parseIntParam(req, "limit", 10, 0); v != 25 {
 		t.Errorf("limit: got %d, want 25", v)
 	}
-	if v := parseIntParam(req, "missing", 10); v != 10 {
+	if v := parseIntParam(req, "missing", 10, 0); v != 10 {
 		t.Errorf("missing: got %d, want 10", v)
 	}
-	if v := parseIntParam(req, "bad", 10); v != 10 {
+	if v := parseIntParam(req, "bad", 10, 0); v != 10 {
 		t.Errorf("bad: got %d, want 10", v)
 	}
-	if v := parseIntParam(req, "neg", 10); v != 10 {
+	if v := parseIntParam(req, "neg", 10, 0); v != 10 {
 		t.Errorf("neg: got %d, want 10", v)
+	}
+
+	// Cap cases
+	if v := parseIntParam(req, "huge", 10, 100); v != 100 {
+		t.Errorf("over-max: got %d, want 100 (capped)", v)
+	}
+	if v := parseIntParam(req, "limit", 10, 50); v != 25 {
+		t.Errorf("under-max: got %d, want 25", v)
+	}
+	if v := parseIntParam(req, "missing", 10, 5); v != 10 {
+		t.Errorf("missing with cap: got %d, want 10 (default)", v)
 	}
 }
 

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -144,6 +145,14 @@ func defaultTokenHandler(issuerURL *string) http.HandlerFunc {
 // (no token endpoint). Returns the client and a valid JWT for the test user.
 func newTestValidator(t *testing.T) (*oidclient.Client, string) {
 	t.Helper()
+	client, issueToken := newTestValidatorIssuer(t)
+	return client, issueToken("test-sub-1", "tester@example.com", "Tester")
+}
+
+// newTestValidatorIssuer is like newTestValidator but returns the token
+// minting function so tests can authenticate as additional users.
+func newTestValidatorIssuer(t *testing.T) (*oidclient.Client, func(sub, email, name string) string) {
+	t.Helper()
 	srv, issueToken := fakeOIDCProvider(t, nil)
 
 	client, err := oidclient.New(context.Background(), oidclient.Config{
@@ -153,9 +162,7 @@ func newTestValidator(t *testing.T) (*oidclient.Client, string) {
 	if err != nil {
 		t.Fatalf("oidclient.New: %v", err)
 	}
-
-	token := issueToken("test-sub-1", "tester@example.com", "Tester")
-	return client, token
+	return client, issueToken
 }
 
 // newTestValidatorWithOIDC creates an oidclient.Client with OIDC flow configured
@@ -189,23 +196,35 @@ func newTestValidatorWithOIDC(t *testing.T, tokenHandler http.HandlerFunc) *oidc
 
 // testFixtures holds all resources for a handler integration test.
 type testFixtures struct {
-	router    http.Handler
-	engine    *herald.Engine
-	store     *storage.SQLiteStore
-	userID    int64
-	feedID    int64
-	articleID int64
-	jwtToken  string // valid JWT for the test user
+	router     http.Handler
+	engine     *herald.Engine
+	store      *storage.SQLiteStore
+	userID     int64
+	feedID     int64
+	articleID  int64
+	jwtToken   string                               // valid JWT for the test user
+	issueToken func(sub, email, name string) string // mints JWTs for additional users
 }
 
 func newTestFixtures(t *testing.T) *testFixtures {
 	t.Helper()
+	return newTestFixturesWith(t, nil)
+}
+
+// newTestFixturesWith builds the standard fixtures, letting the caller tweak
+// the engine config (e.g. point SummaryBaseURL at a fake cloud gateway).
+func newTestFixturesWith(t *testing.T, mutate func(*herald.EngineConfig)) *testFixtures {
+	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 
-	engine, err := herald.NewEngine(herald.EngineConfig{
+	engCfg := herald.EngineConfig{
 		DBPath:   dbPath,
 		ReadOnly: true,
-	})
+	}
+	if mutate != nil {
+		mutate(&engCfg)
+	}
+	engine, err := herald.NewEngine(engCfg)
 	if err != nil {
 		t.Fatalf("NewEngine: %v", err)
 	}
@@ -244,7 +263,8 @@ func newTestFixtures(t *testing.T) *testFixtures {
 		t.Fatalf("AddArticle: %v", err)
 	}
 
-	validator, jwtToken := newTestValidator(t)
+	validator, issueToken := newTestValidatorIssuer(t)
+	jwtToken := issueToken("test-sub-1", "tester@example.com", "Tester")
 	router := newRouter(engine, validator, "", nil)
 
 	t.Cleanup(func() {
@@ -253,14 +273,36 @@ func newTestFixtures(t *testing.T) *testFixtures {
 	})
 
 	return &testFixtures{
-		router:    router,
-		engine:    engine,
-		store:     st,
-		userID:    user.ID,
-		feedID:    feedID,
-		articleID: articleID,
-		jwtToken:  jwtToken,
+		router:     router,
+		engine:     engine,
+		store:      st,
+		userID:     user.ID,
+		feedID:     feedID,
+		articleID:  articleID,
+		jwtToken:   jwtToken,
+		issueToken: issueToken,
 	}
+}
+
+// secondTestUser provisions a second OIDC user and returns its ID and a JWT
+// minted for it, for cross-user authorization tests.
+func secondTestUser(t *testing.T, tf *testFixtures) (int64, string) {
+	t.Helper()
+	u, err := tf.engine.GetOrProvisionOIDCUser("test-sub-2", "Other", "other@example.com")
+	if err != nil {
+		t.Fatalf("GetOrProvisionOIDCUser other: %v", err)
+	}
+	return u.ID, tf.issueToken("test-sub-2", "other@example.com", "Other")
+}
+
+// authedRequestAs makes a test HTTP request authenticated with the given JWT.
+func authedRequestAs(t *testing.T, tf *testFixtures, token, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req.AddCookie(&http.Cookie{Name: "test_jwt", Value: token})
+	rr := httptest.NewRecorder()
+	tf.router.ServeHTTP(rr, req)
+	return rr
 }
 
 // request makes a test HTTP request.
@@ -937,5 +979,128 @@ func TestHandleProcessingStatus(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("status page missing %q", want)
 		}
+	}
+}
+
+// --- Cross-user ownership tests ---
+
+func TestHandleFilterDelete_CrossUser(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	ruleID, err := tf.store.AddFilterRule(&storage.FilterRule{
+		UserID: tf.userID, Axis: "author", Value: "Alice", Score: 5,
+	})
+	if err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	_, otherToken := secondTestUser(t, tf)
+
+	// Another user cannot delete the rule.
+	rr := authedRequestAs(t, tf, otherToken, "DELETE", "/filters/"+itoa(ruleID))
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("cross-user delete: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+	rules, err := tf.engine.GetFilterRules(tf.userID, nil)
+	if err != nil {
+		t.Fatalf("GetFilterRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("rule should survive cross-user delete, got %d rules", len(rules))
+	}
+
+	// The owner can.
+	rr = authedRequest(t, tf, "DELETE", "/filters/"+itoa(ruleID), nil)
+	if rr.Code != http.StatusOK {
+		t.Errorf("owner delete: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	rules, _ = tf.engine.GetFilterRules(tf.userID, nil)
+	if len(rules) != 0 {
+		t.Errorf("expected 0 rules after owner delete, got %d", len(rules))
+	}
+}
+
+func TestHandleNewsletterGenerate_CrossUser(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	nlID, err := tf.store.CreateNewsletter(&storage.Newsletter{
+		UserID: tf.userID, Name: "Mine", Schedule: "manual",
+		Config: storage.NewsletterConfig{MaxArticles: 10},
+	})
+	if err != nil {
+		t.Fatalf("CreateNewsletter: %v", err)
+	}
+	otherID, otherToken := secondTestUser(t, tf)
+
+	rr := authedRequestAs(t, tf, otherToken, "POST", "/newsletters/"+itoa(nlID)+"/generate")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("cross-user generate: got %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	// The victim's newsletter is untouched and no digest row was created for
+	// either user.
+	nl, err := tf.store.GetNewsletter(nlID)
+	if err != nil {
+		t.Fatalf("GetNewsletter: %v", err)
+	}
+	if nl.LastGeneratedAt != nil {
+		t.Errorf("last_generated_at advanced by cross-user generate: %v", nl.LastGeneratedAt)
+	}
+	for _, uid := range []int64{tf.userID, otherID} {
+		if s, _ := tf.store.GetLatestAISummary(uid); s != nil {
+			t.Errorf("unexpected ai_summaries row for user %d: %+v", uid, s)
+		}
+	}
+}
+
+func TestHandleNewsletterGenerate_Owner(t *testing.T) {
+	// Fake cloud gateway so AISummaryEnabled() is true and the background
+	// FinishAISummary finishes quickly against a live endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		delta, _ := json.Marshal(map[string]any{
+			"choices": []map[string]any{{"delta": map[string]any{
+				"content": `{"headline":"H","body":"<p>b</p>"}`,
+			}}},
+		})
+		fmt.Fprintf(w, "data: %s\n\n", delta)
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	tf := newTestFixturesWith(t, func(cfg *herald.EngineConfig) {
+		cfg.SummaryBaseURL = srv.URL
+	})
+
+	nlID, err := tf.store.CreateNewsletter(&storage.Newsletter{
+		UserID: tf.userID, Name: "Mine", Schedule: "manual",
+		Config: storage.NewsletterConfig{MaxArticles: 10},
+	})
+	if err != nil {
+		t.Fatalf("CreateNewsletter: %v", err)
+	}
+
+	rr := authedRequest(t, tf, "POST", "/newsletters/"+itoa(nlID)+"/generate", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("owner generate: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "Generating") {
+		t.Errorf("expected Generating fragment, got %q", rr.Body.String())
+	}
+
+	// Wait for the background FinishAISummary goroutine to settle before the
+	// fixtures tear down (avoids racing engine.Close).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		inprog, err := tf.store.GetInProgressAISummary(tf.userID)
+		if err != nil {
+			t.Fatalf("GetInProgressAISummary: %v", err)
+		}
+		if inprog == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("summary still in progress after 5s")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/cmd/herald-web/main.go
+++ b/cmd/herald-web/main.go
@@ -128,7 +128,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         listenAddr,
-		Handler:      logging(recovery(mux)),
+		Handler:      securityHeaders(logging(recovery(mux))),
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/cmd/herald-web/middleware.go
+++ b/cmd/herald-web/middleware.go
@@ -134,6 +134,22 @@ func (h *handlers) requireAuth(next http.Handler) http.Handler {
 	})
 }
 
+// securityHeaders sets conservative security response headers on every
+// response. The CSP currently permits inline scripts/styles because some
+// templates use them; tightening script-src with nonces is a follow-up.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'")
+		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // logging logs each request with method, path, status, and duration.
 func logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -153,6 +153,8 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("DELETE /admin/prompts/{promptType}", auth(adminAuth(http.HandlerFunc(h.handleAdminPromptReset))), smoke.Example("promptType", "curation"))
 	mux.Handle("GET /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))))
 	mux.Handle("POST /admin/digest", auth(adminAuth(http.HandlerFunc(h.handleAdminDigest))), smoke.Form(url.Values{"header": {"<p>Header</p>"}, "footer": {"<p>Footer</p>"}}))
+	mux.Handle("GET /admin/users", auth(adminAuth(http.HandlerFunc(h.handleAdminUsers))))
+	mux.Handle("DELETE /admin/users/{userID}", auth(adminAuth(http.HandlerFunc(h.handleAdminUserDelete))), smoke.Example("userID", "1"), smoke.Status(400))
 
 	// Smoke manifest introspection — emits the recorded RouteSpecs as JSON for
 	// the smolder runner. Gated on SMOKE_MANIFEST because it enumerates the

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -133,9 +133,10 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	// Ollama model list (used by prompt settings pages).
 	mux.Handle("GET /api/ollama/models", auth(http.HandlerFunc(h.handleOllamaModels)))
 
-	// Per-user AI prompt customization. save targets "summarization"; reset
-	// targets the seeded "curation" prompt so the two don't interact.
-	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Example("promptType", "summarization"), smoke.Form(url.Values{"template": {"Summarize: {{.Content}}"}}))
+	// Per-user AI prompt customization. save targets "group_summary"
+	// ("summarization" is admin-global since #162); reset targets the seeded
+	// "curation" prompt so the two don't interact.
+	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Example("promptType", "group_summary"), smoke.Form(url.Values{"template": {"Summarize the group: {{.Articles}}"}}))
 	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)), smoke.Example("promptType", "curation"))
 
 	// Admin-only routes.

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -422,9 +422,9 @@
       "pattern": "/settings/prompts/{promptType}",
       "effect": "mutating",
       "example_params": {
-        "promptType": "summarization"
+        "promptType": "group_summary"
       },
-      "request_body": "template=Summarize%3A+%7B%7B.Content%7D%7D",
+      "request_body": "template=Summarize+the+group%3A+%7B%7B.Articles%7D%7D",
       "content_type": "application/x-www-form-urlencoded",
       "complete": true
     },

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -54,6 +54,22 @@
     },
     {
       "method": "GET",
+      "pattern": "/admin/users",
+      "effect": "read_only",
+      "complete": true
+    },
+    {
+      "method": "DELETE",
+      "pattern": "/admin/users/{userID}",
+      "effect": "mutating",
+      "example_params": {
+        "userID": "1"
+      },
+      "expect_status": 400,
+      "complete": true
+    },
+    {
+      "method": "GET",
       "pattern": "/api/ollama/models",
       "effect": "read_only",
       "complete": true

--- a/cmd/herald-web/templates/admin_users.html
+++ b/cmd/herald-web/templates/admin_users.html
@@ -1,0 +1,42 @@
+{{define "title"}}Herald - User Management{{end}}
+{{define "nav"}}{{template "shared-nav" "settings"}}{{end}}
+{{define "content"}}
+<main class="container" style="max-width:900px;">
+    {{template "settings-subnav" (dict "Active" "admin-users" "IsAdmin" true)}}
+    <h2>Users</h2>
+
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Created</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Users}}
+            <tr>
+                <td>{{.ID}}</td>
+                <td>{{.Name}}</td>
+                <td>{{if .Email}}{{.Email}}{{else}}<span class="secondary">--</span>{{end}}</td>
+                <td><small class="secondary">{{.CreatedAt.Format "2006-01-02"}}</small></td>
+                <td>
+                    <form method="post" action="/admin/users/{{.ID}}" onsubmit="return confirm('Delete user {{.Name}} and all their data? This cannot be undone.');">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button type="submit" class="secondary" style="padding:0.2rem 0.6rem;font-size:0.85em;"
+                            hx-delete="/admin/users/{{.ID}}"
+                            hx-confirm="Delete user {{.Name}} and all their data? This cannot be undone."
+                            hx-target="closest tr"
+                            hx-swap="outerHTML">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        {{else}}
+            <tr><td colspan="5" class="secondary">No users found.</td></tr>
+        {{end}}
+        </tbody>
+    </table>
+</main>
+{{end}}

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -185,7 +185,8 @@ func importCmd() *cobra.Command {
 			defer store.Close()
 
 			fetcher := feeds.NewFetcher(store)
-			if err := fetcher.ImportOPML(opmlPath, userID); err != nil {
+			// Local CLI import is admin-only and intentionally exempt from the per-user feed cap (pass 0 = unbounded).
+			if err := fetcher.ImportOPML(opmlPath, userID, 0); err != nil {
 				return fmt.Errorf("failed to import OPML: %w", err)
 			}
 

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -318,10 +318,9 @@ func processCmd() *cobra.Command {
 
 			result.HighInterest = len(highInterestArticles)
 
-			// Use Majordomo format for JSON output, traditional format for others
+			// Use structured cron output format for JSON, traditional format for others
 			if outputFormat == "json" {
-				// Output in Majordomo CommandOutput format
-				return formatter.OutputMajordomoResult(result, userID, highInterestArticles)
+				return formatter.OutputCronResult(result, userID, highInterestArticles)
 			}
 
 			// Output result summary (text/human formats)

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -483,19 +483,23 @@ func doFetch(ctx context.Context) error {
 		formatter.Warning("skipping embedding backfill and group matching")
 	}
 
-	// Security screening is global: each article is screened once and the verdict
-	// is shared by every subscriber (#141), so run it once per cycle before the
-	// per-user pipelines rather than re-screening per user. One breaker check,
-	// not one per user (#111).
+	// Security screening and summarization are global: each article is screened
+	// and summarized once, with the verdict and summary shared by every
+	// subscriber (#141, #162), so run both once per cycle before the per-user
+	// pipelines rather than redoing them per user. One breaker check, not one
+	// per user (#111).
 	securityStage := newPipelineStage(store, processor, groupMatcher, formatter, cfg.DefaultUserID)
 	totalProcessed, err := securityStage.RunSecurity(ctx)
 	if err != nil {
 		formatter.Warning("security pass failed: %v", err)
 	}
+	if _, err := securityStage.RunSummaries(ctx); err != nil {
+		formatter.Warning("summarize pass failed: %v", err)
+	}
 
 	// Run the per-user pipeline for each subscribing user. It drives every stage
 	// from its own state-driven, newest-first query, reading the article-level
-	// security verdict to decide what to summarize/curate, so this cycle's freshly
+	// security verdict to decide what to curate, so this cycle's freshly
 	// screened articles are processed ahead of older backlog, and anything left
 	// pending from prior cycles drains the same way. Self-skips when the AI
 	// backend is unavailable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ SQLite schema managed by `internal/storage/schema.go`. Key tables:
 | `read_state` | Per-user read flag, starred flag, interest score, security score |
 | `user_preferences` | Key-value preference store per user (keywords, thresholds, notification settings) |
 | `user_feeds` | Many-to-many subscription mapping between users and feeds |
-| `article_summaries` | Cached AI summaries per user per article |
+| `article_summaries` | Cached AI summaries, one per article, shared by all users |
 | `article_groups` | Topic clusters with centroid embeddings |
 | `article_group_members` | Many-to-many membership between groups and articles |
 | `group_summaries` | Cached group narrative summaries with max interest score |
@@ -158,7 +158,7 @@ SQLite schema managed by `internal/storage/schema.go`. Key tables:
 | `filter_rules` | Scoring rules by author, category, or tag (positive or negative) |
 | `users` | Registered users for multi-user deployments |
 
-Feeds are shared across users; `user_feeds` tracks subscriptions. Articles are stored once; `read_state` tracks per-user scores and read status. Summaries are per-user because different users may have different summarization prompts.
+Feeds are shared across users; `user_feeds` tracks subscriptions. Articles are stored once; `read_state` tracks per-user scores and read status. Summaries are per-article and shared by every subscriber, like the security verdict: each article is summarized once with the global summarization prompt.
 
 ## Prompt System
 
@@ -181,7 +181,7 @@ The five prompt types are:
 
 Each prompt type also has a configurable temperature following the same 3-tier fallback.
 
-The `security` prompt type is intentionally excluded from MCP access — it cannot be viewed or modified through the MCP tools.
+The `security` prompt type is intentionally excluded from MCP access — it cannot be viewed or modified through the MCP tools. The `summarization` prompt is global: summaries are shared per-article, so only the admin (user 0) override applies and per-user customization is rejected.
 
 ## MCP Integration
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -26,6 +26,11 @@ Feedreader uses five different AI prompts:
 | `summarization` | Generate concise article summaries | 0.3 | `{{.Title}}`, `{{.Content}}` |
 | `group_summary` | Create narratives from related articles | 0.5 | `{{.Topic}}`, `{{.Articles}}` |
 
+The `security` and `summarization` prompts are global: their output is a
+property of the article, shared by every subscriber, so only the admin
+(user 0) override, the config file, or the embedded default applies.
+Per-user overrides for these two types are not allowed.
+
 ## Configuration
 
 ### Tier 1: Embedded Defaults (No Configuration Needed)

--- a/engine.go
+++ b/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -637,18 +638,31 @@ func (e *Engine) effectiveIncludeFeeds(userID int64, cfg storage.NewsletterConfi
 }
 
 // feedURLCandidates returns the URLs to attempt for a user-supplied feed
-// input. If the input already contains a scheme it's returned as-is;
-// otherwise https:// is tried first and http:// as a fallback, so a user
-// pasting "example.com/feed.xml" still works.
+// input. If the input already contains a scheme it's returned as-is (provided
+// the scheme is http or https); otherwise https:// is tried first and http://
+// as a fallback, so a user pasting "example.com/feed.xml" still works.
+// Candidates with a scheme other than http/https are dropped; file://, gopher://,
+// ftp://, etc. are never returned.
 func feedURLCandidates(input string) []string {
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return nil
 	}
+	var raw []string
 	if strings.Contains(input, "://") {
-		return []string{input}
+		raw = []string{input}
+	} else {
+		raw = []string{"https://" + input, "http://" + input}
 	}
-	return []string{"https://" + input, "http://" + input}
+	var out []string
+	for _, candidate := range raw {
+		u, err := url.Parse(candidate)
+		if err != nil || !feeds.AllowedFetchScheme(u.Scheme) {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
 }
 
 // SubscribeFeed adds a feed and subscribes the user to it.

--- a/engine.go
+++ b/engine.go
@@ -241,7 +241,7 @@ func (e *Engine) GetArticleForUser(userID, articleID int64) (*Article, error) {
 		return nil, err
 	}
 	result := articleFromInternal(*a)
-	if summary, err := e.store.GetArticleSummary(userID, articleID); err == nil && summary != nil {
+	if summary, err := e.store.GetArticleSummary(articleID); err == nil && summary != nil {
 		result.AISummary = summary.AISummary
 	}
 	return &result, nil
@@ -1118,7 +1118,7 @@ func (e *Engine) GenerateNewsletterIssue(ctx context.Context, userID, newsletter
 			URL:       a.URL,
 			Score:     score,
 		}
-		if summary, err := e.store.GetArticleSummary(userID, a.ID); err == nil && summary != nil {
+		if summary, err := e.store.GetArticleSummary(a.ID); err == nil && summary != nil {
 			input.AISummary = summary.AISummary
 		} else if a.Summary != "" {
 			input.AISummary = a.Summary
@@ -1236,7 +1236,7 @@ func (e *Engine) GenerateBriefing(userID int64) (string, error) {
 		fmt.Fprintf(&briefing, "## %s (%.1f/10)\n", article.Title, score)
 		fmt.Fprintf(&briefing, "%s\n", article.URL)
 
-		if summary, err := e.store.GetArticleSummary(userID, article.ID); err == nil && summary != nil {
+		if summary, err := e.store.GetArticleSummary(article.ID); err == nil && summary != nil {
 			fmt.Fprintf(&briefing, "%s\n", summary.AISummary)
 		} else if article.Summary != "" {
 			fmt.Fprintf(&briefing, "%s\n", article.Summary)
@@ -1355,9 +1355,11 @@ func (e *Engine) GetRecentCycleStats(limit int) ([]CycleStats, error) {
 	return out, nil
 }
 
-// PendingCounts returns the number of articles awaiting AI processing.
+// PendingCounts returns the number of articles awaiting AI processing. The
+// unsummarized count is global — summaries are shared per-article (#162) —
+// while the unscored count stays per-user.
 func (e *Engine) PendingCounts(userID int64) (unsummarized, unscored int, err error) {
-	unsummarized, err = e.store.GetUnsummarizedArticleCount(userID)
+	unsummarized, err = e.store.GetUnsummarizedArticleCount()
 	if err != nil {
 		return 0, 0, err
 	}
@@ -1516,6 +1518,11 @@ func (e *Engine) ListPrompts(userID int64) ([]PromptInfo, error) {
 
 	var result []PromptInfo
 	for pt := range allowedPromptTypes {
+		// The summarization prompt is global (#162): only the admin (user 0)
+		// can see or customize it.
+		if pt == "summarization" && userID != 0 {
+			continue
+		}
 		info := PromptInfo{
 			Type:        pt,
 			Status:      "default",
@@ -1574,6 +1581,11 @@ func (e *Engine) SetPrompt(userID int64, promptType, template string, temp *floa
 	if !allowedPromptTypes[promptType] {
 		return fmt.Errorf("unknown or restricted prompt type: %q", promptType)
 	}
+	// Per-article summaries are shared by all users (#162), so the
+	// summarization prompt is global: only the admin row (user 0) applies.
+	if promptType == "summarization" && userID != 0 {
+		return fmt.Errorf("summarization prompt is global; set it as admin")
+	}
 
 	// If only temperature/model is being set, we need to fetch the existing template
 	if template == "" {
@@ -1599,6 +1611,10 @@ func (e *Engine) SetPrompt(userID int64, promptType, template string, temp *floa
 func (e *Engine) ResetPrompt(userID int64, promptType string) error {
 	if !allowedPromptTypes[promptType] {
 		return fmt.Errorf("unknown or restricted prompt type: %q", promptType)
+	}
+	// See SetPrompt: the summarization prompt is global (#162).
+	if promptType == "summarization" && userID != 0 {
+		return fmt.Errorf("summarization prompt is global; set it as admin")
 	}
 	return e.store.DeleteUserPrompt(userID, promptType)
 }

--- a/engine.go
+++ b/engine.go
@@ -559,12 +559,12 @@ func (e *Engine) MarkArticlesRead(userID int64, articleIDs []int64) error {
 
 // ImportOPML imports feeds from an OPML file and subscribes the user.
 func (e *Engine) ImportOPML(path string, userID int64) error {
-	return e.fetcher.ImportOPML(path, userID)
+	return e.fetcher.ImportOPML(path, userID, e.config.Limits.MaxFeedsPerUser)
 }
 
 // ImportOPMLReader imports feeds from an OPML reader and subscribes the user.
 func (e *Engine) ImportOPMLReader(r io.Reader, userID int64) error {
-	return e.fetcher.ImportOPMLReader(r, userID)
+	return e.fetcher.ImportOPMLReader(r, userID, e.config.Limits.MaxFeedsPerUser)
 }
 
 // GetUserFeeds returns all feeds a user is subscribed to.

--- a/engine.go
+++ b/engine.go
@@ -1708,6 +1708,16 @@ func (e *Engine) ListUsers() ([]User, error) {
 	return result, nil
 }
 
+// DeleteUser removes a user and everything they own. It refuses to delete the
+// global sentinel (user 0, which owns shared/admin prompts) and the configured
+// default user, since those underpin shared state.
+func (e *Engine) DeleteUser(userID int64) error {
+	if userID == 0 || userID == e.config.DefaultUserID {
+		return fmt.Errorf("refusing to delete reserved user %d", userID)
+	}
+	return e.store.DeleteUser(userID)
+}
+
 // GetOrProvisionOIDCUser looks up a Herald user by their OIDC subject claim,
 // creating one if this is their first login. Email is synced on each login.
 func (e *Engine) GetOrProvisionOIDCUser(sub, name, email string) (*User, error) {

--- a/engine.go
+++ b/engine.go
@@ -637,6 +637,15 @@ func (e *Engine) effectiveIncludeFeeds(userID int64, cfg storage.NewsletterConfi
 	return out
 }
 
+// overQuota returns a non-nil error if have >= limit, treating limit <= 0 as
+// unbounded. resource is used in the message ("feeds", "filter rules", ...).
+func overQuota(resource string, have, limit int) error {
+	if limit > 0 && have >= limit {
+		return fmt.Errorf("%s limit reached (%d); delete some before adding more", resource, limit)
+	}
+	return nil
+}
+
 // feedURLCandidates returns the URLs to attempt for a user-supplied feed
 // input. If the input already contains a scheme it's returned as-is (provided
 // the scheme is http or https); otherwise https:// is tried first and http://
@@ -670,6 +679,14 @@ func feedURLCandidates(input string) []string {
 // is unreachable or not a valid RSS/Atom feed. If the URL has no scheme,
 // https:// and http:// are tried in turn.
 func (e *Engine) SubscribeFeed(userID int64, rawURL, title string) error {
+	existingFeeds, err := e.GetUserFeeds(userID)
+	if err != nil {
+		return fmt.Errorf("check feed quota: %w", err)
+	}
+	if err := overQuota("feed", len(existingFeeds), e.config.Limits.MaxFeedsPerUser); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -993,6 +1010,13 @@ func (e *Engine) DisbandGroup(userID, groupID int64) error {
 
 // CreateNewsletter creates a new newsletter definition for a user.
 func (e *Engine) CreateNewsletter(userID int64, name, schedule, emailRecipient, promptTemplate string, config storage.NewsletterConfig) (int64, error) {
+	existingNewsletters, err := e.GetUserNewsletters(userID)
+	if err != nil {
+		return 0, fmt.Errorf("check newsletter quota: %w", err)
+	}
+	if err := overQuota("newsletter", len(existingNewsletters), e.config.Limits.MaxNewslettersPerUser); err != nil {
+		return 0, err
+	}
 	if config.MaxArticles == 0 {
 		config.MaxArticles = 20
 	}
@@ -1730,6 +1754,13 @@ func (e *Engine) AddFilterRule(userID int64, rule FilterRule) (int64, error) {
 	}
 	if rule.Value == "" {
 		return 0, fmt.Errorf("filter rule value cannot be empty")
+	}
+	existingRules, err := e.GetFilterRules(userID, nil)
+	if err != nil {
+		return 0, fmt.Errorf("check filter rule quota: %w", err)
+	}
+	if err := overQuota("filter rule", len(existingRules), e.config.Limits.MaxFilterRulesPerUser); err != nil {
+		return 0, err
 	}
 	sr := &storage.FilterRule{
 		UserID: userID,

--- a/engine.go
+++ b/engine.go
@@ -1834,11 +1834,6 @@ func (e *Engine) GetArticleImageMap(articleID int64) (map[string]int64, error) {
 	return e.store.GetArticleImageMap(articleID)
 }
 
-// GetArticleImage returns a cached image by its ID.
-func (e *Engine) GetArticleImage(imageID int64) (*storage.ArticleImage, error) {
-	return e.store.GetArticleImage(imageID)
-}
-
 // GetArticleImageForUser returns a cached image by its ID when the user is
 // subscribed to the owning article's feed. No access reads as nil, nil —
 // indistinguishable from a missing image, so the handler 404s either way.

--- a/engine.go
+++ b/engine.go
@@ -869,10 +869,14 @@ func (e *Engine) GetUserGroups(userID int64) ([]ArticleGroup, error) {
 }
 
 // GetGroupArticles returns the articles in a specific group with their scores.
-func (e *Engine) GetGroupArticles(groupID int64) (*ArticleGroup, error) {
+// The group must belong to the given user.
+func (e *Engine) GetGroupArticles(userID, groupID int64) (*ArticleGroup, error) {
 	group, err := e.store.GetGroup(groupID)
 	if err != nil {
 		return nil, fmt.Errorf("get group: %w", err)
+	}
+	if group == nil || group.UserID != userID {
+		return nil, fmt.Errorf("group not found or not owned by user")
 	}
 
 	articles, err := e.store.GetGroupArticles(groupID)
@@ -883,16 +887,14 @@ func (e *Engine) GetGroupArticles(groupID int64) (*ArticleGroup, error) {
 	ag := &ArticleGroup{
 		Articles: articlesFromInternal(articles),
 		Count:    len(articles),
-	}
 
-	if group != nil {
-		ag.ID = group.ID
-		ag.UserID = group.UserID
-		ag.Topic = group.Topic
-		ag.DisplayName = group.DisplayName
-		ag.Muted = group.Muted
-		ag.CreatedAt = group.CreatedAt
-		ag.UpdatedAt = group.UpdatedAt
+		ID:          group.ID,
+		UserID:      group.UserID,
+		Topic:       group.Topic,
+		DisplayName: group.DisplayName,
+		Muted:       group.Muted,
+		CreatedAt:   group.CreatedAt,
+		UpdatedAt:   group.UpdatedAt,
 	}
 
 	// Attach summary
@@ -940,6 +942,14 @@ func (e *Engine) MarkGroupRead(userID, groupID int64, before int64) error {
 
 // MuteGroup mutes a group (hides from sidebar) and marks all its articles as read.
 func (e *Engine) MuteGroup(userID, groupID int64) error {
+	// Verify the group belongs to this user
+	group, err := e.store.GetGroup(groupID)
+	if err != nil {
+		return fmt.Errorf("get group: %w", err)
+	}
+	if group == nil || group.UserID != userID {
+		return fmt.Errorf("group not found or not owned by user")
+	}
 	if err := e.store.SetGroupMuted(groupID, true); err != nil {
 		return err
 	}

--- a/engine.go
+++ b/engine.go
@@ -1711,14 +1711,14 @@ func (e *Engine) GetFilterRules(userID int64, feedID *int64) ([]FilterRule, erro
 	return result, nil
 }
 
-// UpdateFilterRule updates the score of an existing filter rule.
-func (e *Engine) UpdateFilterRule(ruleID int64, score int) error {
-	return e.store.UpdateFilterRuleScore(ruleID, score)
+// UpdateFilterRule updates the score of a filter rule owned by the user.
+func (e *Engine) UpdateFilterRule(userID, ruleID int64, score int) error {
+	return e.store.UpdateFilterRuleScore(userID, ruleID, score)
 }
 
-// DeleteFilterRule deletes a filter rule by ID.
-func (e *Engine) DeleteFilterRule(ruleID int64) error {
-	return e.store.DeleteFilterRule(ruleID)
+// DeleteFilterRule deletes a filter rule by ID, scoped to the owning user.
+func (e *Engine) DeleteFilterRule(userID, ruleID int64) error {
+	return e.store.DeleteFilterRule(userID, ruleID)
 }
 
 // GetFeedMetadata returns discoverable authors and categories for a feed.

--- a/engine.go
+++ b/engine.go
@@ -234,8 +234,14 @@ func (e *Engine) GetArticle(articleID int64) (*Article, error) {
 	return &result, nil
 }
 
-// GetArticleForUser returns a single article enriched with its AI summary for the given user.
+// GetArticleForUser returns a single article enriched with its AI summary for
+// the given user. The article must belong to a feed the user is subscribed to;
+// anything else reads as not found (#162).
 func (e *Engine) GetArticleForUser(userID, articleID int64) (*Article, error) {
+	subscribed, err := e.store.UserSubscribedToArticleFeed(userID, articleID)
+	if err != nil || !subscribed {
+		return nil, fmt.Errorf("article %d not found for user %d", articleID, userID)
+	}
 	a, err := e.store.GetArticle(articleID)
 	if err != nil {
 		return nil, err
@@ -1627,8 +1633,13 @@ func (e *Engine) DefaultPrompt(promptType string) (string, error) {
 	return ai.DefaultPrompt(ai.PromptType(promptType))
 }
 
-// StarArticle sets or clears the starred flag on an article.
+// StarArticle sets or clears the starred flag on an article. Only articles
+// from the user's subscribed feeds can be starred (#162).
 func (e *Engine) StarArticle(userID, articleID int64, starred bool) error {
+	subscribed, err := e.store.UserSubscribedToArticleFeed(userID, articleID)
+	if err != nil || !subscribed {
+		return fmt.Errorf("article %d not found for user %d", articleID, userID)
+	}
 	return e.store.UpdateStarred(userID, articleID, starred)
 }
 
@@ -1826,6 +1837,21 @@ func (e *Engine) GetArticleImageMap(articleID int64) (map[string]int64, error) {
 // GetArticleImage returns a cached image by its ID.
 func (e *Engine) GetArticleImage(imageID int64) (*storage.ArticleImage, error) {
 	return e.store.GetArticleImage(imageID)
+}
+
+// GetArticleImageForUser returns a cached image by its ID when the user is
+// subscribed to the owning article's feed. No access reads as nil, nil —
+// indistinguishable from a missing image, so the handler 404s either way.
+func (e *Engine) GetArticleImageForUser(userID, imageID int64) (*storage.ArticleImage, error) {
+	img, err := e.store.GetArticleImage(imageID)
+	if err != nil || img == nil {
+		return img, err
+	}
+	subscribed, err := e.store.UserSubscribedToArticleFeed(userID, img.ArticleID)
+	if err != nil || !subscribed {
+		return nil, nil
+	}
+	return img, nil
 }
 
 func feedFromInternal(f storage.Feed) Feed {

--- a/engine_summary.go
+++ b/engine_summary.go
@@ -115,6 +115,12 @@ func (e *Engine) BeginAISummary(userID int64, newsletterID *int64) (id int64, pr
 	if e.summarizer == nil {
 		return 0, "", fmt.Errorf("AI summary not configured")
 	}
+	if newsletterID != nil {
+		nl, nerr := e.store.GetNewsletter(*newsletterID)
+		if nerr != nil || nl == nil || nl.UserID != userID {
+			return 0, "", fmt.Errorf("newsletter not found or not owned by user")
+		}
+	}
 	if inprog, ierr := e.store.GetInProgressAISummary(userID); ierr == nil && inprog != nil {
 		return inprog.ID, "", fmt.Errorf("a summary is already generating")
 	}

--- a/engine_summary_test.go
+++ b/engine_summary_test.go
@@ -293,3 +293,41 @@ func TestGenerateForConfig(t *testing.T) {
 		t.Fatalf("chrome not wrapped: %s", wrapped)
 	}
 }
+
+func TestBeginAISummaryNewsletterOwnership(t *testing.T) {
+	srv := digestServer(t)
+	defer srv.Close()
+	store, err := storage.NewSQLiteStore(filepath.Join(t.TempDir(), "h.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	userA, _ := store.CreateUser("a")
+	userB, _ := store.CreateUser("b")
+	nlID, err := store.CreateNewsletter(&storage.Newsletter{
+		UserID: userA, Name: "A digest", Schedule: "manual",
+		Config: storage.NewsletterConfig{MaxArticles: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Engine{
+		store:      store,
+		summarizer: ai.NewCloudSummarizer(srv.URL, "", "m", time.Minute, false),
+		config:     storage.DefaultConfig(),
+	}
+
+	// Another user cannot generate against A's newsletter config.
+	if _, _, err := e.BeginAISummary(userB, &nlID); err == nil || !strings.Contains(err.Error(), "not owned") {
+		t.Fatalf("expected not-owned error, got %v", err)
+	}
+	if inprog, _ := store.GetInProgressAISummary(userB); inprog != nil {
+		t.Errorf("no generating row should exist for user B, got %+v", inprog)
+	}
+
+	// The owner can.
+	if _, _, err := e.BeginAISummary(userA, &nlID); err != nil {
+		t.Fatalf("owner BeginAISummary: %v", err)
+	}
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -277,7 +277,7 @@ func TestGroupLifecycle(t *testing.T) {
 	}
 
 	// Get group articles
-	group, err := engine.GetGroupArticles(groupID)
+	group, err := engine.GetGroupArticles(1, groupID)
 	if err != nil {
 		t.Fatalf("GetGroupArticles: %v", err)
 	}
@@ -293,13 +293,9 @@ func TestGetGroupArticlesNotFound(t *testing.T) {
 	engine, cleanup := newTestEngine(t)
 	defer cleanup()
 
-	group, err := engine.GetGroupArticles(999)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// Empty group is fine, not an error
-	if len(group.Articles) != 0 {
-		t.Errorf("expected 0 articles, got %d", len(group.Articles))
+	group, err := engine.GetGroupArticles(1, 999)
+	if err == nil {
+		t.Fatalf("expected error for missing group, got group %+v", group)
 	}
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -209,7 +209,15 @@ func TestGetArticleForUser(t *testing.T) {
 		t.Errorf("AISummary: got %q", article.AISummary)
 	}
 
-	// The summary is a property of the article (#162): every user sees it.
+	// A non-subscriber cannot read the article at all (#162).
+	if _, err := engine.GetArticleForUser(2, articleID); err == nil {
+		t.Fatal("expected error for a user not subscribed to the feed")
+	}
+
+	// The summary is a property of the article (#162): every subscriber sees it.
+	if err := engine.store.SubscribeUserToFeed(2, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed: %v", err)
+	}
 	article, err = engine.GetArticleForUser(2, articleID)
 	if err != nil {
 		t.Fatalf("GetArticleForUser user 2: %v", err)

--- a/engine_test.go
+++ b/engine_test.go
@@ -470,7 +470,7 @@ func TestFilterRulesCRUD(t *testing.T) {
 	}
 
 	// Update score
-	if err := engine.UpdateFilterRule(id, 10); err != nil {
+	if err := engine.UpdateFilterRule(userID, id, 10); err != nil {
 		t.Fatalf("UpdateFilterRule: %v", err)
 	}
 	rules, _ = engine.GetFilterRules(userID, nil)
@@ -479,7 +479,7 @@ func TestFilterRulesCRUD(t *testing.T) {
 	}
 
 	// Delete
-	if err := engine.DeleteFilterRule(id); err != nil {
+	if err := engine.DeleteFilterRule(userID, id); err != nil {
 		t.Fatalf("DeleteFilterRule: %v", err)
 	}
 	rules, _ = engine.GetFilterRules(userID, nil)

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,13 +1,27 @@
 package herald
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/matthewjhunter/herald/internal/feeds"
 	"github.com/matthewjhunter/herald/internal/storage"
 )
+
+// TestMain installs a permissive dial control for the entire test binary so
+// that httptest.NewServer (which binds to 127.0.0.1) is reachable for the
+// feed-quota tests that call SubscribeFeed against a local server.
+func TestMain(m *testing.M) {
+	restore := feeds.UsePermissiveDialForTesting()
+	defer restore()
+	os.Exit(m.Run())
+}
 
 func newTestEngine(t *testing.T) (*Engine, func()) {
 	t.Helper()
@@ -895,5 +909,142 @@ func TestSummarizationPromptIsGlobal(t *testing.T) {
 	}
 	if !hasSummarization(adminPrompts) {
 		t.Error("ListPrompts(0) must include the summarization prompt")
+	}
+}
+
+// --- Per-user quota tests ---
+
+// minimalRSSHandler returns an http.Handler serving a tiny valid RSS feed.
+const minimalRSS = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <guid>item-1</guid>
+      <title>Test Article</title>
+      <link>https://example.com/1</link>
+    </item>
+  </channel>
+</rss>`
+
+func rssHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, minimalRSS)
+	})
+}
+
+func TestFeedQuota(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+	engine.config.Limits.MaxFeedsPerUser = 2
+
+	userID := int64(1)
+
+	srv1 := httptest.NewServer(rssHandler())
+	defer srv1.Close()
+	srv2 := httptest.NewServer(rssHandler())
+	defer srv2.Close()
+	srv3 := httptest.NewServer(rssHandler())
+	defer srv3.Close()
+
+	if err := engine.SubscribeFeed(userID, srv1.URL, "Feed 1"); err != nil {
+		t.Fatalf("first SubscribeFeed: %v", err)
+	}
+	if err := engine.SubscribeFeed(userID, srv2.URL, "Feed 2"); err != nil {
+		t.Fatalf("second SubscribeFeed: %v", err)
+	}
+
+	err := engine.SubscribeFeed(userID, srv3.URL, "Feed 3")
+	if err == nil {
+		t.Fatal("expected error on third SubscribeFeed (limit 2)")
+	}
+	if !strings.Contains(err.Error(), "limit reached") {
+		t.Errorf("error should contain 'limit reached', got: %v", err)
+	}
+
+	got, err := engine.GetUserFeeds(userID)
+	if err != nil {
+		t.Fatalf("GetUserFeeds: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 feeds after quota block, got %d", len(got))
+	}
+}
+
+func TestFilterRuleQuota(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+	engine.config.Limits.MaxFilterRulesPerUser = 1
+
+	userID := int64(1)
+
+	_, err := engine.AddFilterRule(userID, FilterRule{Axis: "author", Value: "Alice", Score: 1})
+	if err != nil {
+		t.Fatalf("first AddFilterRule: %v", err)
+	}
+
+	_, err = engine.AddFilterRule(userID, FilterRule{Axis: "author", Value: "Bob", Score: 1})
+	if err == nil {
+		t.Fatal("expected error on second AddFilterRule (limit 1)")
+	}
+	if !strings.Contains(err.Error(), "limit reached") {
+		t.Errorf("error should contain 'limit reached', got: %v", err)
+	}
+}
+
+func TestNewsletterQuota(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+	engine.config.Limits.MaxNewslettersPerUser = 1
+
+	userID, err := engine.RegisterUser("testuser")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+
+	_, err = engine.CreateNewsletter(userID, "Weekly", "", "", "", storage.NewsletterConfig{})
+	if err != nil {
+		t.Fatalf("first CreateNewsletter: %v", err)
+	}
+
+	_, err = engine.CreateNewsletter(userID, "Daily", "", "", "", storage.NewsletterConfig{})
+	if err == nil {
+		t.Fatal("expected error on second CreateNewsletter (limit 1)")
+	}
+	if !strings.Contains(err.Error(), "limit reached") {
+		t.Errorf("error should contain 'limit reached', got: %v", err)
+	}
+}
+
+func TestQuotaUnbounded(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+	// limit 0 = unbounded for all three resources
+	engine.config.Limits.MaxFeedsPerUser = 0
+	engine.config.Limits.MaxFilterRulesPerUser = 0
+	engine.config.Limits.MaxNewslettersPerUser = 0
+
+	// Filter rules use userID=1 (no user FK on filter_rules)
+	filterUserID := int64(1)
+	for i := range 3 {
+		_, err := engine.AddFilterRule(filterUserID, FilterRule{
+			Axis: "author", Value: fmt.Sprintf("Author%d", i), Score: 1,
+		})
+		if err != nil {
+			t.Fatalf("AddFilterRule %d with limit=0: %v", i, err)
+		}
+	}
+
+	// Newsletters require the user to exist (FK to users table)
+	nlUserID, err := engine.RegisterUser("unbounded-user")
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	for i := range 3 {
+		_, err := engine.CreateNewsletter(nlUserID, fmt.Sprintf("NL%d", i), "", "", "", storage.NewsletterConfig{})
+		if err != nil {
+			t.Fatalf("CreateNewsletter %d with limit=0: %v", i, err)
+		}
 	}
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -842,3 +842,50 @@ func TestGetGroupArticlesCrossUser(t *testing.T) {
 		t.Errorf("unexpected group: %+v", group)
 	}
 }
+
+func TestSummarizationPromptIsGlobal(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	// A regular user can neither set nor reset the summarization prompt.
+	if err := engine.SetPrompt(1, "summarization", "mine: {{.Content}}", nil, nil); err == nil ||
+		!strings.Contains(err.Error(), "global") {
+		t.Fatalf("expected global-prompt rejection for SetPrompt, got %v", err)
+	}
+	if err := engine.ResetPrompt(1, "summarization"); err == nil ||
+		!strings.Contains(err.Error(), "global") {
+		t.Fatalf("expected global-prompt rejection for ResetPrompt, got %v", err)
+	}
+
+	// The admin (user 0) can.
+	if err := engine.SetPrompt(0, "summarization", "admin: {{.Content}}", nil, nil); err != nil {
+		t.Fatalf("admin SetPrompt: %v", err)
+	}
+	if err := engine.ResetPrompt(0, "summarization"); err != nil {
+		t.Fatalf("admin ResetPrompt: %v", err)
+	}
+
+	// ListPrompts hides the type from regular users and shows it to the admin.
+	hasSummarization := func(prompts []PromptInfo) bool {
+		for _, p := range prompts {
+			if p.Type == "summarization" {
+				return true
+			}
+		}
+		return false
+	}
+	userPrompts, err := engine.ListPrompts(1)
+	if err != nil {
+		t.Fatalf("ListPrompts(1): %v", err)
+	}
+	if hasSummarization(userPrompts) {
+		t.Error("ListPrompts(1) must omit the summarization prompt")
+	}
+	adminPrompts, err := engine.ListPrompts(0)
+	if err != nil {
+		t.Fatalf("ListPrompts(0): %v", err)
+	}
+	if !hasSummarization(adminPrompts) {
+		t.Error("ListPrompts(0) must include the summarization prompt")
+	}
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -199,7 +199,7 @@ func TestGetArticleForUser(t *testing.T) {
 	}
 
 	// Store an AI summary and verify it's returned
-	engine.store.UpdateArticleAISummary(1, articleID, "This is the AI-generated summary.")
+	engine.store.UpdateArticleAISummary(articleID, "This is the AI-generated summary.")
 
 	article, err = engine.GetArticleForUser(1, articleID)
 	if err != nil {
@@ -209,13 +209,13 @@ func TestGetArticleForUser(t *testing.T) {
 		t.Errorf("AISummary: got %q", article.AISummary)
 	}
 
-	// Different user should not see user 1's summary
+	// The summary is a property of the article (#162): every user sees it.
 	article, err = engine.GetArticleForUser(2, articleID)
 	if err != nil {
 		t.Fatalf("GetArticleForUser user 2: %v", err)
 	}
-	if article.AISummary != "" {
-		t.Errorf("expected empty AISummary for user 2, got %q", article.AISummary)
+	if article.AISummary != "This is the AI-generated summary." {
+		t.Errorf("expected the shared AISummary for user 2, got %q", article.AISummary)
 	}
 }
 
@@ -350,7 +350,7 @@ func TestGetFeedStats(t *testing.T) {
 	engine.store.UpdateReadState(1, id1, true, nil, nil, nil, nil)
 
 	// Summarize one article in feed 2
-	engine.store.UpdateArticleAISummary(1, id4, "Summary of article 4")
+	engine.store.UpdateArticleAISummary(id4, "Summary of article 4")
 
 	result, err := engine.GetFeedStats(1)
 	if err != nil {

--- a/engine_test.go
+++ b/engine_test.go
@@ -779,7 +779,7 @@ func TestFeedURLCandidates(t *testing.T) {
 	}{
 		{"https://example.com/feed", []string{"https://example.com/feed"}},
 		{"http://example.com/feed", []string{"http://example.com/feed"}},
-		{"feed://example.com/feed", []string{"feed://example.com/feed"}},
+		{"feed://example.com/feed", nil}, // non-http(s) scheme rejected
 		{"example.com", []string{"https://example.com", "http://example.com"}},
 		{"example.com/feed.xml", []string{"https://example.com/feed.xml", "http://example.com/feed.xml"}},
 		{"  example.com  ", []string{"https://example.com", "http://example.com"}},

--- a/engine_test.go
+++ b/engine_test.go
@@ -791,3 +791,54 @@ func TestFeedURLCandidates(t *testing.T) {
 		}
 	}
 }
+
+func TestMuteGroupCrossUser(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	groupID, err := engine.store.CreateArticleGroup(1, "Owned by user 1")
+	if err != nil {
+		t.Fatalf("CreateArticleGroup: %v", err)
+	}
+
+	if err := engine.MuteGroup(2, groupID); err == nil {
+		t.Fatal("expected error muting another user's group")
+	}
+	muted, err := engine.store.IsGroupMuted(groupID)
+	if err != nil {
+		t.Fatalf("IsGroupMuted: %v", err)
+	}
+	if muted {
+		t.Error("group should not be muted after cross-user MuteGroup")
+	}
+
+	// The owner can mute it.
+	if err := engine.MuteGroup(1, groupID); err != nil {
+		t.Fatalf("owner MuteGroup: %v", err)
+	}
+	if muted, _ := engine.store.IsGroupMuted(groupID); !muted {
+		t.Error("group should be muted after owner MuteGroup")
+	}
+}
+
+func TestGetGroupArticlesCrossUser(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	groupID, err := engine.store.CreateArticleGroup(1, "Owned by user 1")
+	if err != nil {
+		t.Fatalf("CreateArticleGroup: %v", err)
+	}
+
+	if _, err := engine.GetGroupArticles(2, groupID); err == nil {
+		t.Fatal("expected error reading another user's group")
+	}
+
+	group, err := engine.GetGroupArticles(1, groupID)
+	if err != nil {
+		t.Fatalf("owner GetGroupArticles: %v", err)
+	}
+	if group.ID != groupID || group.Topic != "Owned by user 1" {
+		t.Errorf("unexpected group: %+v", group)
+	}
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -1048,3 +1048,37 @@ func TestQuotaUnbounded(t *testing.T) {
 		}
 	}
 }
+
+// TestDeleteUserGuard confirms that DeleteUser refuses to delete the global
+// sentinel (0) and the configured default user (1 by default).
+func TestDeleteUserGuard(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	// Sentinel user 0.
+	if err := engine.DeleteUser(0); err == nil {
+		t.Error("expected error deleting sentinel user 0, got nil")
+	}
+
+	// Default user (id 1 in a fresh DB where DefaultUserID defaults to 1).
+	if err := engine.DeleteUser(engine.config.DefaultUserID); err == nil {
+		t.Errorf("expected error deleting default user %d, got nil", engine.config.DefaultUserID)
+	}
+
+	// A real non-reserved user must be deletable.
+	// Register two users: the first will get id=1 which equals DefaultUserID,
+	// so register a second one to get a genuinely non-reserved id.
+	if _, err2 := engine.RegisterUser("default-placeholder"); err2 != nil {
+		t.Fatalf("RegisterUser placeholder: %v", err2)
+	}
+	id, err2 := engine.RegisterUser("to-be-deleted")
+	if err2 != nil {
+		t.Fatalf("RegisterUser: %v", err2)
+	}
+	if id == engine.config.DefaultUserID || id == 0 {
+		t.Fatalf("test assumption broken: to-be-deleted got reserved id %d", id)
+	}
+	if err2 := engine.DeleteUser(id); err2 != nil {
+		t.Errorf("DeleteUser(%d) unexpected error: %v", id, err2)
+	}
+}

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -74,6 +74,11 @@ type openAIClient struct {
 	// to half-open. Exposed as a field for tests.
 	breakerCooldown time.Duration
 
+	// sem bounds the number of in-flight generate() calls in this process.
+	// nil when unbounded (MaxConcurrent <= 0). A buffered channel is the
+	// idiomatic counting semaphore.
+	sem chan struct{}
+
 	mu             sync.Mutex
 	consecutive4xx int
 	circuitOpen    bool
@@ -81,13 +86,17 @@ type openAIClient struct {
 	lastStatus     int
 }
 
-func newOpenAIClient(baseURL, apiKey string) *openAIClient {
-	return &openAIClient{
+func newOpenAIClient(baseURL, apiKey string, maxConcurrent int) *openAIClient {
+	c := &openAIClient{
 		baseURL:         strings.TrimRight(baseURL, "/"),
 		apiKey:          apiKey,
 		httpClient:      &http.Client{},
 		breakerCooldown: defaultBreakerCooldown,
 	}
+	if maxConcurrent > 0 {
+		c.sem = make(chan struct{}, maxConcurrent)
+	}
+	return c
 }
 
 // tripBreaker increments the consecutive 4xx counter and trips the circuit
@@ -189,6 +198,15 @@ func (c *openAIClient) generate(ctx context.Context, model, prompt string, tempe
 		return "", &ClientError{
 			StatusCode: 0,
 			Body:       fmt.Sprintf("circuit breaker open — AI calls blocked after repeated HTTP %d responses; retrying after cooldown", status),
+		}
+	}
+
+	if c.sem != nil {
+		select {
+		case c.sem <- struct{}{}:
+			defer func() { <-c.sem }()
+		case <-ctx.Done():
+			return "", ctx.Err()
 		}
 	}
 

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ func TestGenerateReportsBackendUnavailable(t *testing.T) {
 			w.Write([]byte(`{"error":"model not found"}`))
 		}))
 		defer srv.Close()
-		_, err := newOpenAIClient(srv.URL, "k").generate(ctx, "m", "hi", 0.7)
+		_, err := newOpenAIClient(srv.URL, "k", 0).generate(ctx, "m", "hi", 0.7)
 		if !errors.Is(err, ErrBackendUnavailable) {
 			t.Fatalf("4xx: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
 		}
@@ -37,7 +38,7 @@ func TestGenerateReportsBackendUnavailable(t *testing.T) {
 			w.Write([]byte("upstream down"))
 		}))
 		defer srv.Close()
-		_, err := newOpenAIClient(srv.URL, "k").generate(ctx, "m", "hi", 0.7)
+		_, err := newOpenAIClient(srv.URL, "k", 0).generate(ctx, "m", "hi", 0.7)
 		if !errors.Is(err, ErrBackendUnavailable) {
 			t.Fatalf("5xx: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
 		}
@@ -48,7 +49,7 @@ func TestGenerateReportsBackendUnavailable(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 		url := srv.URL
 		srv.Close()
-		_, err := newOpenAIClient(url, "k").generate(ctx, "m", "hi", 0.7)
+		_, err := newOpenAIClient(url, "k", 0).generate(ctx, "m", "hi", 0.7)
 		if !errors.Is(err, ErrBackendUnavailable) {
 			t.Fatalf("transport: errors.Is(ErrBackendUnavailable) = false; err=%T %v", err, err)
 		}
@@ -60,7 +61,7 @@ func TestGenerateReportsBackendUnavailable(t *testing.T) {
 			w.Write([]byte(`{"error":"unauthorized"}`))
 		}))
 		defer srv.Close()
-		c := newOpenAIClient(srv.URL, "bad")
+		c := newOpenAIClient(srv.URL, "bad", 0)
 		for range clientBreakerThreshold {
 			c.generate(ctx, "m", "hi", 0.7) //nolint:errcheck
 		}
@@ -84,7 +85,7 @@ func TestBackendAvailableTracksBreaker(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "bad")
+	c := newOpenAIClient(srv.URL, "bad", 0)
 	c.breakerCooldown = 10 * time.Millisecond
 	p := &AIProcessor{client: c}
 	ctx := context.Background()
@@ -116,7 +117,7 @@ func TestCircuitBreakerTripsAfterConsecutive4xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "bad-key")
+	c := newOpenAIClient(srv.URL, "bad-key", 0)
 	ctx := context.Background()
 
 	// First clientBreakerThreshold calls should each return ClientError.
@@ -165,7 +166,7 @@ func TestCircuitBreakerResetsOnSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "key")
+	c := newOpenAIClient(srv.URL, "key", 0)
 	ctx := context.Background()
 
 	// Run up to threshold-1 failures.
@@ -210,7 +211,7 @@ func TestCircuitBreakerHalfOpenAfterCooldown(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "key")
+	c := newOpenAIClient(srv.URL, "key", 0)
 	c.breakerCooldown = 50 * time.Millisecond
 	ctx := context.Background()
 
@@ -261,7 +262,7 @@ func TestCircuitBreakerRecoversFrom401(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "bad-key")
+	c := newOpenAIClient(srv.URL, "bad-key", 0)
 	c.breakerCooldown = 50 * time.Millisecond
 	ctx := context.Background()
 
@@ -312,7 +313,7 @@ func TestCircuitBreakerIgnores5xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "key")
+	c := newOpenAIClient(srv.URL, "key", 0)
 	ctx := context.Background()
 
 	// 5xx errors should NOT trip the breaker.
@@ -349,7 +350,7 @@ func TestGenerate_SendsMaxTokens(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newOpenAIClient(srv.URL, "")
+	c := newOpenAIClient(srv.URL, "", 0)
 	if _, err := c.generate(context.Background(), "test-model", "hello", 0.1); err != nil {
 		t.Fatalf("generate: %v", err)
 	}
@@ -414,5 +415,131 @@ func TestExtractJSON_EmptyAndPlainText(t *testing.T) {
 	}
 	if got := extractJSON("nothing useful here"); got != "nothing useful here" {
 		t.Errorf("no-brace input: got %q", got)
+	}
+}
+
+// TestSemaphoreCeilingEnforced verifies that a client with maxConcurrent=2
+// never sends more than 2 concurrent requests to the backend, even when 5
+// goroutines call generate simultaneously.
+func TestSemaphoreCeilingEnforced(t *testing.T) {
+	const ceiling = 2
+	const goroutines = 5
+
+	var (
+		inflight    atomic.Int32
+		maxObserved atomic.Int32
+		release     = make(chan struct{})
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		cur := inflight.Add(1)
+		defer inflight.Add(-1)
+
+		// Record the maximum seen.
+		for {
+			old := maxObserved.Load()
+			if cur <= old || maxObserved.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+
+		// Block until the test releases all handlers.
+		<-release
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := newOpenAIClient(srv.URL, "", ceiling)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.generate(ctx, "m", "p", 0.1) //nolint:errcheck
+		}()
+	}
+
+	// Give goroutines time to reach the server and fill the semaphore.
+	time.Sleep(100 * time.Millisecond)
+
+	// Unblock all handlers.
+	close(release)
+	wg.Wait()
+
+	if got := maxObserved.Load(); got > ceiling {
+		t.Errorf("max concurrent requests = %d, want <= %d", got, ceiling)
+	}
+}
+
+// TestSemaphoreUnboundedWhenZero verifies that maxConcurrent=0 leaves sem nil
+// (no gate) and that generate still works.
+func TestSemaphoreUnboundedWhenZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := newOpenAIClient(srv.URL, "", 0)
+	if c.sem != nil {
+		t.Fatal("expected sem == nil for maxConcurrent=0")
+	}
+
+	result, err := c.generate(context.Background(), "m", "p", 0.1)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q, want %q", result, "ok")
+	}
+}
+
+// TestSemaphoreContextCancelWhileWaiting verifies that a generate call whose
+// context is already cancelled returns promptly with ctx.Err() rather than
+// blocking on a full semaphore.
+func TestSemaphoreContextCancelWhileWaiting(t *testing.T) {
+	// hold blocks the one slot so the second call must wait.
+	hold := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-hold
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer func() {
+		close(hold)
+		srv.Close()
+	}()
+
+	c := newOpenAIClient(srv.URL, "", 1)
+
+	// Fill the single semaphore slot with a blocking call.
+	bgCtx := context.Background()
+	ready := make(chan struct{})
+	go func() {
+		// Signal that we're about to call generate, then call it.
+		close(ready)
+		c.generate(bgCtx, "m", "p", 0.1) //nolint:errcheck
+	}()
+	<-ready
+	// Give the goroutine time to acquire the slot.
+	time.Sleep(20 * time.Millisecond)
+
+	// Now try to generate with an already-cancelled context.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.generate(cancelledCtx, "m", "p", 0.1)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 }

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -55,6 +55,7 @@ func NewAIProcessor(baseURL, securityModel, curationModel string, store any, con
 
 	var apiKey string
 	callTimeout := 2 * time.Minute
+	maxConcurrent := 0
 	if cfg, ok := config.(*storage.Config); ok && cfg != nil {
 		if cfg.Ollama.APIKey != "" {
 			apiKey = cfg.Ollama.APIKey
@@ -62,12 +63,13 @@ func NewAIProcessor(baseURL, securityModel, curationModel string, store any, con
 		if cfg.Ollama.Timeout > 0 {
 			callTimeout = cfg.Ollama.Timeout
 		}
+		maxConcurrent = cfg.Ollama.MaxConcurrent
 	}
 
 	promptLoader := newPromptLoaderSafe(store, config)
 
 	return &AIProcessor{
-		client:        newOpenAIClient(baseURL, apiKey),
+		client:        newOpenAIClient(baseURL, apiKey, maxConcurrent),
 		securityModel: securityModel,
 		curationModel: curationModel,
 		promptLoader:  promptLoader,

--- a/internal/ai/summarization.go
+++ b/internal/ai/summarization.go
@@ -9,8 +9,12 @@ import (
 
 // SummarizeArticle generates an AI summary for a single article.
 // maxSummaryLength is communicated to the model in the prompt; pass 0 to omit.
-func (p *AIProcessor) SummarizeArticle(ctx context.Context, userID int64, title, content string, maxSummaryLength int) (string, error) {
-	promptTemplate, err := p.promptLoader.GetPrompt(userID, PromptTypeSummarization)
+// The summary is a property of the article, shared by every subscriber (#162),
+// so it always uses the global summarization prompt/temperature (the user_id=0
+// admin override, then config, then default) — never a per-user prompt.
+func (p *AIProcessor) SummarizeArticle(ctx context.Context, title, content string, maxSummaryLength int) (string, error) {
+	const globalUser = int64(0)
+	promptTemplate, err := p.promptLoader.GetPrompt(globalUser, PromptTypeSummarization)
 	if err != nil {
 		return "", fmt.Errorf("failed to load summarization prompt: %w", err)
 	}
@@ -25,7 +29,7 @@ func (p *AIProcessor) SummarizeArticle(ctx context.Context, userID int64, title,
 		return "", fmt.Errorf("failed to render summarization prompt: %w", err)
 	}
 
-	temperature := p.promptLoader.GetTemperature(userID, PromptTypeSummarization)
+	temperature := p.promptLoader.GetTemperature(globalUser, PromptTypeSummarization)
 
 	callCtx, cancel := p.withCallTimeout(ctx)
 	defer cancel()

--- a/internal/feeds/fetcher.go
+++ b/internal/feeds/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -73,7 +74,7 @@ func NewFetcher(store storage.Store) *Fetcher {
 	parser.UserAgent = FeedUserAgent
 	return &Fetcher{
 		parser: parser,
-		client: &http.Client{},
+		client: newSafeClient(30 * time.Second),
 		store:  store,
 	}
 }
@@ -117,7 +118,8 @@ func (f *Fetcher) FetchFeed(ctx context.Context, feed storage.Feed) (*FetchResul
 		return nil, fmt.Errorf("feed %s returned status %d", feed.URL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	const maxFeedBytes = 10 << 20 // 10 MB: generous for RSS/Atom; bounds memory.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read feed %s: %w", feed.URL, err)
 	}
@@ -165,6 +167,12 @@ func (f *Fetcher) importOPMLBytes(data []byte, userID int64) error {
 		for _, outline := range outlines {
 			// If this outline has a feed URL, add it
 			if outline.XMLURL != "" {
+				// Reject non-http(s) schemes before touching the feeds table.
+				if u, err := url.Parse(outline.XMLURL); err != nil || !AllowedFetchScheme(u.Scheme) {
+					fmt.Fprintf(os.Stderr, "Warning: skipping OPML entry with disallowed URL %s\n", outline.XMLURL)
+					continue
+				}
+
 				title := outline.Title
 				if title == "" {
 					title = outline.Text

--- a/internal/feeds/fetcher.go
+++ b/internal/feeds/fetcher.go
@@ -137,27 +137,40 @@ func (f *Fetcher) FetchFeed(ctx context.Context, feed storage.Feed) (*FetchResul
 }
 
 // ImportOPMLReader imports feeds from an OPML reader and subscribes user to them.
-func (f *Fetcher) ImportOPMLReader(r io.Reader, userID int64) error {
+// maxFeeds caps the total number of feeds the user may be subscribed to after import;
+// pass 0 (or any value <= 0) for unbounded (e.g. local admin CLI).
+func (f *Fetcher) ImportOPMLReader(r io.Reader, userID int64, maxFeeds int) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("failed to read OPML: %w", err)
 	}
-	return f.importOPMLBytes(data, userID)
+	return f.importOPMLBytes(data, userID, maxFeeds)
 }
 
-// ImportOPML imports feeds from an OPML file and subscribes user to them
-func (f *Fetcher) ImportOPML(opmlPath string, userID int64) error {
+// ImportOPML imports feeds from an OPML file and subscribes user to them.
+// maxFeeds caps the total number of feeds the user may be subscribed to after import;
+// pass 0 (or any value <= 0) for unbounded (e.g. local admin CLI).
+func (f *Fetcher) ImportOPML(opmlPath string, userID int64, maxFeeds int) error {
 	data, err := os.ReadFile(opmlPath)
 	if err != nil {
 		return fmt.Errorf("failed to read OPML file: %w", err)
 	}
-	return f.importOPMLBytes(data, userID)
+	return f.importOPMLBytes(data, userID, maxFeeds)
 }
 
-func (f *Fetcher) importOPMLBytes(data []byte, userID int64) error {
+func (f *Fetcher) importOPMLBytes(data []byte, userID int64, maxFeeds int) error {
 	var opml OPML
 	if err := xml.Unmarshal(data, &opml); err != nil {
 		return fmt.Errorf("failed to parse OPML: %w", err)
+	}
+
+	// Establish the user's current subscription count for cap enforcement.
+	// Skip the lookup when the cap is disabled (maxFeeds <= 0).
+	subscribed := 0
+	if maxFeeds > 0 {
+		if existing, err := f.store.GetUserFeeds(userID); err == nil {
+			subscribed = len(existing)
+		}
 	}
 
 	// Process outlines recursively
@@ -170,6 +183,12 @@ func (f *Fetcher) importOPMLBytes(data []byte, userID int64) error {
 				// Reject non-http(s) schemes before touching the feeds table.
 				if u, err := url.Parse(outline.XMLURL); err != nil || !AllowedFetchScheme(u.Scheme) {
 					fmt.Fprintf(os.Stderr, "Warning: skipping OPML entry with disallowed URL %s\n", outline.XMLURL)
+					continue
+				}
+
+				// Enforce the per-user feed cap before subscribing.
+				if maxFeeds > 0 && subscribed >= maxFeeds {
+					fmt.Fprintf(os.Stderr, "Warning: feed limit (%d) reached; skipping %s\n", maxFeeds, outline.XMLURL)
 					continue
 				}
 
@@ -204,6 +223,7 @@ func (f *Fetcher) importOPMLBytes(data []byte, userID int64) error {
 					fmt.Fprintf(os.Stderr, "Warning: failed to subscribe to feed %s: %v\n", outline.XMLURL, err)
 				} else {
 					added++
+					subscribed++
 				}
 			}
 

--- a/internal/feeds/fetcher_test.go
+++ b/internal/feeds/fetcher_test.go
@@ -59,7 +59,7 @@ func TestImportOPML(t *testing.T) {
 	path := writeOPML(t, opml)
 	fetcher := NewFetcher(store)
 
-	if err := fetcher.ImportOPML(path, 1); err != nil {
+	if err := fetcher.ImportOPML(path, 1, 0); err != nil {
 		t.Fatalf("ImportOPML failed: %v", err)
 	}
 
@@ -101,7 +101,7 @@ func TestImportOPML_NestedFolders(t *testing.T) {
 	path := writeOPML(t, opml)
 	fetcher := NewFetcher(store)
 
-	if err := fetcher.ImportOPML(path, 1); err != nil {
+	if err := fetcher.ImportOPML(path, 1, 0); err != nil {
 		t.Fatalf("ImportOPML failed: %v", err)
 	}
 
@@ -129,10 +129,10 @@ func TestImportOPML_DuplicateFeeds(t *testing.T) {
 	fetcher := NewFetcher(store)
 
 	// Import twice
-	if err := fetcher.ImportOPML(path, 1); err != nil {
+	if err := fetcher.ImportOPML(path, 1, 0); err != nil {
 		t.Fatalf("first ImportOPML failed: %v", err)
 	}
-	if err := fetcher.ImportOPML(path, 1); err != nil {
+	if err := fetcher.ImportOPML(path, 1, 0); err != nil {
 		t.Fatalf("second ImportOPML failed: %v", err)
 	}
 
@@ -150,10 +150,89 @@ func TestImportOPML_MissingFile(t *testing.T) {
 	defer cleanup()
 
 	fetcher := NewFetcher(store)
-	err := fetcher.ImportOPML("/nonexistent/feeds.opml", 1)
+	err := fetcher.ImportOPML("/nonexistent/feeds.opml", 1, 0)
 	if err == nil {
 		t.Fatal("expected error for missing OPML file, got nil")
 	}
+}
+
+func TestImportOPML_FeedCap(t *testing.T) {
+	opml4 := `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Feed A" type="rss" xmlUrl="https://example.com/a.xml"/>
+    <outline text="Feed B" type="rss" xmlUrl="https://example.com/b.xml"/>
+    <outline text="Feed C" type="rss" xmlUrl="https://example.com/c.xml"/>
+    <outline text="Feed D" type="rss" xmlUrl="https://example.com/d.xml"/>
+  </body>
+</opml>`
+
+	t.Run("capped at 2", func(t *testing.T) {
+		store, cleanup := newTestStore(t)
+		defer cleanup()
+		fetcher := NewFetcher(store)
+		path := writeOPML(t, opml4)
+
+		if err := fetcher.ImportOPML(path, 1, 2); err != nil {
+			t.Fatalf("ImportOPML failed: %v", err)
+		}
+
+		userFeeds, err := store.GetUserFeeds(1)
+		if err != nil {
+			t.Fatalf("GetUserFeeds failed: %v", err)
+		}
+		if len(userFeeds) != 2 {
+			t.Errorf("expected 2 subscribed feeds (cap=2), got %d", len(userFeeds))
+		}
+	})
+
+	t.Run("unbounded when maxFeeds=0", func(t *testing.T) {
+		store, cleanup := newTestStore(t)
+		defer cleanup()
+		fetcher := NewFetcher(store)
+		path := writeOPML(t, opml4)
+
+		if err := fetcher.ImportOPML(path, 1, 0); err != nil {
+			t.Fatalf("ImportOPML failed: %v", err)
+		}
+
+		userFeeds, err := store.GetUserFeeds(1)
+		if err != nil {
+			t.Fatalf("GetUserFeeds failed: %v", err)
+		}
+		if len(userFeeds) != 4 {
+			t.Errorf("expected 4 subscribed feeds (unbounded), got %d", len(userFeeds))
+		}
+	})
+
+	t.Run("cap respected with pre-existing subscriptions", func(t *testing.T) {
+		store, cleanup := newTestStore(t)
+		defer cleanup()
+		fetcher := NewFetcher(store)
+
+		// Pre-subscribe the user to 1 feed directly
+		preID, err := store.AddFeed("https://example.com/pre.xml", "Pre-existing", "")
+		if err != nil {
+			t.Fatalf("AddFeed failed: %v", err)
+		}
+		if err := store.SubscribeUserToFeed(1, preID); err != nil {
+			t.Fatalf("SubscribeUserToFeed failed: %v", err)
+		}
+
+		path := writeOPML(t, opml4)
+		// cap=2 with 1 pre-existing subscription -> only 1 new feed should be added
+		if err := fetcher.ImportOPML(path, 1, 2); err != nil {
+			t.Fatalf("ImportOPML failed: %v", err)
+		}
+
+		userFeeds, err := store.GetUserFeeds(1)
+		if err != nil {
+			t.Fatalf("GetUserFeeds failed: %v", err)
+		}
+		if len(userFeeds) != 2 {
+			t.Errorf("expected 2 subscribed feeds total (1 pre-existing + 1 new, cap=2), got %d", len(userFeeds))
+		}
+	})
 }
 
 func TestStoreArticles(t *testing.T) {

--- a/internal/feeds/fetcher_test.go
+++ b/internal/feeds/fetcher_test.go
@@ -16,6 +16,15 @@ import (
 	ext "github.com/mmcdole/gofeed/extensions"
 )
 
+// TestMain installs a permissive dial control for the entire test binary so
+// that httptest.NewServer (which binds to 127.0.0.1) is reachable. Production
+// code always starts with safeControl; this swap is test-binary-only.
+func TestMain(m *testing.M) {
+	restore := UsePermissiveDialForTesting()
+	defer restore()
+	os.Exit(m.Run())
+}
+
 func newTestStore(t *testing.T) (*storage.SQLiteStore, func()) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")

--- a/internal/feeds/fulltext.go
+++ b/internal/feeds/fulltext.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"math/rand/v2"
 	"net/http"
@@ -315,7 +316,7 @@ func fetchReadableContent(ctx context.Context, client *http.Client, articleURL s
 
 	httpClient := client
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 20 * time.Second}
+		httpClient = newSafeClient(20 * time.Second)
 	}
 
 	resp, err := httpClient.Do(req)
@@ -335,7 +336,8 @@ func fetchReadableContent(ctx context.Context, client *http.Client, articleURL s
 		return "", fmt.Errorf("non-HTML content-type %q for %s", ct, articleURL)
 	}
 
-	article, err := readability.FromReader(resp.Body, parsedURL)
+	const maxArticleBytes = 10 << 20 // 10 MB cap for full-text extraction.
+	article, err := readability.FromReader(io.LimitReader(resp.Body, maxArticleBytes), parsedURL)
 	if err != nil {
 		return "", fmt.Errorf("readability parse: %w", err)
 	}

--- a/internal/feeds/images.go
+++ b/internal/feeds/images.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
@@ -107,7 +108,7 @@ func resolveToImageURL(ctx context.Context, client *http.Client, picURL string) 
 
 	httpClient := client
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = newSafeClient(30 * time.Second)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/feeds/safedial.go
+++ b/internal/feeds/safedial.go
@@ -1,0 +1,100 @@
+package feeds
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// dialControl is the net.Dialer Control hook used by newSafeClient.
+// Production code uses safeControl, which rejects non-public addresses.
+// Tests that need to reach loopback (httptest.NewServer binds 127.0.0.1)
+// swap this to a permissive no-op via usePermissiveDialForTesting.
+var dialControl = safeControl
+
+// isDisallowedIP reports whether an IP must not be dialed: loopback,
+// link-local (incl. 169.254.0.0/16 and fe80::/10), private (RFC1918 /
+// fc00::/7 ULA), unspecified, and multicast. Public unicast addresses pass.
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
+		ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// safeControl is a net.Dialer Control hook: it runs after DNS resolution,
+// once per resolved address, with the concrete IP:port about to be dialed.
+// Returning an error aborts that dial.
+func safeControl(network, address string, c syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("safedial: bad address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("safedial: non-IP dial target %q", host)
+	}
+	if isDisallowedIP(ip) {
+		return fmt.Errorf("safedial: refusing to dial non-public address %s", ip)
+	}
+	return nil
+}
+
+// permissiveControl is a no-op dial control used only in tests. It allows
+// loopback and private addresses so httptest.NewServer targets work.
+func permissiveControl(network, address string, c syscall.RawConn) error {
+	return nil
+}
+
+// UsePermissiveDialForTesting swaps dialControl to a no-op that allows any
+// address. Call it in TestMain; the returned function restores the original.
+// Production code always runs with safeControl (the module-level default).
+// This function is intended for use in tests only.
+func UsePermissiveDialForTesting() (restore func()) {
+	prev := dialControl
+	dialControl = permissiveControl
+	return func() { dialControl = prev }
+}
+
+// newSafeClient returns an http.Client that refuses non-public destinations
+// (checked at dial time, so redirects and DNS rebinding are covered), allows
+// only http/https, and applies the given overall timeout.
+//
+// The dial control function is read from the dialControl package variable at
+// each dial, not captured at construction time, so TestMain can swap the
+// variable once before any tests run and all clients created during that run
+// pick up the permissive control.
+func newSafeClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			return dialControl(network, address, c)
+		},
+	}
+	transport := &http.Transport{
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("safedial: stopped after 10 redirects")
+			}
+			if s := req.URL.Scheme; s != "http" && s != "https" {
+				return fmt.Errorf("safedial: refusing redirect to scheme %q", s)
+			}
+			return nil
+		},
+	}
+}
+
+// AllowedFetchScheme reports whether a URL scheme may be fetched.
+func AllowedFetchScheme(scheme string) bool {
+	return scheme == "http" || scheme == "https"
+}

--- a/internal/feeds/safedial_test.go
+++ b/internal/feeds/safedial_test.go
@@ -1,0 +1,98 @@
+package feeds
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestIsDisallowedIP(t *testing.T) {
+	cases := []struct {
+		ip         string
+		disallowed bool
+	}{
+		// Loopback
+		{"127.0.0.1", true},
+		{"::1", true},
+		// Link-local (cloud metadata endpoint)
+		{"169.254.169.254", true},
+		// Private RFC1918
+		{"10.0.0.1", true},
+		{"192.168.1.1", true},
+		{"172.16.0.1", true},
+		// ULA (fc00::/7)
+		{"fc00::1", true},
+		// Unspecified
+		{"0.0.0.0", true},
+		// Public -- must NOT be disallowed
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"2606:4700:4700::1111", false}, // Cloudflare public IPv6
+	}
+
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("failed to parse test IP %q", tc.ip)
+		}
+		got := isDisallowedIP(ip)
+		if got != tc.disallowed {
+			t.Errorf("isDisallowedIP(%s) = %v, want %v", tc.ip, got, tc.disallowed)
+		}
+	}
+}
+
+func TestAllowedFetchScheme(t *testing.T) {
+	cases := []struct {
+		scheme  string
+		allowed bool
+	}{
+		{"http", true},
+		{"https", true},
+		{"file", false},
+		{"ftp", false},
+		{"gopher", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		got := AllowedFetchScheme(tc.scheme)
+		if got != tc.allowed {
+			t.Errorf("AllowedFetchScheme(%q) = %v, want %v", tc.scheme, got, tc.allowed)
+		}
+	}
+}
+
+// TestSafeClient_RefusesLoopback verifies that a client built with the strict
+// safeControl hook refuses to dial a loopback address. httptest.NewServer binds
+// to 127.0.0.1, which is exactly what must be blocked in production.
+//
+// NOTE: TestMain (fetcher_test.go) installs permissiveControl for the whole
+// test binary. This test temporarily restores safeControl so it can assert the
+// guard works.
+func TestSafeClient_RefusesLoopback(t *testing.T) {
+	// Restore strict dial control for this specific test.
+	// TestMain sets dialControl = permissiveControl for the whole binary.
+	// This test needs safeControl to verify that the guard fires, so temporarily
+	// restore strictness and put the permissive control back when done.
+	saved := dialControl
+	dialControl = safeControl
+	defer func() { dialControl = saved }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	client := newSafeClient(5e9) // 5 s
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected error dialing loopback, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Errorf("expected 'non-public' in error, got: %v", err)
+	}
+}

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -318,7 +318,7 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
-// CommandOutput represents Majordomo cron command output
+// CommandOutput represents Herald cron command output
 type CommandOutput struct {
 	Text     string            `json:"text"`
 	Title    string            `json:"title,omitempty"`
@@ -328,10 +328,10 @@ type CommandOutput struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// OutputMajordomoResult outputs results for Majordomo cron integration
-func (f *Formatter) OutputMajordomoResult(result *FetchResult, userID int64, highInterestArticles []storage.Article) error {
+// OutputCronResult outputs results for Herald cron integration
+func (f *Formatter) OutputCronResult(result *FetchResult, userID int64, highInterestArticles []storage.Article) error {
 	if f.format != FormatJSON {
-		return fmt.Errorf("majordomo output only supports JSON format")
+		return fmt.Errorf("cron output only supports JSON format")
 	}
 
 	var text strings.Builder

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -202,13 +202,13 @@ func TestOutputHighInterestNotification_JSON(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_EmptyText(t *testing.T) {
+func TestOutputCronResult_EmptyText(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatJSON, &out, &errBuf)
 
 	result := &FetchResult{NewArticles: 5, ProcessedCount: 5, HighInterest: 0}
-	if err := f.OutputMajordomoResult(result, 1, nil); err != nil {
-		t.Fatalf("OutputMajordomoResult failed: %v", err)
+	if err := f.OutputCronResult(result, 1, nil); err != nil {
+		t.Fatalf("OutputCronResult failed: %v", err)
 	}
 
 	var decoded CommandOutput
@@ -224,7 +224,7 @@ func TestOutputMajordomoResult_EmptyText(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_WithArticles(t *testing.T) {
+func TestOutputCronResult_WithArticles(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatJSON, &out, &errBuf)
 
@@ -233,8 +233,8 @@ func TestOutputMajordomoResult_WithArticles(t *testing.T) {
 	}
 	result := &FetchResult{NewArticles: 3, ProcessedCount: 3, HighInterest: 1}
 
-	if err := f.OutputMajordomoResult(result, 1, articles); err != nil {
-		t.Fatalf("OutputMajordomoResult failed: %v", err)
+	if err := f.OutputCronResult(result, 1, articles); err != nil {
+		t.Fatalf("OutputCronResult failed: %v", err)
 	}
 
 	var decoded CommandOutput
@@ -253,12 +253,12 @@ func TestOutputMajordomoResult_WithArticles(t *testing.T) {
 	}
 }
 
-func TestOutputMajordomoResult_NonJSON(t *testing.T) {
+func TestOutputCronResult_NonJSON(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	f := NewFormatterWithWriters(FormatHuman, &out, &errBuf)
 
 	result := &FetchResult{}
-	err := f.OutputMajordomoResult(result, 1, nil)
+	err := f.OutputCronResult(result, 1, nil)
 	if err == nil {
 		t.Fatal("expected error for non-JSON format, got nil")
 	}

--- a/internal/pipeline/clusterstage.go
+++ b/internal/pipeline/clusterstage.go
@@ -185,7 +185,7 @@ func (s *Stage) nameGroup(ctx context.Context, groupID int64) {
 	var inputs []ai.GroupSummaryInput
 	var maxScore float64
 	for _, a := range arts {
-		summary, err := s.Store.GetArticleSummary(s.UserID, a.ID)
+		summary, err := s.Store.GetArticleSummary(a.ID)
 		if err != nil || summary == nil {
 			continue
 		}

--- a/internal/pipeline/clusterstage_test.go
+++ b/internal/pipeline/clusterstage_test.go
@@ -47,7 +47,7 @@ func TestClusterFormsNewGroupFromSiblings(t *testing.T) {
 	embedArt(t, store, c, []float32{0, 0, 1})      // unrelated
 	// Summaries + scores so the naming step has something to work with.
 	for _, art := range []storage.Article{a, b} {
-		if err := store.UpdateArticleAISummary(1, art.ID, "summary of "+art.GUID); err != nil {
+		if err := store.UpdateArticleAISummary(art.ID, "summary of "+art.GUID); err != nil {
 			t.Fatal(err)
 		}
 		if err := store.SetInterestScore(1, art.ID, 8); err != nil {
@@ -97,7 +97,7 @@ func TestClusterSkipsTopicRefineOnEmptySummary(t *testing.T) {
 	embedArt(t, store, b, []float32{0.99, 0.05, 0})
 	embedArt(t, store, c, []float32{0.98, 0.1, 0}) // all three cluster together (>=3 → refine path)
 	for _, art := range []storage.Article{a, b, c} {
-		if err := store.UpdateArticleAISummary(1, art.ID, "summary of "+art.GUID); err != nil {
+		if err := store.UpdateArticleAISummary(art.ID, "summary of "+art.GUID); err != nil {
 			t.Fatal(err)
 		}
 		if err := store.SetInterestScore(1, art.ID, 8); err != nil {

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -34,29 +34,42 @@ func (s *Stage) RunSecurity(ctx context.Context) (int, error) {
 	return processed, err
 }
 
+// RunSummaries summarizes every security-passed article that lacks a cached
+// summary, exactly once, globally. Like the security verdict (#141), the
+// summary is a property of the article, shared by all subscribers (#162), so
+// this runs once per cycle rather than once per user — one breaker check,
+// draining the global queue newest-first. Returns the number of articles
+// attempted this call.
+func (s *Stage) RunSummaries(ctx context.Context) (int, error) {
+	if !s.AI.BackendAvailable() {
+		s.Formatter.Warning("pipeline: skipping summarize pass — AI backend unavailable (breaker open)")
+		return 0, nil
+	}
+	processed := 0
+	err := s.drain(
+		func(limit int) ([]storage.Article, error) {
+			return s.Store.GetUnsummarizedScoredArticles(s.Cfg.Thresholds.SecurityScore, limit)
+		},
+		func(arts []storage.Article) { processed += len(s.Summarize(ctx, arts)) },
+	)
+	return processed, err
+}
+
 // Run executes the per-user pipeline: it drives each stage from its own
 // state-driven query, in order, so any pending article advances one stage at a
-// time. Security screening is NOT here — it is the global RunSecurity pass,
-// which runs once per cycle before the per-user pipelines. This pipeline starts
-// at summarize, reading the article-level security verdict to decide which
-// articles it processes for this user. Every query is newest-first, so fresh
-// articles are processed ahead of older backlog; work left by prior cycles
-// drains the same way. The whole run is skipped when the LLM backend is
-// unavailable.
+// time. Security screening and summarization are NOT here — they are the
+// global RunSecurity and RunSummaries passes, which run once per cycle before
+// the per-user pipelines. This pipeline starts at curation, reading the
+// article-level security verdict to decide which articles it scores for this
+// user. Every query is newest-first, so fresh articles are processed ahead of
+// older backlog; work left by prior cycles drains the same way. The whole run
+// is skipped when the LLM backend is unavailable.
 func (s *Stage) Run(ctx context.Context) error {
 	if !s.AI.BackendAvailable() {
 		s.Formatter.Warning("pipeline: skipping run for user %d — AI backend unavailable (breaker open)", s.UserID)
 		return nil
 	}
 
-	if err := s.drain(
-		func(limit int) ([]storage.Article, error) {
-			return s.Store.GetUnsummarizedScoredArticles(s.UserID, s.Cfg.Thresholds.SecurityScore, limit)
-		},
-		func(arts []storage.Article) { s.Summarize(ctx, arts) },
-	); err != nil {
-		return err
-	}
 	if err := s.drain(
 		func(limit int) ([]storage.Article, error) {
 			return s.Store.GetUnscoredCurationArticles(s.UserID, s.Cfg.Thresholds.SecurityScore, limit)

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -38,8 +38,8 @@ func (s *Stage) RunSecurity(ctx context.Context) (int, error) {
 // summary, exactly once, globally. Like the security verdict (#141), the
 // summary is a property of the article, shared by all subscribers (#162), so
 // this runs once per cycle rather than once per user — one breaker check,
-// draining the global queue newest-first. Returns the number of articles
-// attempted this call.
+// draining the global queue newest-first. Returns the number of articles that
+// now carry a usable summary (or a recorded skip) after this call.
 func (s *Stage) RunSummaries(ctx context.Context) (int, error) {
 	if !s.AI.BackendAvailable() {
 		s.Formatter.Warning("pipeline: skipping summarize pass — AI backend unavailable (breaker open)")

--- a/internal/pipeline/orchestrate_test.go
+++ b/internal/pipeline/orchestrate_test.go
@@ -150,3 +150,55 @@ func TestRunSkipsWhenBreakerOpen(t *testing.T) {
 		t.Fatalf("expected no security calls with breaker open, got %d", fake.secCalls)
 	}
 }
+
+// TestRunSummariesOncePerArticleAcrossUsers proves the cost model of #162:
+// with two subscribers to the same feed, the global pass makes exactly one
+// SummarizeArticle call per article, and the per-user pipelines make none.
+func TestRunSummariesOncePerArticleAcrossUsers(t *testing.T) {
+	fake := happyAI()
+	st, store, feedID := newHarness(t, fake)
+	if err := store.SubscribeUserToFeed(2, feedID); err != nil {
+		t.Fatalf("subscribe user 2: %v", err)
+	}
+
+	a := seed(t, store, feedID, "a", "body a")
+	b := seed(t, store, feedID, "b", "body b")
+	for _, art := range []storage.Article{a, b} {
+		if err := store.ScreenArticleSecurity(art.ID, 9, "ok", false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	n, err := st.RunSummaries(context.Background())
+	if err != nil {
+		t.Fatalf("RunSummaries: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 articles summarized, got %d", n)
+	}
+	if fake.sumCalls != 2 {
+		t.Fatalf("expected exactly 1 model call per article (2 total), got %d", fake.sumCalls)
+	}
+
+	// A second global pass finds nothing to do.
+	if n, err := st.RunSummaries(context.Background()); err != nil || n != 0 {
+		t.Fatalf("second RunSummaries = (%d, %v), want (0, nil)", n, err)
+	}
+
+	// The per-user pipelines never call the summarizer.
+	for _, uid := range []int64{1, 2} {
+		userStage := &Stage{
+			Store:     store,
+			AI:        fake,
+			Cfg:       st.Cfg,
+			Formatter: st.Formatter,
+			UserID:    uid,
+		}
+		if err := userStage.Run(context.Background()); err != nil {
+			t.Fatalf("Run user %d: %v", uid, err)
+		}
+	}
+	if fake.sumCalls != 2 {
+		t.Fatalf("per-user runs must not summarize; calls went from 2 to %d", fake.sumCalls)
+	}
+}

--- a/internal/pipeline/orchestrate_test.go
+++ b/internal/pipeline/orchestrate_test.go
@@ -34,14 +34,21 @@ func TestRunEndToEnd(t *testing.T) {
 	a := seed(t, store, feedID, "a", strings.Repeat("x", 500))
 	b := seed(t, store, feedID, "b", strings.Repeat("y", 500))
 
-	// The global security pass screens both, then the per-user pipeline advances
-	// them through every stage.
+	// The global security and summarize passes handle both, then the per-user
+	// pipeline advances them through the remaining stages.
 	processed, err := st.RunSecurity(context.Background())
 	if err != nil {
 		t.Fatalf("RunSecurity: %v", err)
 	}
 	if processed != 2 {
 		t.Fatalf("expected 2 articles processed, got %d", processed)
+	}
+	summarized, err := st.RunSummaries(context.Background())
+	if err != nil {
+		t.Fatalf("RunSummaries: %v", err)
+	}
+	if summarized != 2 {
+		t.Fatalf("expected 2 articles summarized, got %d", summarized)
 	}
 	if err := st.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -56,7 +63,7 @@ func TestRunEndToEnd(t *testing.T) {
 		t.Fatalf("expected all articles curated, still pending: %v", ids(cur))
 	}
 	for _, art := range []storage.Article{a, b} {
-		if sum, _ := store.GetArticleSummary(1, art.ID); sum == nil {
+		if sum, _ := store.GetArticleSummary(art.ID); sum == nil {
 			t.Fatalf("article %d not summarized", art.ID)
 		}
 	}
@@ -78,6 +85,9 @@ func TestRunDrainsBacklog(t *testing.T) {
 	if _, err := st.RunSecurity(context.Background()); err != nil {
 		t.Fatalf("RunSecurity: %v", err)
 	}
+	if _, err := st.RunSummaries(context.Background()); err != nil {
+		t.Fatalf("RunSummaries: %v", err)
+	}
 	if err := st.Run(context.Background()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -86,7 +96,7 @@ func TestRunDrainsBacklog(t *testing.T) {
 		t.Fatalf("backlog not drained, still unscreened: %v", ids(unscreened))
 	}
 	for _, a := range arts {
-		if sum, _ := store.GetArticleSummary(1, a.ID); sum == nil {
+		if sum, _ := store.GetArticleSummary(a.ID); sum == nil {
 			t.Fatalf("article %d not summarized after backfill", a.ID)
 		}
 	}
@@ -106,16 +116,19 @@ func TestRunTerminatesOnPersistentFailure(t *testing.T) {
 	}
 
 	done := make(chan error, 1)
-	go func() { done <- st.Run(context.Background()) }()
+	go func() {
+		_, err := st.RunSummaries(context.Background())
+		done <- err
+	}()
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Fatalf("Run: %v", err)
+			t.Fatalf("RunSummaries: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("Run hung on a persistently-failing stage")
+		t.Fatal("RunSummaries hung on a persistently-failing stage")
 	}
-	if sum, _ := store.GetArticleSummary(1, a.ID); sum != nil {
+	if sum, _ := store.GetArticleSummary(a.ID); sum != nil {
 		t.Fatal("garbage summary must not be cached")
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -18,7 +18,7 @@ import (
 // open, instead of attempting (and logging) one blocked call per article.
 type AI interface {
 	SecurityCheck(ctx context.Context, title, content string) (*ai.SecurityResult, error)
-	SummarizeArticle(ctx context.Context, userID int64, title, content string, maxSummaryLength int) (string, error)
+	SummarizeArticle(ctx context.Context, title, content string, maxSummaryLength int) (string, error)
 	CurateArticle(ctx context.Context, userID int64, title, content string, keywords []string) (*ai.CurationResult, error)
 	GenerateGroupSummary(ctx context.Context, userID int64, topic string, articles []ai.GroupSummaryInput) (*ai.GroupSummaryResult, error)
 	RefineGroupTopic(ctx context.Context, userID int64, groupSummary string) (string, error)

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -90,21 +90,24 @@ func (s *Stage) securityOne(ctx context.Context, article storage.Article) *stora
 }
 
 // Summarize generates and caches an AI summary for each (already security-passed)
-// article that lacks one. Articles that already have a cached summary pass
-// through unchanged. Transient failures (backend error, garbled output) are left
+// article that lacks one. Like the security verdict (#141), the summary is a
+// property of the article, shared by every subscriber (#162) — this stage runs
+// in the global, once-per-cycle summarize pass (RunSummaries), not in the
+// per-user pipeline. Articles that already have a cached summary pass through
+// unchanged. Transient failures (backend error, garbled output) are left
 // unsummarized for a later cycle to retry; deterministic rejections (summary not
 // shorter than the source, or over the length budget) are marked skipped so they
 // are not retried forever. Returns the articles that now have a usable summary.
 func (s *Stage) Summarize(ctx context.Context, in []storage.Article) []storage.Article {
 	if !s.AI.BackendAvailable() {
-		s.Formatter.Warning("pipeline: skipping summarize stage for user %d — AI backend unavailable (breaker open)", s.UserID)
+		s.Formatter.Warning("pipeline: skipping summarize stage — AI backend unavailable (breaker open)")
 		return nil
 	}
 	return s.mapArticles(ctx, in, s.summarizeOne)
 }
 
 func (s *Stage) summarizeOne(ctx context.Context, article storage.Article) *storage.Article {
-	existing, err := s.Store.GetArticleSummary(s.UserID, article.ID)
+	existing, err := s.Store.GetArticleSummary(article.ID)
 	if err != nil {
 		s.Formatter.Warning("failed to check article summary for %d: %v", article.ID, err)
 		return nil
@@ -116,7 +119,7 @@ func (s *Stage) summarizeOne(ctx context.Context, article storage.Article) *stor
 
 	content := articleContent(article)
 	maxLen := s.Cfg.Summarization.MaxSummaryLength
-	summary, err := s.AI.SummarizeArticle(ctx, s.UserID, article.Title, content, maxLen)
+	summary, err := s.AI.SummarizeArticle(ctx, article.Title, content, maxLen)
 	if err != nil {
 		// Transient — leave unsummarized, retry next cycle.
 		s.Formatter.Warning("summarization failed for article %d: %v", article.ID, err)
@@ -132,17 +135,17 @@ func (s *Stage) summarizeOne(ctx context.Context, article storage.Article) *stor
 	if len(summary) > len(content) {
 		reason := fmt.Sprintf("summary longer than content (%d > %d)", len(summary), len(content))
 		s.Formatter.Warning("marking article %d summarization skipped: %s", article.ID, reason)
-		s.Store.MarkSummarizationSkipped(s.UserID, article.ID, reason) //nolint:errcheck
+		s.Store.MarkSummarizationSkipped(article.ID, reason) //nolint:errcheck
 		return &article
 	}
 	if maxLen > 0 && len(summary) > maxLen+maxLen*15/100 {
 		reason := fmt.Sprintf("summary exceeds max length by >15%% (%d > %d)", len(summary), maxLen)
 		s.Formatter.Warning("marking article %d summarization skipped: %s", article.ID, reason)
-		s.Store.MarkSummarizationSkipped(s.UserID, article.ID, reason) //nolint:errcheck
+		s.Store.MarkSummarizationSkipped(article.ID, reason) //nolint:errcheck
 		return &article
 	}
 
-	if err := s.Store.UpdateArticleAISummary(s.UserID, article.ID, summary); err != nil {
+	if err := s.Store.UpdateArticleAISummary(article.ID, summary); err != nil {
 		s.Formatter.Warning("failed to cache AI summary for %d: %v", article.ID, err)
 		return nil
 	}

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -58,7 +58,7 @@ func (f *fakeAI) SecurityCheck(_ context.Context, title, content string) (*ai.Se
 	return &ai.SecurityResult{Safe: true, Score: 9}, nil
 }
 
-func (f *fakeAI) SummarizeArticle(_ context.Context, _ int64, title, content string, _ int) (string, error) {
+func (f *fakeAI) SummarizeArticle(_ context.Context, title, content string, _ int) (string, error) {
 	f.mu.Lock()
 	f.sumCalls++
 	f.mu.Unlock()
@@ -274,7 +274,7 @@ func TestSummarizeStage(t *testing.T) {
 		if len(out) != 1 {
 			t.Fatalf("expected article to advance, got %v", ids(out))
 		}
-		got, _ := store.GetArticleSummary(1, a.ID)
+		got, _ := store.GetArticleSummary(a.ID)
 		if got == nil || got.AISummary != "good summary" {
 			t.Fatalf("summary not cached: %+v", got)
 		}
@@ -288,7 +288,7 @@ func TestSummarizeStage(t *testing.T) {
 		if len(out) != 0 {
 			t.Fatalf("garbled summary must not advance the article, got %v", ids(out))
 		}
-		if got, _ := store.GetArticleSummary(1, a.ID); got != nil {
+		if got, _ := store.GetArticleSummary(a.ID); got != nil {
 			t.Fatalf("garbled summary must not be cached, got %+v", got)
 		}
 	})
@@ -304,7 +304,7 @@ func TestSummarizeStage(t *testing.T) {
 			t.Fatalf("deterministically-skipped article should still advance, got %v", ids(out))
 		}
 		// Marked skipped (summary row exists) so it won't be retried.
-		got, _ := store.GetArticleSummary(1, a.ID)
+		got, _ := store.GetArticleSummary(a.ID)
 		if got == nil {
 			t.Fatal("expected a skip row recorded for the over-length summary")
 		}
@@ -313,7 +313,7 @@ func TestSummarizeStage(t *testing.T) {
 	t.Run("already-summarized article passes through without a model call", func(t *testing.T) {
 		a := seed(t, store, feedID, "cached", "body")
 		mustPass(a)
-		if err := store.UpdateArticleAISummary(1, a.ID, "preexisting"); err != nil {
+		if err := store.UpdateArticleAISummary(a.ID, "preexisting"); err != nil {
 			t.Fatal(err)
 		}
 		before := st.AI.(*fakeAI).sumCalls
@@ -347,7 +347,7 @@ func TestCurateStage(t *testing.T) {
 		if len(cur) != 0 {
 			t.Fatalf("curated article should leave the curation queue, got %v", ids(cur))
 		}
-		scored, _ := store.GetUnsummarizedScoredArticles(1, 7.0, 10)
+		scored, _ := store.GetUnsummarizedScoredArticles(7.0, 10)
 		if len(scored) != 1 {
 			t.Fatalf("security score must survive curation, got %v", ids(scored))
 		}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -16,6 +16,9 @@ type Config struct {
 		CurationModel string        `yaml:"curation_model"`
 		Timeout       time.Duration `yaml:"timeout"`
 		MaxParallel   int           `yaml:"max_parallel"`
+		// MaxConcurrent bounds the number of in-flight generate() calls in this
+		// process. <= 0 means unbounded (no gate).
+		MaxConcurrent int `yaml:"max_concurrent"`
 	} `yaml:"ollama"`
 
 	Thresholds struct {
@@ -114,6 +117,7 @@ func DefaultConfig() *Config {
 	cfg.Ollama.SecurityModel = "gemma3:4b"
 	cfg.Ollama.CurationModel = "llama3.1:8b"
 	cfg.Ollama.Timeout = 2 * time.Minute
+	cfg.Ollama.MaxConcurrent = 8
 	cfg.Summarization.MinArticleLength = 200
 	cfg.Summarization.MaxSummaryLength = 500
 	cfg.Grouping.Enabled = true

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -24,6 +24,12 @@ type Config struct {
 		SecurityMediumScore float64 `yaml:"security_medium_score"`
 	} `yaml:"thresholds"`
 
+	Limits struct {
+		MaxFeedsPerUser       int `yaml:"max_feeds_per_user"`
+		MaxFilterRulesPerUser int `yaml:"max_filter_rules_per_user"`
+		MaxNewslettersPerUser int `yaml:"max_newsletters_per_user"`
+	} `yaml:"limits"`
+
 	Preferences struct {
 		Keywords         []string `yaml:"keywords"`
 		PreferredSources []string `yaml:"preferred_sources"`
@@ -118,6 +124,9 @@ func DefaultConfig() *Config {
 	cfg.Thresholds.InterestScore = 8.0
 	cfg.Thresholds.SecurityScore = 7.0
 	cfg.Thresholds.SecurityMediumScore = 4.0
+	cfg.Limits.MaxFeedsPerUser = 1000
+	cfg.Limits.MaxFilterRulesPerUser = 1000
+	cfg.Limits.MaxNewslettersPerUser = 50
 	// Default temperatures (can be overridden in config)
 	cfg.Temperatures.Security = 0.3
 	cfg.Temperatures.Curation = 0.5

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -64,7 +64,7 @@ func MigrateStore(ctx context.Context, src, dst Store) (*MigrateStats, error) {
 		{"user_prompts", func() error { return migrateUserPrompts(ctx, srcDB, dst, userMap, stats) }},
 		{"article_authors", func() error { return migrateArticleAuthors(ctx, srcDB, dst, articleMap) }},
 		{"article_categories", func() error { return migrateArticleCategories(ctx, srcDB, dst, articleMap) }},
-		{"article_summaries", func() error { return migrateArticleSummaries(ctx, srcDB, dst, userMap, articleMap) }},
+		{"article_summaries", func() error { return migrateArticleSummaries(ctx, srcDB, dst, articleMap) }},
 		{"article_groups", func() error { return migrateArticleGroups(ctx, srcDB, dst, userMap, articleMap, groupMap, stats) }},
 		{"filter_rules", func() error { return migrateFilterRules(ctx, srcDB, dst, userMap, feedMap, stats) }},
 		{"fever_credentials", func() error { return migrateFeverCredentials(ctx, srcDB, dst, userMap, stats) }},
@@ -625,29 +625,36 @@ func migrateArticleCategories(ctx context.Context, src *tracedDB, dst Store, art
 	return nil
 }
 
-func migrateArticleSummaries(ctx context.Context, src *tracedDB, dst Store, userMap, articleMap map[int64]int64) error {
+// migrateArticleSummaries copies the per-article summary rows (#162). The
+// source is always opened through NewSQLiteStore/NewPostgresStore, which
+// rebuild any old per-user table to per-article shape before we read it.
+func migrateArticleSummaries(ctx context.Context, src *tracedDB, dst Store, articleMap map[int64]int64) error {
 	rows, err := src.QueryContext(ctx,
-		"SELECT user_id, article_id, ai_summary FROM article_summaries ORDER BY user_id, article_id")
+		"SELECT article_id, ai_summary, COALESCE(skip_reason, '') FROM article_summaries ORDER BY article_id")
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		var srcUserID, srcArticleID int64
-		var summary string
-		if err := rows.Scan(&srcUserID, &srcArticleID, &summary); err != nil {
+		var srcArticleID int64
+		var summary, skipReason string
+		if err := rows.Scan(&srcArticleID, &summary, &skipReason); err != nil {
 			return err
-		}
-		dstUserID, ok := userMap[srcUserID]
-		if !ok {
-			continue
 		}
 		dstArticleID, ok := articleMap[srcArticleID]
 		if !ok {
 			continue
 		}
-		if err := dst.UpdateArticleAISummary(dstUserID, dstArticleID, summary); err != nil {
+		// Preserve skip markers (empty summary + reason = "tried, rejected,
+		// don't retry") instead of flattening them into empty summaries.
+		if summary == "" && skipReason != "" {
+			if err := dst.MarkSummarizationSkipped(dstArticleID, skipReason); err != nil {
+				return fmt.Errorf("MarkSummarizationSkipped: %w", err)
+			}
+			continue
+		}
+		if err := dst.UpdateArticleAISummary(dstArticleID, summary); err != nil {
 			return fmt.Errorf("UpdateArticleAISummary: %w", err)
 		}
 	}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -373,6 +373,33 @@ func (s *PostgresStore) ListUsers() ([]User, error) {
 	return users, rows.Err()
 }
 
+// DeleteUser removes a user and everything they own, atomically. Tables that
+// lack a users FK are deleted explicitly; tables with ON DELETE CASCADE are
+// handled automatically when the users row is removed.
+func (s *PostgresStore) DeleteUser(userID int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("delete user: begin: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+	stmts := []string{
+		"DELETE FROM read_state WHERE user_id = $1",
+		"DELETE FROM user_preferences WHERE user_id = $1",
+		"DELETE FROM user_feeds WHERE user_id = $1",
+		"DELETE FROM feed_tags WHERE user_id = $1",
+		"DELETE FROM user_prompts WHERE user_id = $1",
+		"DELETE FROM filter_rules WHERE user_id = $1",
+		"DELETE FROM article_groups WHERE user_id = $1", // cascades article_group_members + group_summaries
+		"DELETE FROM users WHERE id = $1",               // cascades fever_credentials, newsletters+issues, ai_summaries
+	}
+	for _, q := range stmts {
+		if _, err := tx.Exec(q, userID); err != nil {
+			return fmt.Errorf("delete user (%q): %w", q, err)
+		}
+	}
+	return tx.Commit()
+}
+
 // --- User prompts ---
 
 func (s *PostgresStore) GetUserPrompt(userID int64, promptType string) (string, error) {

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -998,18 +998,16 @@ func (s *PostgresStore) GetUnscoredArticleCount(userID int64) (int, error) {
 	return count, nil
 }
 
-func (s *PostgresStore) GetUnsummarizedScoredArticles(userID int64, securityThreshold float64, limit int) ([]Article, error) {
+func (s *PostgresStore) GetUnsummarizedScoredArticles(securityThreshold float64, limit int) ([]Article, error) {
 	rows, err := s.db.Query(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = uf.user_id
-		WHERE uf.user_id = ?
-		  AND a.security_score >= ?
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
+		WHERE a.security_score >= ?
 		  AND asumm.article_id IS NULL
 		ORDER BY a.published_date DESC
-		LIMIT ?`, userID, securityThreshold, limit)
+		LIMIT ?`, securityThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get unsummarized scored articles: %w", err)
 	}
@@ -1146,15 +1144,13 @@ func (s *PostgresStore) GetUngroupedEmbeddedArticles(userID int64, model string,
 	return scanArticles(rows)
 }
 
-func (s *PostgresStore) GetUnsummarizedArticleCount(userID int64) (int, error) {
+func (s *PostgresStore) GetUnsummarizedArticleCount() (int, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT COUNT(*)
 		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = ?
-		WHERE uf.user_id = ? AND asumm.article_id IS NULL`,
-		userID, userID,
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
+		WHERE asumm.article_id IS NULL`,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("get unsummarized article count: %w", err)
@@ -1489,15 +1485,15 @@ func (s *PostgresStore) HasFilterRules(userID int64) (bool, error) {
 
 // --- Article summaries ---
 
-func (s *PostgresStore) UpdateArticleAISummary(userID, articleID int64, aiSummary string) error {
+func (s *PostgresStore) UpdateArticleAISummary(articleID int64, aiSummary string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
-		 VALUES (?, ?, ?, NULL)
-		 ON CONFLICT(user_id, article_id) DO UPDATE SET
+		`INSERT INTO article_summaries (article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, NULL)
+		 ON CONFLICT(article_id) DO UPDATE SET
 		   ai_summary = EXCLUDED.ai_summary,
 		   skip_reason = NULL,
 		   generated_at = NOW()`,
-		userID, articleID, aiSummary,
+		articleID, aiSummary,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update AI summary: %w", err)
@@ -1505,14 +1501,14 @@ func (s *PostgresStore) UpdateArticleAISummary(userID, articleID int64, aiSummar
 	return nil
 }
 
-func (s *PostgresStore) MarkSummarizationSkipped(userID, articleID int64, reason string) error {
+func (s *PostgresStore) MarkSummarizationSkipped(articleID int64, reason string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
-		 VALUES (?, ?, '', ?)
-		 ON CONFLICT (user_id, article_id) DO UPDATE SET
+		`INSERT INTO article_summaries (article_id, ai_summary, skip_reason)
+		 VALUES (?, '', ?)
+		 ON CONFLICT (article_id) DO UPDATE SET
 		   skip_reason = EXCLUDED.skip_reason,
 		   generated_at = NOW()`,
-		userID, articleID, reason,
+		articleID, reason,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to mark summarization skipped: %w", err)
@@ -1520,12 +1516,12 @@ func (s *PostgresStore) MarkSummarizationSkipped(userID, articleID int64, reason
 	return nil
 }
 
-func (s *PostgresStore) GetArticleSummary(userID, articleID int64) (*ArticleSummary, error) {
+func (s *PostgresStore) GetArticleSummary(articleID int64) (*ArticleSummary, error) {
 	var as ArticleSummary
 	err := s.db.QueryRow(
-		"SELECT user_id, article_id, ai_summary, generated_at FROM article_summaries WHERE user_id = ? AND article_id = ?",
-		userID, articleID,
-	).Scan(&as.UserID, &as.ArticleID, &as.AISummary, &as.GeneratedAt)
+		"SELECT article_id, ai_summary, generated_at FROM article_summaries WHERE article_id = ?",
+		articleID,
+	).Scan(&as.ArticleID, &as.AISummary, &as.GeneratedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1562,11 +1558,12 @@ func (s *PostgresStore) GetProcessingStats(userID int64) (*ProcessingStats, erro
 		return nil, fmt.Errorf("get processing stats (funnel): %w", err)
 	}
 
+	// Summaries are per-article and shared by all subscribers (#162), so these
+	// two funnel numbers are global, like the security columns above.
 	err = s.db.QueryRow(`
 		SELECT
-			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND ai_summary <> ''),
-			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND COALESCE(skip_reason, '') <> '')`,
-		userID, userID,
+			(SELECT COUNT(*) FROM article_summaries WHERE ai_summary <> ''),
+			(SELECT COUNT(*) FROM article_summaries WHERE COALESCE(skip_reason, '') <> '')`,
 	).Scan(&p.Summarized, &p.SummarizeSkipped)
 	if err != nil {
 		return nil, fmt.Errorf("get processing stats (summaries): %w", err)
@@ -1650,10 +1647,10 @@ func (s *PostgresStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 		JOIN user_feeds uf ON uf.feed_id = f.id AND uf.user_id = ?
 		JOIN articles a ON a.feed_id = f.id
 		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = ?
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
 		GROUP BY f.id, uf.user_title
 		ORDER BY COALESCE(uf.user_title, f.title)`,
-		userID, userID, userID,
+		userID, userID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get feed stats: %w", err)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -160,6 +160,45 @@ func NewPostgresStore(dsn string) (*PostgresStore, error) {
 			return nil, fmt.Errorf("failed to run postgres migration: %w", err)
 		}
 	}
+
+	// Migrate article_summaries from per-user (user_id, article_id) PK to
+	// per-article (#162) — mirrors the SQLite rebuild. The dedup prefers a
+	// real summary over a skip marker, then the lowest user_id.
+	var summariesPerUser bool
+	if err := db.QueryRow(
+		`SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'article_summaries' AND column_name = 'user_id'
+		)`).Scan(&summariesPerUser); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to inspect article_summaries schema: %w", err)
+	}
+	if summariesPerUser {
+		if _, err := db.Exec(`
+			CREATE TABLE article_summaries_new (
+				article_id   BIGINT PRIMARY KEY,
+				ai_summary   TEXT NOT NULL,
+				skip_reason  TEXT,
+				generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+			);
+			INSERT INTO article_summaries_new (article_id, ai_summary, skip_reason, generated_at)
+			SELECT article_id, ai_summary, skip_reason, generated_at
+			FROM (
+				SELECT *, ROW_NUMBER() OVER (
+					PARTITION BY article_id
+					ORDER BY (ai_summary = '') ASC, user_id ASC
+				) AS rn
+				FROM article_summaries
+			) t WHERE rn = 1;
+			DROP TABLE article_summaries;
+			ALTER TABLE article_summaries_new RENAME TO article_summaries;
+		`); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to migrate article_summaries: %w", err)
+		}
+	}
+
 	return &PostgresStore{db: &tracedDB{DB: db, useRebind: true}}, nil
 }
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -520,6 +520,23 @@ func (s *PostgresStore) DeleteUserPreference(userID int64, key string) error {
 
 // --- Read state ---
 
+// UserSubscribedToArticleFeed reports whether the user is subscribed to the
+// feed that owns the article. Unknown article IDs return false, nil.
+func (s *PostgresStore) UserSubscribedToArticleFeed(userID, articleID int64) (bool, error) {
+	var subscribed bool
+	err := s.db.QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM articles a
+			JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
+			WHERE a.id = ?
+		)`, userID, articleID,
+	).Scan(&subscribed)
+	if err != nil {
+		return false, fmt.Errorf("check article subscription: %w", err)
+	}
+	return subscribed, nil
+}
+
 func (s *PostgresStore) UpdateStarred(userID, articleID int64, starred bool) error {
 	_, err := s.db.Exec(
 		`INSERT INTO read_state (user_id, article_id, starred)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1417,18 +1417,24 @@ func (s *PostgresStore) GetFilterRules(userID int64, feedID *int64) ([]FilterRul
 	return rules, rows.Err()
 }
 
-func (s *PostgresStore) UpdateFilterRuleScore(ruleID int64, score int) error {
-	_, err := s.db.Exec("UPDATE filter_rules SET score = ? WHERE id = ?", score, ruleID)
+func (s *PostgresStore) UpdateFilterRuleScore(userID, ruleID int64, score int) error {
+	res, err := s.db.Exec("UPDATE filter_rules SET score = ? WHERE id = ? AND user_id = ?", score, ruleID, userID)
 	if err != nil {
 		return fmt.Errorf("update filter rule score: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("filter rule %d not found for user %d", ruleID, userID)
 	}
 	return nil
 }
 
-func (s *PostgresStore) DeleteFilterRule(ruleID int64) error {
-	_, err := s.db.Exec("DELETE FROM filter_rules WHERE id = ?", ruleID)
+func (s *PostgresStore) DeleteFilterRule(userID, ruleID int64) error {
+	res, err := s.db.Exec("DELETE FROM filter_rules WHERE id = ? AND user_id = ?", ruleID, userID)
 	if err != nil {
 		return fmt.Errorf("delete filter rule: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("filter rule %d not found for user %d", ruleID, userID)
 	}
 	return nil
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -108,16 +108,12 @@ CREATE TABLE IF NOT EXISTS feed_tags (
 CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, tag);
 
 CREATE TABLE IF NOT EXISTS article_summaries (
-    user_id INTEGER NOT NULL DEFAULT 1,
-    article_id INTEGER NOT NULL,
+    article_id INTEGER PRIMARY KEY,
     ai_summary TEXT NOT NULL,
     skip_reason TEXT,
     generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (user_id, article_id),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );
-
-CREATE INDEX IF NOT EXISTS idx_article_summaries_article ON article_summaries(article_id);
 
 CREATE TABLE IF NOT EXISTS article_groups (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/storage/schema_postgres.go
+++ b/internal/storage/schema_postgres.go
@@ -114,16 +114,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_tags_unique ON feed_tags(user_id, fee
 CREATE INDEX IF NOT EXISTS idx_feed_tags_user_tag ON feed_tags(user_id, lower(tag));
 
 CREATE TABLE IF NOT EXISTS article_summaries (
-    user_id      BIGINT NOT NULL DEFAULT 1,
-    article_id   BIGINT NOT NULL,
+    article_id   BIGINT PRIMARY KEY,
     ai_summary   TEXT NOT NULL,
     skip_reason  TEXT,
     generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (user_id, article_id),
     FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
 );
-
-CREATE INDEX IF NOT EXISTS idx_article_summaries_article ON article_summaries(article_id);
 
 CREATE TABLE IF NOT EXISTS article_groups (
     id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -879,6 +879,23 @@ func (s *SQLiteStore) DeleteUserPreference(userID int64, key string) error {
 	return err
 }
 
+// UserSubscribedToArticleFeed reports whether the user is subscribed to the
+// feed that owns the article. Unknown article IDs return false, nil.
+func (s *SQLiteStore) UserSubscribedToArticleFeed(userID, articleID int64) (bool, error) {
+	var subscribed bool
+	err := s.db.QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM articles a
+			JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
+			WHERE a.id = ?
+		)`, userID, articleID,
+	).Scan(&subscribed)
+	if err != nil {
+		return false, fmt.Errorf("check article subscription: %w", err)
+	}
+	return subscribed, nil
+}
+
 // UpdateStarred sets the starred flag on an article's read state.
 func (s *SQLiteStore) UpdateStarred(userID, articleID int64, starred bool) error {
 	_, err := s.db.Exec(

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -429,6 +429,39 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		}
 	}
 
+	// Migrate article_summaries from per-user (user_id, article_id) PK to
+	// per-article (#162): a summary is a property of the article, like the
+	// security verdict (#141). Detect the old schema by the presence of a
+	// user_id column. The dedup prefers a real summary over a skip marker
+	// ((ai_summary = '') ASC), then the lowest user_id — the same tiebreak
+	// philosophy as the #141 backfill.
+	if needsArticleSummariesMigration(db) {
+		migrationSQL := `
+			CREATE TABLE article_summaries_new (
+				article_id INTEGER PRIMARY KEY,
+				ai_summary TEXT NOT NULL,
+				skip_reason TEXT,
+				generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+			);
+			INSERT INTO article_summaries_new (article_id, ai_summary, skip_reason, generated_at)
+			SELECT article_id, ai_summary, skip_reason, generated_at
+			FROM (
+				SELECT *, ROW_NUMBER() OVER (
+					PARTITION BY article_id
+					ORDER BY (ai_summary = '') ASC, user_id ASC
+				) AS rn
+				FROM article_summaries
+			) WHERE rn = 1;
+			DROP TABLE article_summaries;
+			ALTER TABLE article_summaries_new RENAME TO article_summaries;
+		`
+		if _, err := db.Exec(migrationSQL); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to migrate article_summaries: %w", err)
+		}
+	}
+
 	return &SQLiteStore{db: &tracedDB{DB: db}}, nil
 }
 
@@ -454,6 +487,30 @@ func needsReadStateMigration(db *sql.DB) bool {
 		}
 	}
 	return true // table exists but has no user_id column
+}
+
+// needsArticleSummariesMigration checks whether article_summaries still uses
+// the old per-user shape (a user_id column is present). Returns false for
+// fresh databases that already have the per-article schema (#162).
+func needsArticleSummariesMigration(db *sql.DB) bool {
+	rows, err := db.Query("PRAGMA table_info(article_summaries)")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		if name == "user_id" {
+			return true // old per-user shape — rebuild to per-article
+		}
+	}
+	return false
 }
 
 // scanFeeds scans a *sql.Rows result set into a []Feed slice.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -718,6 +718,33 @@ func (s *SQLiteStore) ListUsers() ([]User, error) {
 	return users, rows.Err()
 }
 
+// DeleteUser removes a user and everything they own, atomically. Tables that
+// lack a users FK are deleted explicitly; tables with ON DELETE CASCADE are
+// handled automatically when the users row is removed.
+func (s *SQLiteStore) DeleteUser(userID int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("delete user: begin: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+	stmts := []string{
+		"DELETE FROM read_state WHERE user_id = ?",
+		"DELETE FROM user_preferences WHERE user_id = ?",
+		"DELETE FROM user_feeds WHERE user_id = ?",
+		"DELETE FROM feed_tags WHERE user_id = ?",
+		"DELETE FROM user_prompts WHERE user_id = ?",
+		"DELETE FROM filter_rules WHERE user_id = ?",
+		"DELETE FROM article_groups WHERE user_id = ?", // cascades article_group_members + group_summaries
+		"DELETE FROM users WHERE id = ?",               // cascades fever_credentials, newsletters+issues, ai_summaries
+	}
+	for _, q := range stmts {
+		if _, err := tx.Exec(q, userID); err != nil {
+			return fmt.Errorf("delete user (%q): %w", q, err)
+		}
+	}
+	return tx.Commit()
+}
+
 // User prompt management
 
 // GetUserPrompt retrieves a user's custom prompt template

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -53,7 +53,6 @@ type Article struct {
 }
 
 type ArticleSummary struct {
-	UserID      int64
 	ArticleID   int64
 	AISummary   string
 	GeneratedAt time.Time
@@ -1402,18 +1401,19 @@ func (s *SQLiteStore) GetArticlesByInterestScore(userID int64, threshold float64
 	return articles, scores, rows.Err()
 }
 
-// UpdateArticleAISummary stores the AI-generated summary for an article (per-user).
+// UpdateArticleAISummary stores the AI-generated summary for an article. The
+// summary is a property of the article, shared by all subscribers (#162).
 // Clears any prior skip_reason so a previously-skipped article that later
 // summarizes successfully transitions back to a normal cached row.
-func (s *SQLiteStore) UpdateArticleAISummary(userID, articleID int64, aiSummary string) error {
+func (s *SQLiteStore) UpdateArticleAISummary(articleID int64, aiSummary string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
-		 VALUES (?, ?, ?, NULL)
-		 ON CONFLICT(user_id, article_id) DO UPDATE SET
+		`INSERT INTO article_summaries (article_id, ai_summary, skip_reason)
+		 VALUES (?, ?, NULL)
+		 ON CONFLICT(article_id) DO UPDATE SET
 		   ai_summary = excluded.ai_summary,
 		   skip_reason = NULL,
 		   generated_at = CURRENT_TIMESTAMP`,
-		userID, articleID, aiSummary,
+		articleID, aiSummary,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update AI summary: %w", err)
@@ -1425,14 +1425,14 @@ func (s *SQLiteStore) UpdateArticleAISummary(userID, articleID int64, aiSummary 
 // (e.g., the model can't compress content shorter than the input). Stores an
 // empty ai_summary plus a non-null skip_reason so the article drops out of the
 // backfill set and isn't retried each cycle.
-func (s *SQLiteStore) MarkSummarizationSkipped(userID, articleID int64, reason string) error {
+func (s *SQLiteStore) MarkSummarizationSkipped(articleID int64, reason string) error {
 	_, err := s.db.Exec(
-		`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
-		 VALUES (?, ?, '', ?)
-		 ON CONFLICT(user_id, article_id) DO UPDATE SET
+		`INSERT INTO article_summaries (article_id, ai_summary, skip_reason)
+		 VALUES (?, '', ?)
+		 ON CONFLICT(article_id) DO UPDATE SET
 		   skip_reason = excluded.skip_reason,
 		   generated_at = CURRENT_TIMESTAMP`,
-		userID, articleID, reason,
+		articleID, reason,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to mark summarization skipped: %w", err)
@@ -1440,13 +1440,13 @@ func (s *SQLiteStore) MarkSummarizationSkipped(userID, articleID int64, reason s
 	return nil
 }
 
-// GetArticleSummary retrieves the AI summary for an article for a specific user
-func (s *SQLiteStore) GetArticleSummary(userID, articleID int64) (*ArticleSummary, error) {
+// GetArticleSummary retrieves the shared AI summary for an article.
+func (s *SQLiteStore) GetArticleSummary(articleID int64) (*ArticleSummary, error) {
 	var as ArticleSummary
 	err := s.db.QueryRow(
-		"SELECT user_id, article_id, ai_summary, generated_at FROM article_summaries WHERE user_id = ? AND article_id = ?",
-		userID, articleID,
-	).Scan(&as.UserID, &as.ArticleID, &as.AISummary, &as.GeneratedAt)
+		"SELECT article_id, ai_summary, generated_at FROM article_summaries WHERE article_id = ?",
+		articleID,
+	).Scan(&as.ArticleID, &as.AISummary, &as.GeneratedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1483,10 +1483,10 @@ func (s *SQLiteStore) GetFeedStats(userID int64) ([]FeedStats, error) {
 		JOIN user_feeds uf ON uf.feed_id = f.id AND uf.user_id = ?
 		JOIN articles a ON a.feed_id = f.id
 		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = ?
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
 		GROUP BY f.id, uf.user_title
 		ORDER BY COALESCE(uf.user_title, f.title)`,
-		userID, userID, userID,
+		userID, userID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get feed stats: %w", err)
@@ -1551,11 +1551,12 @@ func (s *SQLiteStore) GetProcessingStats(userID int64) (*ProcessingStats, error)
 		return nil, fmt.Errorf("get processing stats (funnel): %w", err)
 	}
 
+	// Summaries are per-article and shared by all subscribers (#162), so these
+	// two funnel numbers are global, like the security columns above.
 	err = s.db.QueryRow(`
 		SELECT
-			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND ai_summary <> ''),
-			(SELECT COUNT(*) FROM article_summaries WHERE user_id = ? AND COALESCE(skip_reason, '') <> '')`,
-		userID, userID,
+			(SELECT COUNT(*) FROM article_summaries WHERE ai_summary <> ''),
+			(SELECT COUNT(*) FROM article_summaries WHERE COALESCE(skip_reason, '') <> '')`,
 	).Scan(&p.Summarized, &p.SummarizeSkipped)
 	if err != nil {
 		return nil, fmt.Errorf("get processing stats (summaries): %w", err)
@@ -2369,17 +2370,16 @@ func (s *SQLiteStore) GetUnscoredArticleCount(userID int64) (int, error) {
 	return count, nil
 }
 
-// GetUnsummarizedArticleCount returns the number of articles from the user's
-// subscribed feeds that have no AI summary yet (pending content summarization).
-func (s *SQLiteStore) GetUnsummarizedArticleCount(userID int64) (int, error) {
+// GetUnsummarizedArticleCount returns the number of articles that have no
+// shared AI summary yet (pending content summarization). Global, like the
+// summarize pass itself (#162).
+func (s *SQLiteStore) GetUnsummarizedArticleCount() (int, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT COUNT(*)
 		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = ?
-		WHERE uf.user_id = ? AND asumm.article_id IS NULL`,
-		userID, userID,
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
+		WHERE asumm.article_id IS NULL`,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("get unsummarized article count: %w", err)
@@ -2387,24 +2387,22 @@ func (s *SQLiteStore) GetUnsummarizedArticleCount(userID int64) (int, error) {
 	return count, nil
 }
 
-// GetUnsummarizedScoredArticles returns articles that have been AI-scored with
-// a passing security score but lack a cached AI summary. Used by the daemon's
-// summary backfill pass to re-attempt summarization that failed transiently
-// (e.g., Ollama timeout, garbled output) during the original scoring cycle.
-func (s *SQLiteStore) GetUnsummarizedScoredArticles(userID int64, securityThreshold float64, limit int) ([]Article, error) {
+// GetUnsummarizedScoredArticles returns articles that passed the security
+// screen but lack a cached AI summary. Global — the summary is a property of
+// the article, shared by all subscribers (#162) — so this drives the daemon's
+// once-per-cycle summarize pass, mirroring GetUnscreenedArticles.
+func (s *SQLiteStore) GetUnsummarizedScoredArticles(securityThreshold float64, limit int) ([]Article, error) {
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date
 		FROM articles a
-		JOIN user_feeds uf ON a.feed_id = uf.feed_id
-		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id AND asumm.user_id = uf.user_id
-		WHERE uf.user_id = ?
-		  AND a.security_score >= ?
+		LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
+		WHERE a.security_score >= ?
 		  AND asumm.article_id IS NULL
 		ORDER BY a.published_date DESC
 		LIMIT ?
 	`
-	rows, err := s.db.Query(query, userID, securityThreshold, limit)
+	rows, err := s.db.Query(query, securityThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get unsummarized scored articles: %w", err)
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2824,20 +2824,26 @@ func (s *SQLiteStore) GetFilterRules(userID int64, feedID *int64) ([]FilterRule,
 	return rules, rows.Err()
 }
 
-// UpdateFilterRuleScore updates the score of an existing filter rule.
-func (s *SQLiteStore) UpdateFilterRuleScore(ruleID int64, score int) error {
-	_, err := s.db.Exec("UPDATE filter_rules SET score = ? WHERE id = ?", score, ruleID)
+// UpdateFilterRuleScore updates the score of an existing filter rule owned by the user.
+func (s *SQLiteStore) UpdateFilterRuleScore(userID, ruleID int64, score int) error {
+	res, err := s.db.Exec("UPDATE filter_rules SET score = ? WHERE id = ? AND user_id = ?", score, ruleID, userID)
 	if err != nil {
 		return fmt.Errorf("update filter rule score: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("filter rule %d not found for user %d", ruleID, userID)
 	}
 	return nil
 }
 
-// DeleteFilterRule deletes a filter rule by ID.
-func (s *SQLiteStore) DeleteFilterRule(ruleID int64) error {
-	_, err := s.db.Exec("DELETE FROM filter_rules WHERE id = ?", ruleID)
+// DeleteFilterRule deletes a filter rule by ID, scoped to the owning user.
+func (s *SQLiteStore) DeleteFilterRule(userID, ruleID int64) error {
+	res, err := s.db.Exec("DELETE FROM filter_rules WHERE id = ? AND user_id = ?", ruleID, userID)
 	if err != nil {
 		return fmt.Errorf("delete filter rule: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("filter rule %d not found for user %d", ruleID, userID)
 	}
 	return nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -571,7 +571,7 @@ func TestArticleSummary(t *testing.T) {
 	})
 
 	// No summary initially
-	summary, err := store.GetArticleSummary(1, articleID)
+	summary, err := store.GetArticleSummary(articleID)
 	if err != nil {
 		t.Fatalf("GetArticleSummary failed: %v", err)
 	}
@@ -580,12 +580,12 @@ func TestArticleSummary(t *testing.T) {
 	}
 
 	// Set a summary
-	if err := store.UpdateArticleAISummary(1, articleID, "This is an AI summary"); err != nil {
+	if err := store.UpdateArticleAISummary(articleID, "This is an AI summary"); err != nil {
 		t.Fatalf("UpdateArticleAISummary failed: %v", err)
 	}
 
 	// Retrieve it
-	summary, err = store.GetArticleSummary(1, articleID)
+	summary, err = store.GetArticleSummary(articleID)
 	if err != nil {
 		t.Fatalf("GetArticleSummary failed: %v", err)
 	}
@@ -595,8 +595,8 @@ func TestArticleSummary(t *testing.T) {
 	if summary.AISummary != "This is an AI summary" {
 		t.Errorf("summary = %q, want %q", summary.AISummary, "This is an AI summary")
 	}
-	if summary.UserID != 1 || summary.ArticleID != articleID {
-		t.Errorf("summary IDs mismatch: user=%d article=%d", summary.UserID, summary.ArticleID)
+	if summary.ArticleID != articleID {
+		t.Errorf("summary article ID mismatch: article=%d", summary.ArticleID)
 	}
 }
 
@@ -1411,7 +1411,7 @@ func TestMigrateStore(t *testing.T) {
 
 	src.StoreArticleAuthors(artID, []ArticleAuthor{{Name: "Author One", Email: "a@b.com"}})
 	src.StoreArticleCategories(artID, []string{"Security"})
-	src.UpdateArticleAISummary(1, artID, "AI summary text")
+	src.UpdateArticleAISummary(artID, "AI summary text")
 
 	groupID, _ := src.CreateArticleGroup(1, "Cluster")
 	src.AddArticleToGroup(groupID, artID)
@@ -1797,7 +1797,7 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		URL: "https://example.com/1", PublishedDate: &now,
 	})
 	store.ScreenArticleSecurity(a1, 10.0, "", false)
-	store.UpdateArticleAISummary(1, a1, "an existing summary")
+	store.UpdateArticleAISummary(a1, "an existing summary")
 
 	// Article 2: scored, passed security, NO summary — included.
 	a2, _ := store.AddArticle(&Article{
@@ -1825,11 +1825,11 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 		URL: "https://example.com/5", PublishedDate: &now,
 	})
 	store.ScreenArticleSecurity(a5, 10.0, "", false)
-	if err := store.MarkSummarizationSkipped(1, a5, "summary longer than content"); err != nil {
+	if err := store.MarkSummarizationSkipped(a5, "summary longer than content"); err != nil {
 		t.Fatalf("MarkSummarizationSkipped: %v", err)
 	}
 
-	got, err := store.GetUnsummarizedScoredArticles(1, 7.0, 100)
+	got, err := store.GetUnsummarizedScoredArticles(7.0, 100)
 	if err != nil {
 		t.Fatalf("GetUnsummarizedScoredArticles: %v", err)
 	}
@@ -1844,7 +1844,7 @@ func TestGetUnsummarizedScoredArticles(t *testing.T) {
 	// a1 has a summary row, a5 has a sentinel row — both are excluded.
 	// a2 (scored, no summary), a3 (security-failed, no summary row written),
 	// and a4 (never scored, no summary row) are all counted.
-	count, err := store.GetUnsummarizedArticleCount(1)
+	count, err := store.GetUnsummarizedArticleCount()
 	if err != nil {
 		t.Fatalf("GetUnsummarizedArticleCount: %v", err)
 	}
@@ -2765,7 +2765,7 @@ func TestSetInterestScorePreservesSecurity(t *testing.T) {
 		// Security score must survive (>= 7.0), so the article still qualifies as
 		// security-passed for the summary stage. If SetInterestScore had nulled it,
 		// this query would return nothing.
-		scored, err := store.GetUnsummarizedScoredArticles(1, 7.0, 10)
+		scored, err := store.GetUnsummarizedScoredArticles(7.0, 10)
 		if err != nil {
 			t.Fatalf("GetUnsummarizedScoredArticles: %v", err)
 		}
@@ -2878,7 +2878,7 @@ func TestGetProcessingStats(t *testing.T) {
 	if err := store.SetInterestScore(1, a2, 7); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.UpdateArticleAISummary(1, a2, "a real summary"); err != nil {
+	if err := store.UpdateArticleAISummary(a2, "a real summary"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2886,7 +2886,7 @@ func TestGetProcessingStats(t *testing.T) {
 	if err := store.ScreenArticleSecurity(a3, 3, "unsafe", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.MarkSummarizationSkipped(1, a3, "too short"); err != nil {
+	if err := store.MarkSummarizationSkipped(a3, "too short"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2966,3 +2966,39 @@ func TestCycleStats(t *testing.T) {
 		t.Fatalf("limit=1 returned %d rows", len(one))
 	}
 }
+
+func TestFilterRuleUserScoping(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	id, err := store.AddFilterRule(&FilterRule{UserID: 1, Axis: "author", Value: "Alice", Score: 5})
+	if err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	// Another user can neither update nor delete the rule.
+	if err := store.UpdateFilterRuleScore(2, id, 10); err == nil {
+		t.Error("expected error updating another user's rule")
+	}
+	if err := store.DeleteFilterRule(2, id); err == nil {
+		t.Error("expected error deleting another user's rule")
+	}
+	rules, err := store.GetFilterRules(1, nil)
+	if err != nil {
+		t.Fatalf("GetFilterRules: %v", err)
+	}
+	if len(rules) != 1 || rules[0].Score != 5 {
+		t.Fatalf("rule should survive cross-user mutations unchanged, got %+v", rules)
+	}
+
+	// The owner can do both.
+	if err := store.UpdateFilterRuleScore(1, id, 10); err != nil {
+		t.Fatalf("owner UpdateFilterRuleScore: %v", err)
+	}
+	if err := store.DeleteFilterRule(1, id); err != nil {
+		t.Fatalf("owner DeleteFilterRule: %v", err)
+	}
+	if rules, _ := store.GetFilterRules(1, nil); len(rules) != 0 {
+		t.Errorf("expected 0 rules after owner delete, got %d", len(rules))
+	}
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -3030,3 +3030,241 @@ func TestUserSubscribedToArticleFeed(t *testing.T) {
 		}
 	})
 }
+
+// TestDeleteUser verifies that DeleteUser removes rows in every per-user table
+// and leaves other users' data untouched.
+func TestDeleteUser(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		// Create two users. User 2 is the one we will delete; user 3 acts as a
+		// bystander whose rows must survive.
+		delID, err := store.CreateUser("DeleteMe")
+		if err != nil {
+			t.Fatalf("CreateUser del: %v", err)
+		}
+		keepID, err := store.CreateUser("KeepMe")
+		if err != nil {
+			t.Fatalf("CreateUser keep: %v", err)
+		}
+
+		// Seed a feed and article used by both users.
+		feedID, err := store.AddFeed("https://example.com/feed", "Test Feed", "")
+		if err != nil {
+			t.Fatalf("AddFeed: %v", err)
+		}
+		pub := time.Now().Add(-time.Hour)
+		articleID, err := store.AddArticle(&Article{
+			FeedID: feedID, GUID: "del-test-guid", Title: "T",
+			URL: "https://example.com/a", PublishedDate: &pub,
+		})
+		if err != nil {
+			t.Fatalf("AddArticle: %v", err)
+		}
+
+		// --- Seed per-user rows for the deleted user ---
+
+		// read_state
+		if err := store.SubscribeUserToFeed(delID, feedID); err != nil {
+			t.Fatalf("subscribe del: %v", err)
+		}
+		score := 0.8
+		if err := store.UpdateReadState(delID, articleID, false, &score, &score, nil, nil); err != nil {
+			t.Fatalf("UpdateReadState del: %v", err)
+		}
+
+		// user_preferences
+		if err := store.SetUserPreference(delID, "theme", "dark"); err != nil {
+			t.Fatalf("SetUserPreference del: %v", err)
+		}
+
+		// feed_tags
+		if err := store.AddFeedTag(delID, feedID, "testtag"); err != nil {
+			t.Fatalf("AddFeedTag del: %v", err)
+		}
+
+		// user_prompts
+		if err := store.SetUserPrompt(delID, "curation", "custom prompt", nil, nil); err != nil {
+			t.Fatalf("SetUserPrompt del: %v", err)
+		}
+
+		// filter_rules
+		ruleID, err := store.AddFilterRule(&FilterRule{UserID: delID, Axis: "author", Value: "spam", Score: -100})
+		if err != nil {
+			t.Fatalf("AddFilterRule del: %v", err)
+		}
+		if ruleID == 0 {
+			t.Fatal("expected non-zero rule id")
+		}
+
+		// article_groups (+ article_group_members cascade)
+		groupID, err := store.CreateArticleGroup(delID, "TestGroup")
+		if err != nil {
+			t.Fatalf("CreateArticleGroup del: %v", err)
+		}
+		if err := store.AddArticleToGroup(groupID, articleID); err != nil {
+			t.Fatalf("AddArticleToGroup del: %v", err)
+		}
+		if err := store.UpdateGroupSummary(groupID, "head", "body", 1, nil); err != nil {
+			t.Fatalf("UpdateGroupSummary del: %v", err)
+		}
+
+		// fever_credentials (ON DELETE CASCADE from users)
+		if err := store.SetFeverCredential(delID, "test-api-key"); err != nil {
+			t.Fatalf("SetFeverCredential del: %v", err)
+		}
+
+		// newsletters + newsletter_issues (ON DELETE CASCADE from users)
+		nlID, err := store.CreateNewsletter(&Newsletter{
+			UserID: delID, Name: "Test NL", Schedule: "manual",
+			Config: NewsletterConfig{MaxArticles: 10},
+		})
+		if err != nil {
+			t.Fatalf("CreateNewsletter del: %v", err)
+		}
+		issueID, err := store.CreateNewsletterIssue(&NewsletterIssue{
+			NewsletterID: nlID, Headline: "iss1", ContentHTML: "<p>body</p>",
+		})
+		if err != nil {
+			t.Fatalf("CreateNewsletterIssue del: %v", err)
+		}
+		if issueID == 0 {
+			t.Fatal("expected non-zero issue id")
+		}
+
+		// ai_summaries (ON DELETE CASCADE from users)
+		sumID, err := store.CreateAISummary(&AISummary{
+			UserID: delID, Model: "test-model", Prompt: "test prompt",
+		})
+		if err != nil {
+			t.Fatalf("CreateAISummary del: %v", err)
+		}
+		if sumID == 0 {
+			t.Fatal("expected non-zero summary id")
+		}
+
+		// --- Seed bystander rows for the kept user ---
+		if err := store.SubscribeUserToFeed(keepID, feedID); err != nil {
+			t.Fatalf("subscribe keep: %v", err)
+		}
+		if err := store.UpdateReadState(keepID, articleID, false, &score, &score, nil, nil); err != nil {
+			t.Fatalf("UpdateReadState keep: %v", err)
+		}
+		if err := store.SetUserPreference(keepID, "theme", "light"); err != nil {
+			t.Fatalf("SetUserPreference keep: %v", err)
+		}
+		if err := store.SetUserPrompt(keepID, "curation", "keep prompt", nil, nil); err != nil {
+			t.Fatalf("SetUserPrompt keep: %v", err)
+		}
+		keepNlID, err := store.CreateNewsletter(&Newsletter{
+			UserID: keepID, Name: "Keep NL", Schedule: "manual",
+			Config: NewsletterConfig{MaxArticles: 5},
+		})
+		if err != nil {
+			t.Fatalf("CreateNewsletter keep: %v", err)
+		}
+		if keepNlID == 0 {
+			t.Fatal("expected non-zero keep newsletter id")
+		}
+
+		// --- Delete the target user ---
+		if err := store.DeleteUser(delID); err != nil {
+			t.Fatalf("DeleteUser: %v", err)
+		}
+
+		// --- Assert: deleted user's rows are gone in every table ---
+
+		// users row
+		users, _ := store.ListUsers()
+		for _, u := range users {
+			if u.ID == delID {
+				t.Errorf("deleted user row still present: id=%d", delID)
+			}
+		}
+
+		// read_state
+		feeds, _ := store.GetUserFeeds(delID)
+		if len(feeds) != 0 {
+			t.Errorf("user_feeds: expected 0 for deleted user, got %d", len(feeds))
+		}
+
+		// user_preferences
+		prefs, _ := store.GetAllUserPreferences(delID)
+		if len(prefs) != 0 {
+			t.Errorf("user_preferences: expected 0 for deleted user, got %d", len(prefs))
+		}
+
+		// feed_tags
+		tags, _ := store.GetUserTags(delID)
+		if len(tags) != 0 {
+			t.Errorf("feed_tags: expected 0 for deleted user, got %d", len(tags))
+		}
+
+		// user_prompts
+		prompts, _ := store.ListUserPrompts(delID)
+		if len(prompts) != 0 {
+			t.Errorf("user_prompts: expected 0 for deleted user, got %d", len(prompts))
+		}
+
+		// filter_rules
+		rules, _ := store.GetFilterRules(delID, nil)
+		if len(rules) != 0 {
+			t.Errorf("filter_rules: expected 0 for deleted user, got %d", len(rules))
+		}
+
+		// article_groups + cascade of article_group_members and group_summaries
+		groups, _ := store.GetUserGroups(delID)
+		if len(groups) != 0 {
+			t.Errorf("article_groups: expected 0 for deleted user, got %d", len(groups))
+		}
+		// The group row is gone, so GetGroupSummary should not find it.
+		if gs, err := store.GetGroupSummary(groupID); err == nil && gs != nil {
+			t.Errorf("group_summaries: expected gone after group delete, got headline=%q", gs.Headline)
+		}
+
+		// fever_credentials (cascaded via users FK)
+		if u, err := store.GetUserByFeverAPIKey("test-api-key"); err == nil && u != nil {
+			t.Errorf("fever_credentials: expected gone after user delete")
+		}
+
+		// newsletters + newsletter_issues (cascaded via users FK)
+		nls, _ := store.GetUserNewsletters(delID)
+		if len(nls) != 0 {
+			t.Errorf("newsletters: expected 0 for deleted user, got %d", len(nls))
+		}
+		// newsletter_issues cascade is confirmed by the newsletter itself being gone;
+		// no direct API to query issues by newsletter after the newsletter is deleted.
+
+		// ai_summaries (cascaded via users FK)
+		if s, err := store.GetAISummary(delID, sumID); err == nil && s != nil {
+			t.Errorf("ai_summaries: expected gone after user delete, got id=%d", s.ID)
+		}
+
+		// --- Assert: bystander (kept user) rows are untouched ---
+		keepFeeds, _ := store.GetUserFeeds(keepID)
+		if len(keepFeeds) == 0 {
+			t.Errorf("user_feeds: kept user's feeds should survive deletion of other user")
+		}
+		keepPrefs, _ := store.GetAllUserPreferences(keepID)
+		if len(keepPrefs) == 0 {
+			t.Errorf("user_preferences: kept user's prefs should survive")
+		}
+		keepPrompts, _ := store.ListUserPrompts(keepID)
+		if len(keepPrompts) == 0 {
+			t.Errorf("user_prompts: kept user's prompts should survive")
+		}
+		keepNls, _ := store.GetUserNewsletters(keepID)
+		if len(keepNls) == 0 {
+			t.Errorf("newsletters: kept user's newsletters should survive")
+		}
+	})
+}
+
+// TestDeleteUserIdemptotent confirms that deleting a non-existent user
+// succeeds without error (all DELETEs match 0 rows, which is fine).
+func TestDeleteUserIdempotent(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		// No user with id 99999 exists; DeleteUser should not error.
+		if err := store.DeleteUser(99999); err != nil {
+			t.Errorf("DeleteUser non-existent user: want nil, got %v", err)
+		}
+	})
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -3002,3 +3002,31 @@ func TestFilterRuleUserScoping(t *testing.T) {
 		t.Errorf("expected 0 rules after owner delete, got %d", len(rules))
 	}
 }
+
+func TestUserSubscribedToArticleFeed(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+			t.Fatalf("subscribe: %v", err)
+		}
+		now := time.Now()
+		articleID, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "g", Title: "g",
+			URL: "https://example.com/g", PublishedDate: &now})
+
+		// Subscriber sees the article's feed.
+		ok, err := store.UserSubscribedToArticleFeed(1, articleID)
+		if err != nil || !ok {
+			t.Errorf("subscriber = (%v, %v), want (true, nil)", ok, err)
+		}
+		// Non-subscriber does not.
+		ok, err = store.UserSubscribedToArticleFeed(2, articleID)
+		if err != nil || ok {
+			t.Errorf("non-subscriber = (%v, %v), want (false, nil)", ok, err)
+		}
+		// Nonexistent article is false, nil.
+		ok, err = store.UserSubscribedToArticleFeed(1, 999999)
+		if err != nil || ok {
+			t.Errorf("unknown article = (%v, %v), want (false, nil)", ok, err)
+		}
+	})
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1006,7 +1006,7 @@ func TestFilterRulesCRUD(t *testing.T) {
 	}
 
 	// Update score
-	if err := store.UpdateFilterRuleScore(id1, 10); err != nil {
+	if err := store.UpdateFilterRuleScore(1, id1, 10); err != nil {
 		t.Fatalf("UpdateFilterRuleScore: %v", err)
 	}
 	rules, _ = store.GetFilterRules(1, nil)
@@ -1031,7 +1031,7 @@ func TestFilterRulesCRUD(t *testing.T) {
 	}
 
 	// Delete
-	if err := store.DeleteFilterRule(id2); err != nil {
+	if err := store.DeleteFilterRule(1, id2); err != nil {
 		t.Fatalf("DeleteFilterRule: %v", err)
 	}
 	rules, _ = store.GetFilterRules(1, nil)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -68,6 +68,8 @@ type Store interface {
 	CreateUserWithOIDC(name, email, sub string) (*User, error)
 	UpdateUserOIDCEmail(id int64, email string) error
 	ListUsers() ([]User, error)
+	// DeleteUser removes a user and all rows they own, atomically.
+	DeleteUser(userID int64) error
 
 	// User prompts
 	GetUserPrompt(userID int64, promptType string) (string, error)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -123,8 +123,8 @@ type Store interface {
 	GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int) ([]Article, error)
 	GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int) ([]Article, error)
 	GetUnscoredArticleCount(userID int64) (int, error)
-	GetUnsummarizedArticleCount(userID int64) (int, error)
-	GetUnsummarizedScoredArticles(userID int64, securityThreshold float64, limit int) ([]Article, error)
+	GetUnsummarizedArticleCount() (int, error)
+	GetUnsummarizedScoredArticles(securityThreshold float64, limit int) ([]Article, error)
 	GetUnscoredCurationArticles(userID int64, securityThreshold float64, limit int) ([]Article, error)
 	GetUngroupedEmbeddedArticles(userID int64, model string, securityThreshold float64, since time.Time, limit int) ([]Article, error)
 	GetArticlesNeedingFullText(limit int) ([]Article, error)
@@ -158,10 +158,10 @@ type Store interface {
 	DeleteFilterRule(userID, ruleID int64) error
 	HasFilterRules(userID int64) (bool, error)
 
-	// Article summaries
-	UpdateArticleAISummary(userID, articleID int64, aiSummary string) error
-	MarkSummarizationSkipped(userID, articleID int64, reason string) error
-	GetArticleSummary(userID, articleID int64) (*ArticleSummary, error)
+	// Article summaries (per-article, shared by all subscribers — #162)
+	UpdateArticleAISummary(articleID int64, aiSummary string) error
+	MarkSummarizationSkipped(articleID int64, reason string) error
+	GetArticleSummary(articleID int64) (*ArticleSummary, error)
 
 	// Feed stats
 	GetFeedStats(userID int64) ([]FeedStats, error)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -154,8 +154,8 @@ type Store interface {
 	// Filter rules
 	AddFilterRule(rule *FilterRule) (int64, error)
 	GetFilterRules(userID int64, feedID *int64) ([]FilterRule, error)
-	UpdateFilterRuleScore(ruleID int64, score int) error
-	DeleteFilterRule(ruleID int64) error
+	UpdateFilterRuleScore(userID, ruleID int64, score int) error
+	DeleteFilterRule(userID, ruleID int64) error
 	HasFilterRules(userID int64) (bool, error)
 
 	// Article summaries

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -141,6 +141,10 @@ type Store interface {
 
 	GetStarredArticles(userID int64, limit, offset int, filterThreshold *int) ([]Article, error)
 
+	// UserSubscribedToArticleFeed reports whether the user is subscribed to the
+	// feed that owns the article. Unknown article IDs return false, nil.
+	UserSubscribedToArticleFeed(userID, articleID int64) (bool, error)
+
 	// Article metadata
 	StoreArticleAuthors(articleID int64, authors []ArticleAuthor) error
 	StoreArticleCategories(articleID int64, categories []string) error

--- a/internal/storage/summary_perarticle_test.go
+++ b/internal/storage/summary_perarticle_test.go
@@ -1,0 +1,217 @@
+package storage
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Article summaries moved from per-(user, article) rows onto the article
+// itself (#162), like the security verdict before them (#141). These tests
+// cover the one-time table rebuild from the legacy per-user shape, its
+// idempotency, and the shared-row semantics both store methods rely on.
+
+// seedOldSummariesSchema creates a database whose article_summaries table has
+// the legacy per-user shape, seeded with the given rows, and returns the two
+// article IDs. Row layout per article:
+//
+//	articleA: user 1 -> skip marker, user 2 -> real summary
+//	articleB: user 3 -> skip marker only
+func seedOldSummariesSchema(t *testing.T, path string) (articleA, articleB int64) {
+	t.Helper()
+
+	s1, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	feedID, _ := s1.AddFeed("https://example.com/feed", "Feed", "")
+	now := time.Now()
+	articleA, _ = s1.AddArticle(&Article{FeedID: feedID, GUID: "a", Title: "a",
+		URL: "https://example.com/a", PublishedDate: &now})
+	articleB, _ = s1.AddArticle(&Article{FeedID: feedID, GUID: "b", Title: "b",
+		URL: "https://example.com/b", PublishedDate: &now})
+	if err := s1.Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	// Swap in the OLD per-user table shape and seed legacy rows with a raw
+	// connection, bypassing the store (whose open would migrate it back).
+	db, err := sql.Open("sqlite", path+"?_time_format=sqlite&_pragma=busy_timeout(15000)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(q, args...); err != nil {
+			t.Fatalf("seed legacy article_summaries: %v", err)
+		}
+	}
+	mustExec(`DROP TABLE article_summaries`)
+	mustExec(`CREATE TABLE article_summaries (
+		user_id INTEGER NOT NULL DEFAULT 1,
+		article_id INTEGER NOT NULL,
+		ai_summary TEXT NOT NULL,
+		skip_reason TEXT,
+		generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (user_id, article_id),
+		FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+	)`)
+	mustExec(`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+	          VALUES (1, ?, '', 'could not compress')`, articleA)
+	mustExec(`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+	          VALUES (2, ?, 'the real summary', NULL)`, articleA)
+	mustExec(`INSERT INTO article_summaries (user_id, article_id, ai_summary, skip_reason)
+	          VALUES (3, ?, '', 'over budget')`, articleB)
+	if err := db.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+	return articleA, articleB
+}
+
+func summaryRowCount(t *testing.T, s *SQLiteStore) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM article_summaries`).Scan(&n); err != nil {
+		t.Fatalf("count article_summaries: %v", err)
+	}
+	return n
+}
+
+// TestArticleSummariesMigrationPrefersRealSummary verifies the rebuild keeps
+// exactly one row per article and that a real summary outranks a skip marker
+// regardless of user_id order — the "(ai_summary = ”) ASC" tiebreak.
+func TestArticleSummariesMigrationPrefersRealSummary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summig.db")
+	articleA, articleB := seedOldSummariesSchema(t, path)
+
+	s2, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 2 (migration): %v", err)
+	}
+	defer s2.Close()
+
+	if n := summaryRowCount(t, s2); n != 2 {
+		t.Fatalf("expected 2 rows after dedup, got %d", n)
+	}
+
+	// The real summary (user 2) won over user 1's skip marker.
+	sum, err := s2.GetArticleSummary(articleA)
+	if err != nil || sum == nil {
+		t.Fatalf("GetArticleSummary A: %+v err=%v", sum, err)
+	}
+	if sum.AISummary != "the real summary" {
+		t.Errorf("article A summary = %q, want the user-2 real summary", sum.AISummary)
+	}
+
+	// The skip-only article kept its marker semantics.
+	var aiSummary string
+	var skipReason sql.NullString
+	if err := s2.db.QueryRow(
+		`SELECT ai_summary, skip_reason FROM article_summaries WHERE article_id = ?`, articleB,
+	).Scan(&aiSummary, &skipReason); err != nil {
+		t.Fatalf("read back B: %v", err)
+	}
+	if aiSummary != "" || !skipReason.Valid || skipReason.String != "over budget" {
+		t.Errorf("article B = (%q, %v), want a preserved skip marker", aiSummary, skipReason)
+	}
+
+	// The user_id column is gone.
+	if needsArticleSummariesMigration(s2.db.DB) {
+		t.Error("table still has a user_id column after migration")
+	}
+}
+
+// TestArticleSummariesMigrationIdempotent opens the same database twice: the
+// second open must succeed and leave the row count unchanged.
+func TestArticleSummariesMigrationIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summig-idem.db")
+	seedOldSummariesSchema(t, path)
+
+	s2, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 2 (migration): %v", err)
+	}
+	count := summaryRowCount(t, s2)
+	if err := s2.Close(); err != nil {
+		t.Fatalf("close 2: %v", err)
+	}
+
+	s3, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("open 3 (idempotency): %v", err)
+	}
+	defer s3.Close()
+	if again := summaryRowCount(t, s3); again != count {
+		t.Errorf("row count changed across opens: %d then %d", count, again)
+	}
+}
+
+// TestArticleSummarySharedAcrossUsers proves one summary serves every
+// subscriber: a single UpdateArticleAISummary removes the article from the
+// global unsummarized queue and is readable without a user.
+func TestArticleSummarySharedAcrossUsers(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		for _, uid := range []int64{1, 2} {
+			if err := store.SubscribeUserToFeed(uid, feedID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		now := time.Now()
+		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "shared", Title: "shared",
+			URL: "https://example.com/shared", PublishedDate: &now})
+		if err := store.ScreenArticleSecurity(id, 8.0, "ok", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity: %v", err)
+		}
+
+		if got, _ := store.GetUnsummarizedScoredArticles(7.0, 10); len(got) != 1 || got[0].ID != id {
+			t.Fatalf("article should await one global summarization, got %v", articleIDs(got))
+		}
+
+		if err := store.UpdateArticleAISummary(id, "one shared summary"); err != nil {
+			t.Fatalf("UpdateArticleAISummary: %v", err)
+		}
+
+		sum, err := store.GetArticleSummary(id)
+		if err != nil || sum == nil || sum.AISummary != "one shared summary" {
+			t.Fatalf("GetArticleSummary = %+v err=%v, want the shared summary", sum, err)
+		}
+		if got, _ := store.GetUnsummarizedScoredArticles(7.0, 10); len(got) != 0 {
+			t.Errorf("summarized article must leave the global queue, got %v", articleIDs(got))
+		}
+	})
+}
+
+// TestSummarizationSkipSharedAcrossUsers verifies a skip marker is shared the
+// same way: one MarkSummarizationSkipped keeps the article out of the global
+// queue with no per-user retry.
+func TestSummarizationSkipSharedAcrossUsers(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		for _, uid := range []int64{1, 2} {
+			if err := store.SubscribeUserToFeed(uid, feedID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		now := time.Now()
+		id, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "skip", Title: "skip",
+			URL: "https://example.com/skip", PublishedDate: &now})
+		if err := store.ScreenArticleSecurity(id, 8.0, "ok", false); err != nil {
+			t.Fatalf("ScreenArticleSecurity: %v", err)
+		}
+
+		if err := store.MarkSummarizationSkipped(id, "summary longer than content"); err != nil {
+			t.Fatalf("MarkSummarizationSkipped: %v", err)
+		}
+
+		if got, _ := store.GetUnsummarizedScoredArticles(7.0, 10); len(got) != 0 {
+			t.Errorf("skipped article must stay out of the global queue, got %v", articleIDs(got))
+		}
+		// The marker row exists with an empty summary.
+		sum, err := store.GetArticleSummary(id)
+		if err != nil || sum == nil || sum.AISummary != "" {
+			t.Fatalf("expected an empty-summary skip row, got %+v err=%v", sum, err)
+		}
+	})
+}


### PR DESCRIPTION
This branch carries two audit-driven efforts toward running Herald as a public, multiuser service. Both were planned and reviewed under `plans/` (improve skill); every change passed `task check` (build, `go test -race`, lint, govulncheck).

## Part 1 -- Multiuser readiness

Establishes the shared-vs-per-user contract: feeds, articles, security verdicts, and AI summaries are shared (fetched/screened/summarized once); subscriptions, read state, interest scores, filters, groups, and digests are per-user.

- **Cross-user authorization (IDOR fixes)** -- filter rule update/delete, `MuteGroup`/`GetGroupArticles`, and newsletter generation now enforce per-user ownership; OPML sync token uses constant-time compare.
- **Shared per-article AI summaries** -- `article_summaries` keyed by `article_id` (was per user+article), summarization runs once globally, admin-only prompt; includes a guarded, idempotent table-rebuild migration that dedupes existing rows.
- **Subscription-gated direct access** -- `GET /articles/{id}`, `GET /images/{id}`, and starring now require a subscription to the article's feed, matching the list/search/Fever surfaces. Closes leakage of capability-URL feed content to non-subscribers.

## Part 2 -- Public-service hardening

Re-audited the codebase for open public signup (the prior pass assumed a trusted household instance). Plans 004-007, 009, plus the 005 follow-up.

- **004 SSRF (release-blocking)** -- all outbound feed/image/full-text/favicon/OPML fetches route through one HTTP client that blocks private/loopback/link-local destinations at dial time (covers DNS rebinding and redirect-to-internal), restricts schemes to http/https, caps response size, and sets timeouts.
- **005 per-user resource quotas** -- configurable caps on feeds, filter rules, and newsletters (`limits:` config block; `<= 0` = unbounded). The OPML web-import path is capped too; the local CLI import is exempt.
- **006 global LLM concurrency ceiling** -- a process-global semaphore at the Ollama `generate()` chokepoint bounds concurrent inference (daemon stages + on-demand web generation), configurable via `ollama.max_concurrent`.
- **007 web input limits, security headers, error hygiene** -- pagination `limit`/`offset` and text-field length caps; security headers incl. a Content-Security-Policy (interim: permits inline script/style; nonce tightening deferred); handlers no longer leak internal error detail (also closes SSRF reconnaissance) and return 4xx for input-driven failures.
- **009 admin user deletion** -- transactional `DeleteUser` removing all per-user rows across both SQLite and Postgres backends (explicit deletes for legacy FK-less tables, cascade for the rest), an admin-only endpoint, and a reserved-user guard (user 0 and the default user cannot be deleted).

## Deploy note

First start after this merges rebuilds `article_summaries` to the per-article shape -- guarded and idempotent, tested against the legacy schema, but it is the one schema-touching change. A pre-deploy Postgres backup was taken.

## Deferred (not in this PR)

- AI-cost entitlements / paywall metering (needs a design session).
- Nonce-based CSP tightening (remove `'unsafe-inline'` from `script-src`).
- Per-host connection/rate limits against slow *public* hosts.
- A live-Postgres run of the `DeleteUser` path (its Postgres tests are DSN-gated; SQLite path is fully exercised, Postgres path is correct-by-construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)