### PR TITLE
Read-state read-back, server-driven show/hide read, and session-expiry resilience

### DIFF
--- a/cmd/herald-mcp/server.go
+++ b/cmd/herald-mcp/server.go
@@ -120,7 +120,7 @@ func registerTools(s *mcp.Server, hs *heraldServer) {
 			return jsonResult(result)
 		}
 
-		articles, err := hs.engine.GetUnreadArticles(userID, limit, offset)
+		articles, err := hs.engine.GetUnreadArticles(userID, limit, offset, false)
 		if err != nil {
 			return errResult("%v", err)
 		}

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -213,6 +213,7 @@ type articleListData struct {
 	GroupHeadline string
 	GroupSummary  string
 	Starred       bool
+	ShowRead      bool
 }
 
 type articleRow struct {
@@ -596,6 +597,7 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 	feedID := parseInt64Param(r, "feed_id")
 	groupID := parseInt64Param(r, "group_id")
 	starred := r.URL.Query().Get("starred") == "1"
+	showRead := r.URL.Query().Get("show_read") == "1"
 
 	var articles []herald.Article
 	var err error
@@ -604,11 +606,11 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 	case starred:
 		articles, err = h.engine.GetStarredArticles(uid, limit+1, offset)
 	case groupID > 0:
-		articles, err = h.engine.GetUnreadGroupArticles(uid, groupID, limit+1, offset)
+		articles, err = h.engine.GetUnreadGroupArticles(uid, groupID, limit+1, offset, showRead)
 	case feedID > 0:
-		articles, err = h.engine.GetUnreadArticlesByFeed(uid, feedID, limit+1, offset)
+		articles, err = h.engine.GetUnreadArticlesByFeed(uid, feedID, limit+1, offset, showRead)
 	default:
-		articles, err = h.engine.GetUnreadArticles(uid, limit+1, offset)
+		articles, err = h.engine.GetUnreadArticles(uid, limit+1, offset, showRead)
 	}
 
 	if err != nil {
@@ -636,6 +638,7 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 		FeedID:     feedID,
 		GroupID:    groupID,
 		Starred:    starred,
+		ShowRead:   showRead,
 	}
 
 	// Load group summary banner when viewing a group
@@ -654,6 +657,8 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 			FeedTitle:        feedTitles[a.FeedID],
 			PublishedDateFmt: formatDate(bestDate(a.PublishedDate, &a.FetchedDate)),
 			SecurityFlagged:  a.SecurityFlagged,
+			Read:             a.Read,
+			Starred:          a.Starred,
 		})
 	}
 

--- a/cmd/herald-web/handlers.go
+++ b/cmd/herald-web/handlers.go
@@ -244,6 +244,7 @@ type articleViewData struct {
 	AISummary              string
 	SanitizedContent       template.HTML
 	Starred                bool
+	Read                   bool
 	SecurityFlagged        bool
 	LinkedURL              string
 	LinkedDomain           string
@@ -782,6 +783,9 @@ func (h *handlers) handleArticleView(w http.ResponseWriter, r *http.Request) {
 		SanitizedContent: template.HTML(sanitized), //nolint:gosec // sanitized by bluemonday
 		SecurityFlagged:  article.SecurityFlagged,
 		LinkedURL:        article.LinkedURL,
+		// The article was just auto-marked read above, so the toggle starts
+		// in the read state (offering "Mark unread").
+		Read: true,
 	}
 	if article.LinkedURL != "" {
 		if u, err := url.Parse(article.LinkedURL); err == nil {
@@ -1065,6 +1069,40 @@ func (h *handlers) handleStarToggle(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w,
 		`<button class="%s" data-star-toggle hx-post="/articles/%d/star" hx-swap="outerHTML" hx-vals='{"starred":"%s"}'>%s</button>`,
 		cls, articleID, nextState, label)
+}
+
+// handleReadToggle sets the article's read state for the user and returns the
+// updated toggle button. Opening an article auto-marks it read, so the primary
+// use is marking an article unread again to revisit it later.
+func (h *handlers) handleReadToggle(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	articleID, err := strconv.ParseInt(r.PathValue("articleID"), 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid article ID")
+		return
+	}
+
+	// Default to marking read; the button posts read=false to mark unread.
+	read := r.FormValue("read") != "false"
+	if err := h.engine.SetArticleRead(uid, articleID, read); err != nil {
+		h.renderError(w, http.StatusInternalServerError, "Failed to toggle read state")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, readToggleButton(articleID, read))
+}
+
+// readToggleButton renders the mark-read/unread button for an article in the
+// given read state. Toggling refreshes the sidebar so unread counts track.
+func readToggleButton(articleID int64, read bool) string {
+	nextState, label := "true", "Mark read"
+	if read {
+		nextState, label = "false", "Mark unread"
+	}
+	return fmt.Sprintf(
+		`<button class="outline" data-read-toggle hx-post="/articles/%d/read" hx-swap="outerHTML" hx-vals='{"read":"%s"}' hx-on::after-request="htmx.trigger(document.body, 'feeds-changed')">%s</button>`,
+		articleID, nextState, label)
 }
 
 // discoverResultsData is the template data for the feed_discover_results fragment.

--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -544,6 +544,47 @@ func TestHandleStarToggle(t *testing.T) {
 	}
 }
 
+func TestHandleReadToggle(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	path := "/articles/" + itoa(tf.articleID) + "/read"
+
+	// Mark unread: button should now offer to mark read again, and the
+	// article should reappear in the user's unread list.
+	rr := authedRequestForm(t, tf, "POST", path, url.Values{"read": {"false"}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("mark-unread status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "Mark read") {
+		t.Errorf("response should offer to mark read, got %q", rr.Body.String())
+	}
+	unread, err := tf.engine.GetUnreadArticles(tf.userID, 10, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles: %v", err)
+	}
+	if len(unread) != 1 || unread[0].ID != tf.articleID {
+		t.Errorf("expected article %d back in unread list, got %d articles", tf.articleID, len(unread))
+	}
+
+	// Mark read again: button offers to mark unread, article leaves the list.
+	rr = authedRequestForm(t, tf, "POST", path, url.Values{"read": {"true"}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("mark-read status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "Mark unread") {
+		t.Errorf("response should offer to mark unread, got %q", rr.Body.String())
+	}
+	unread, _ = tf.engine.GetUnreadArticles(tf.userID, 10, 0, false)
+	if len(unread) != 0 {
+		t.Errorf("expected no unread articles after marking read, got %d", len(unread))
+	}
+	// But it is returned when read articles are included, flagged read.
+	all, _ := tf.engine.GetUnreadArticles(tf.userID, 10, 0, true)
+	if len(all) != 1 || !all[0].Read {
+		t.Errorf("expected 1 read article with includeRead, got %d", len(all))
+	}
+}
+
 func TestHandleSidebar(t *testing.T) {
 	tf := newTestFixtures(t)
 

--- a/cmd/herald-web/routes.go
+++ b/cmd/herald-web/routes.go
@@ -93,6 +93,7 @@ func newRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("GET /sidebar", auth(http.HandlerFunc(h.handleSidebar)))
 	mux.Handle("POST /articles/mark-all-read", auth(http.HandlerFunc(h.handleMarkAllRead)), smoke.Form(url.Values{"ids": {"1"}}))
 	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Example("articleID", "1"), smoke.Form(url.Values{"starred": {"true"}}))
+	mux.Handle("POST /articles/{articleID}/read", auth(http.HandlerFunc(h.handleReadToggle)), smoke.Example("articleID", "1"), smoke.Form(url.Values{"read": {"false"}}))
 	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)), smoke.Example("imageID", "1"))
 	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/export.opml", auth(http.HandlerFunc(h.handleOPMLExport)))

--- a/cmd/herald-web/smoke-manifest.json
+++ b/cmd/herald-web/smoke-manifest.json
@@ -99,6 +99,17 @@
     },
     {
       "method": "POST",
+      "pattern": "/articles/{articleID}/read",
+      "effect": "mutating",
+      "example_params": {
+        "articleID": "1"
+      },
+      "request_body": "read=false",
+      "content_type": "application/x-www-form-urlencoded",
+      "complete": true
+    },
+    {
+      "method": "POST",
       "pattern": "/articles/{articleID}/star",
       "effect": "mutating",
       "example_params": {

--- a/cmd/herald-web/static/herald.css
+++ b/cmd/herald-web/static/herald.css
@@ -1,5 +1,31 @@
 /* Herald Web UI Layout */
 
+/* Session-expired reconnect banner. Shown when a background request gets a
+   401 so we can keep the reading pane intact instead of redirecting away. */
+.reconnect-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    background: var(--pico-del-color, #b03a2e);
+    color: #fff;
+    font-size: 0.9rem;
+    text-align: center;
+}
+
+.reconnect-banner[hidden] {
+    display: none;
+}
+
+.reconnect-banner button {
+    margin: 0;
+    padding: 0.2rem 0.8rem;
+    font-size: 0.85rem;
+    --pico-color: #fff;
+    --pico-border-color: #fff;
+}
+
 /* Main app grid: sidebar + resize handle + content */
 .app-grid {
     display: grid;

--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -20,6 +20,35 @@
         }
     }
 
+    // Graceful auth-expiry handling. When the session cookie expires, any
+    // request (including the periodic background sidebar refresh) gets a 401
+    // with an HX-Redirect header. Left to htmx, that header triggers a full
+    // page navigation to the login flow -- yanking the user off whatever
+    // article they were reading. Instead we cancel htmx's response handling
+    // and surface a non-destructive "reconnect" banner, preserving the
+    // reading pane until the user chooses to re-authenticate.
+    (function() {
+        var banner = document.getElementById('reconnect-banner');
+        var btn = document.getElementById('reconnect-btn');
+        var loginURL = '/';
+
+        document.body.addEventListener('htmx:beforeOnLoad', function(e) {
+            var xhr = e.detail && e.detail.xhr;
+            if (!xhr || xhr.status !== 401) return;
+            // Cancelling beforeOnLoad stops htmx from swapping content AND from
+            // honouring the HX-Redirect header, so the page stays put.
+            e.preventDefault();
+            loginURL = xhr.getResponseHeader('HX-Redirect') || loginURL;
+            if (banner) banner.hidden = false;
+        });
+
+        if (btn) {
+            btn.addEventListener('click', function() {
+                window.location.href = loginURL;
+            });
+        }
+    })();
+
     // Intercept sidebar link clicks to capture the current selection
     document.addEventListener('click', function(e) {
         var link = e.target.closest('#sidebar nav a[hx-get]');

--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -331,7 +331,14 @@
         applyState();
     })();
 
-    // Hide-read articles toggle
+    // Hide-read articles toggle.
+    //
+    // "Hide read" (the default) fetches only unread articles, matching the
+    // server's default. "Show read" re-fetches the list with show_read=1 so
+    // already-read articles -- including ones read in a previous session --
+    // come back, rendered faded. The choice is authoritative for every request
+    // that loads the article list (initial load, sidebar navigation, infinite
+    // scroll) via the htmx:configRequest hook below, so it survives navigation.
     (function() {
         var STORAGE_KEY = 'herald-hide-read';
         var list = document.getElementById('article-list');
@@ -343,14 +350,34 @@
 
         function applyState() {
             var hiding = isHiding();
+            // The CSS class still hides rows marked read in-session (the
+            // hx-on::after-request handler on each row), so an article you open
+            // while hiding disappears without a refetch.
             if (list) list.classList.toggle('hide-read', hiding);
             if (btn) btn.textContent = hiding ? 'Show read' : 'Hide read';
         }
+
+        // Make the toggle authoritative for every article-list request,
+        // regardless of the URL htmx started from.
+        document.body.addEventListener('htmx:configRequest', function(e) {
+            if (e.detail.path !== '/articles') return;
+            if (isHiding()) {
+                delete e.detail.parameters['show_read'];
+            } else {
+                e.detail.parameters['show_read'] = '1';
+            }
+        });
 
         if (btn) {
             btn.addEventListener('click', function() {
                 localStorage.setItem(STORAGE_KEY, isHiding() ? 'false' : 'true');
                 applyState();
+                // Re-fetch the current view; configRequest adds/removes
+                // show_read, and the OOB sidebar refreshes in the same swap.
+                if (window.htmx) {
+                    var url = '/articles' + (window._heraldSidebarQuery || '');
+                    htmx.ajax('GET', url, { target: '#article-list', swap: 'innerHTML' });
+                }
             });
         }
 

--- a/cmd/herald-web/templates/article_list.html
+++ b/cmd/herald-web/templates/article_list.html
@@ -11,7 +11,7 @@
 {{end}}
 {{if .HasMore}}
 <div class="scroll-sentinel"
-     hx-get="/articles?offset={{.NextOffset}}{{if $.FeedID}}&feed_id={{$.FeedID}}{{end}}{{if $.GroupID}}&group_id={{$.GroupID}}{{end}}{{if $.Starred}}&starred=1{{end}}"
+     hx-get="/articles?offset={{.NextOffset}}{{if $.FeedID}}&feed_id={{$.FeedID}}{{end}}{{if $.GroupID}}&group_id={{$.GroupID}}{{end}}{{if $.Starred}}&starred=1{{end}}{{if $.ShowRead}}&show_read=1{{end}}"
      hx-trigger="intersect root:#article-list"
      hx-swap="outerHTML">
     Loading more...

--- a/cmd/herald-web/templates/article_view.html
+++ b/cmd/herald-web/templates/article_view.html
@@ -48,5 +48,13 @@
             hx-swap="outerHTML">
         {{if .Starred}}&#9733; Starred{{else}}&#9734; Star{{end}}
     </button>
+    <button class="outline"
+            data-read-toggle
+            hx-post="/articles/{{.ID}}/read"
+            hx-swap="outerHTML"
+            hx-vals='{"read":"{{if .Read}}false{{else}}true{{end}}"}'
+            hx-on::after-request="htmx.trigger(document.body, 'feeds-changed')">
+        {{if .Read}}Mark unread{{else}}Mark read{{end}}
+    </button>
 </div>
 {{end}}

--- a/cmd/herald-web/templates/base.html
+++ b/cmd/herald-web/templates/base.html
@@ -16,6 +16,10 @@
     </script>
 </head>
 <body>
+    <div id="reconnect-banner" class="reconnect-banner" hidden>
+        <span>Your session expired. Reconnect to keep reading -- your current article stays put until you do.</span>
+        <button id="reconnect-btn" class="outline" type="button">Reconnect</button>
+    </div>
     <header class="top-nav">
         <div style="display:flex;flex-direction:column;gap:0;">
             <h1 style="margin-bottom:0;"><a href="/" style="text-decoration:none;color:inherit;">Herald</a></h1>

--- a/engine.go
+++ b/engine.go
@@ -198,9 +198,11 @@ func (e *Engine) FetchAllFeeds(ctx context.Context) (*FetchResult, error) {
 	}, nil
 }
 
-// GetUnreadArticles returns unread articles for a user, up to limit starting at offset.
-func (e *Engine) GetUnreadArticles(userID int64, limit, offset int) ([]Article, error) {
-	articles, err := e.store.GetUnreadArticlesForUser(userID, limit, offset, e.resolveFilterThreshold(userID))
+// GetUnreadArticles returns articles for a user, up to limit starting at offset.
+// When includeRead is true, already-read articles are returned alongside unread
+// ones (each carrying its Read/Starred state); otherwise only unread are returned.
+func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead bool) ([]Article, error) {
+	articles, err := e.store.GetUnreadArticlesForUser(userID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
 	if err != nil {
 		return nil, err
 	}
@@ -216,9 +218,10 @@ func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article,
 	return articlesFromInternal(articles), nil
 }
 
-// GetUnreadArticlesByFeed returns unread articles for a user filtered to a specific feed.
-func (e *Engine) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int) ([]Article, error) {
-	articles, err := e.store.GetUnreadArticlesByFeed(userID, feedID, limit, offset, e.resolveFilterThreshold(userID))
+// GetUnreadArticlesByFeed returns articles for a user filtered to a specific feed.
+// When includeRead is true, read articles are included alongside unread ones.
+func (e *Engine) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, includeRead bool) ([]Article, error) {
+	articles, err := e.store.GetUnreadArticlesByFeed(userID, feedID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
 	if err != nil {
 		return nil, err
 	}
@@ -545,6 +548,12 @@ func (e *Engine) BackfillEmbeddings(ctx context.Context, batchSize int) (int, er
 // MarkArticleRead marks an article as read.
 func (e *Engine) MarkArticleRead(userID, articleID int64) error {
 	return e.store.UpdateReadState(userID, articleID, true, nil, nil, nil, nil)
+}
+
+// SetArticleRead sets the read state of an article for a user to an explicit
+// value, allowing an article to be marked unread again (e.g. a manual toggle).
+func (e *Engine) SetArticleRead(userID, articleID int64, read bool) error {
+	return e.store.UpdateReadState(userID, articleID, read, nil, nil, nil, nil)
 }
 
 // MarkArticlesRead marks a list of articles as read.
@@ -946,9 +955,10 @@ func (e *Engine) GetGroupArticles(userID, groupID int64) (*ArticleGroup, error) 
 	return ag, nil
 }
 
-// GetUnreadGroupArticles returns unread articles belonging to a group.
-func (e *Engine) GetUnreadGroupArticles(userID, groupID int64, limit, offset int) ([]Article, error) {
-	articles, err := e.store.GetUnreadGroupArticles(userID, groupID, limit, offset, e.resolveFilterThreshold(userID))
+// GetUnreadGroupArticles returns articles belonging to a group. When includeRead
+// is true, read articles are included alongside unread ones.
+func (e *Engine) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, includeRead bool) ([]Article, error) {
+	articles, err := e.store.GetUnreadGroupArticles(userID, groupID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
 	if err != nil {
 		return nil, err
 	}
@@ -1866,6 +1876,8 @@ func articleFromInternal(a storage.Article) Article {
 		LinkedURL:       a.LinkedURL,
 		LinkedContent:   a.LinkedContent,
 		SecurityFlagged: a.SecurityFlagged,
+		Read:            a.Read,
+		Starred:         a.Starred,
 	}
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -129,7 +129,7 @@ func TestGetUnreadArticlesEmpty(t *testing.T) {
 	engine, cleanup := newTestEngine(t)
 	defer cleanup()
 
-	articles, err := engine.GetUnreadArticles(1, 10, 0)
+	articles, err := engine.GetUnreadArticles(1, 10, 0, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticles: %v", err)
 	}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -3261,21 +3261,6 @@ func scanArticles(rows *sql.Rows) ([]Article, error) {
 	return articles, rows.Err()
 }
 
-// scanArticlesWithFlags scans rows that include a security_flagged column after the standard article fields.
-func scanArticlesWithFlags(rows *sql.Rows) ([]Article, error) {
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate,
-			&a.SecurityFlagged); err != nil {
-			return nil, fmt.Errorf("scan article: %w", err)
-		}
-		articles = append(articles, a)
-	}
-	return articles, rows.Err()
-}
-
 // scanArticlesWithReadState scans rows that include a security_flagged column
 // plus the per-user read and starred flags, in that order, after the standard
 // article fields. Used by the list queries that surface read/starred state.

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -961,16 +961,17 @@ func (s *PostgresStore) GetArticlesByInterestScore(userID int64, threshold float
 	return articles, scores, rows.Err()
 }
 
-func (s *PostgresStore) GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *PostgresStore) GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClausePG(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(a.security_flagged, FALSE) AS security_flagged
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged,
+		       COALESCE(rs.read, FALSE) AS is_read, COALESCE(rs.starred, FALSE) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.read = FALSE)
+		WHERE uf.user_id = ?` + readFilterClausePG(includeRead) + `
 		AND NOT EXISTS (
 			SELECT 1 FROM article_group_members agm
 			JOIN article_groups ag ON agm.group_id = ag.id
@@ -987,19 +988,20 @@ func (s *PostgresStore) GetUnreadArticlesForUser(userID int64, limit, offset int
 		return nil, fmt.Errorf("failed to get unread articles for user: %w", err)
 	}
 	defer rows.Close()
-	return scanArticlesWithFlags(rows)
+	return scanArticlesWithReadState(rows)
 }
 
-func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClausePG(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(a.security_flagged, FALSE) AS security_flagged
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged,
+		       COALESCE(rs.read, FALSE) AS is_read, COALESCE(rs.starred, FALSE) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND a.feed_id = ? AND (rs.article_id IS NULL OR rs.read = FALSE)
+		WHERE uf.user_id = ? AND a.feed_id = ?` + readFilterClausePG(includeRead) + `
 		AND NOT EXISTS (
 			SELECT 1 FROM article_group_members agm
 			JOIN article_groups ag ON agm.group_id = ag.id
@@ -1016,7 +1018,7 @@ func (s *PostgresStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, off
 		return nil, fmt.Errorf("failed to get unread articles by feed: %w", err)
 	}
 	defer rows.Close()
-	return scanArticlesWithFlags(rows)
+	return scanArticlesWithReadState(rows)
 }
 
 // GetUnscoredArticleCount counts the user's articles still in the AI funnel:
@@ -1239,7 +1241,9 @@ func (s *PostgresStore) GetStarredArticles(userID int64, limit, offset int, filt
 	filterSQL, filterArgs := filterScoreClausePG(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged,
+		       COALESCE(rs.read, FALSE) AS is_read, COALESCE(rs.starred, FALSE) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -1255,7 +1259,7 @@ func (s *PostgresStore) GetStarredArticles(userID int64, limit, offset int, filt
 		return nil, fmt.Errorf("failed to get starred articles: %w", err)
 	}
 	defer rows.Close()
-	return scanArticles(rows)
+	return scanArticlesWithReadState(rows)
 }
 
 // --- Article images ---
@@ -1910,16 +1914,18 @@ func (s *PostgresStore) FindArticleGroup(articleID, userID int64) (*int64, error
 	return &groupID, nil
 }
 
-func (s *PostgresStore) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *PostgresStore) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClausePG(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged,
+		       COALESCE(rs.read, FALSE) AS is_read, COALESCE(rs.starred, FALSE) AS is_starred
 		FROM articles a
 		JOIN article_group_members agm ON a.id = agm.article_id
 		JOIN article_groups ag ON agm.group_id = ag.id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE agm.group_id = ? AND ag.user_id = ? AND (rs.article_id IS NULL OR rs.read = FALSE)
+		WHERE agm.group_id = ? AND ag.user_id = ?` + readFilterClausePG(includeRead) + `
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?`
@@ -1931,7 +1937,7 @@ func (s *PostgresStore) GetUnreadGroupArticles(userID, groupID int64, limit, off
 		return nil, fmt.Errorf("failed to get unread group articles: %w", err)
 	}
 	defer rows.Close()
-	return scanArticles(rows)
+	return scanArticlesWithReadState(rows)
 }
 
 func (s *PostgresStore) GetGroupStats(userID int64) ([]GroupStats, error) {
@@ -2764,18 +2770,21 @@ func (s *PostgresStore) GetFeedGroupMemberships(userID int64) (map[int64][]int64
 func (s *PostgresStore) SearchArticlesFTS(userID int64, query string, limit, offset int) ([]Article, error) {
 	rows, err := s.db.Query(s.db.prepare(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, FALSE) AS security_flagged,
+		       COALESCE(rs.read, FALSE) AS is_read, COALESCE(rs.starred, FALSE) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
+		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?
 		WHERE uf.user_id = ? AND a.search_vector @@ websearch_to_tsquery('english', ?)
 		ORDER BY ts_rank_cd(a.search_vector, websearch_to_tsquery('english', ?)) DESC
 		LIMIT ? OFFSET ?`),
-		userID, query, query, limit, offset)
+		userID, userID, query, query, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("fts search: %w", err)
 	}
 	defer rows.Close()
-	return scanArticles(rows)
+	return scanArticlesWithReadState(rows)
 }
 
 // StoreArticleEmbedding upserts a successful embedding vector. Resets
@@ -3265,6 +3274,32 @@ func scanArticlesWithFlags(rows *sql.Rows) ([]Article, error) {
 		articles = append(articles, a)
 	}
 	return articles, rows.Err()
+}
+
+// scanArticlesWithReadState scans rows that include a security_flagged column
+// plus the per-user read and starred flags, in that order, after the standard
+// article fields. Used by the list queries that surface read/starred state.
+func scanArticlesWithReadState(rows *sql.Rows) ([]Article, error) {
+	var articles []Article
+	for rows.Next() {
+		var a Article
+		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
+			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate,
+			&a.SecurityFlagged, &a.Read, &a.Starred); err != nil {
+			return nil, fmt.Errorf("scan article: %w", err)
+		}
+		articles = append(articles, a)
+	}
+	return articles, rows.Err()
+}
+
+// readFilterClausePG is the Postgres counterpart to readFilterClause: it uses
+// boolean FALSE rather than the integer 0 SQLite tolerates for the read column.
+func readFilterClausePG(includeRead bool) string {
+	if includeRead {
+		return ""
+	}
+	return " AND (rs.article_id IS NULL OR rs.read = FALSE)"
 }
 
 // filterScoreClausePG is identical in logic to filterScoreClause but named

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -50,6 +50,8 @@ type Article struct {
 	LinkedURL       string // outbound link extracted from a link-blog post
 	LinkedContent   string // readability content fetched from LinkedURL
 	SecurityFlagged bool   // true when article passed the medium security threshold but not the full threshold
+	Read            bool   // requesting user's read state; only set by queries that select read_state.read
+	Starred         bool   // requesting user's starred state; only set by queries that select read_state.starred
 }
 
 type ArticleSummary struct {
@@ -1892,16 +1894,18 @@ func (s *SQLiteStore) FindArticleGroup(articleID, userID int64) (*int64, error) 
 }
 
 // GetUnreadGroupArticles returns unread articles belonging to a specific group.
-func (s *SQLiteStore) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *SQLiteStore) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClause(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, 0) AS security_flagged,
+		       COALESCE(rs.read, 0) AS is_read, COALESCE(rs.starred, 0) AS is_starred
 		FROM articles a
 		JOIN article_group_members agm ON a.id = agm.article_id
 		JOIN article_groups ag ON agm.group_id = ag.id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE agm.group_id = ? AND ag.user_id = ? AND (rs.article_id IS NULL OR rs.read = 0)
+		WHERE agm.group_id = ? AND ag.user_id = ?` + readFilterClause(includeRead) + `
 		` + filterSQL + `
 		ORDER BY a.published_date DESC
 		LIMIT ? OFFSET ?
@@ -1915,14 +1919,9 @@ func (s *SQLiteStore) GetUnreadGroupArticles(userID, groupID int64, limit, offse
 	}
 	defer rows.Close()
 
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate); err != nil {
-			return nil, fmt.Errorf("failed to scan article: %w", err)
-		}
-		articles = append(articles, a)
+	articles, err := scanArticlesWithReadState(rows)
+	if err != nil {
+		return nil, err
 	}
 	return articles, rows.Err()
 }
@@ -2522,16 +2521,17 @@ func (s *SQLiteStore) GetUngroupedEmbeddedArticles(userID int64, model string, s
 }
 
 // GetUnreadArticlesForUser returns unread articles from feeds the user subscribes to
-func (s *SQLiteStore) GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *SQLiteStore) GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClause(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(a.security_flagged, 0) AS security_flagged
+		       COALESCE(a.security_flagged, 0) AS security_flagged,
+		       COALESCE(rs.read, 0) AS is_read, COALESCE(rs.starred, 0) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND (rs.article_id IS NULL OR rs.read = 0)
+		WHERE uf.user_id = ?` + readFilterClause(includeRead) + `
 		AND NOT EXISTS (
 			SELECT 1 FROM article_group_members agm
 			JOIN article_groups ag ON agm.group_id = ag.id
@@ -2550,30 +2550,25 @@ func (s *SQLiteStore) GetUnreadArticlesForUser(userID int64, limit, offset int, 
 	}
 	defer rows.Close()
 
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate,
-			&a.SecurityFlagged); err != nil {
-			return nil, fmt.Errorf("failed to scan article: %w", err)
-		}
-		articles = append(articles, a)
+	articles, err := scanArticlesWithReadState(rows)
+	if err != nil {
+		return nil, err
 	}
 	return articles, rows.Err()
 }
 
 // GetUnreadArticlesByFeed returns unread articles for a user filtered to a specific feed.
-func (s *SQLiteStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int) ([]Article, error) {
+func (s *SQLiteStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error) {
 	filterSQL, filterArgs := filterScoreClause(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       COALESCE(a.security_flagged, 0) AS security_flagged
+		       COALESCE(a.security_flagged, 0) AS security_flagged,
+		       COALESCE(rs.read, 0) AS is_read, COALESCE(rs.starred, 0) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		LEFT JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
-		WHERE uf.user_id = ? AND a.feed_id = ? AND (rs.article_id IS NULL OR rs.read = 0)
+		WHERE uf.user_id = ? AND a.feed_id = ?` + readFilterClause(includeRead) + `
 		AND NOT EXISTS (
 			SELECT 1 FROM article_group_members agm
 			JOIN article_groups ag ON agm.group_id = ag.id
@@ -2592,15 +2587,9 @@ func (s *SQLiteStore) GetUnreadArticlesByFeed(userID, feedID int64, limit, offse
 	}
 	defer rows.Close()
 
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate,
-			&a.SecurityFlagged); err != nil {
-			return nil, fmt.Errorf("failed to scan article: %w", err)
-		}
-		articles = append(articles, a)
+	articles, err := scanArticlesWithReadState(rows)
+	if err != nil {
+		return nil, err
 	}
 	return articles, rows.Err()
 }
@@ -2684,7 +2673,9 @@ func (s *SQLiteStore) GetStarredArticles(userID int64, limit, offset int, filter
 	filterSQL, filterArgs := filterScoreClause(userID, filterThreshold)
 	query := `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, 0) AS security_flagged,
+		       COALESCE(rs.read, 0) AS is_read, COALESCE(rs.starred, 0) AS is_starred
 		FROM articles a
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
 		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?
@@ -2702,14 +2693,9 @@ func (s *SQLiteStore) GetStarredArticles(userID int64, limit, offset int, filter
 	}
 	defer rows.Close()
 
-	var articles []Article
-	for rows.Next() {
-		var a Article
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.GUID, &a.Title, &a.URL,
-			&a.Content, &a.Summary, &a.Author, &a.PublishedDate, &a.FetchedDate); err != nil {
-			return nil, fmt.Errorf("failed to scan article: %w", err)
-		}
-		articles = append(articles, a)
+	articles, err := scanArticlesWithReadState(rows)
+	if err != nil {
+		return nil, err
 	}
 	return articles, rows.Err()
 }
@@ -2743,6 +2729,18 @@ func filterScoreClause(userID int64, threshold *int) (string, []any) {
 		) >= ?
 	)`
 	return sql, []any{userID, userID, *threshold}
+}
+
+// readFilterClause returns the WHERE fragment that restricts a list query to
+// unread articles. When includeRead is true it returns an empty string so the
+// query also returns articles the user has already read. It assumes the query
+// LEFT JOINs read_state aliased as rs. Backend-agnostic (plain SQL text), so
+// both the SQLite and Postgres queries share it.
+func readFilterClause(includeRead bool) string {
+	if includeRead {
+		return ""
+	}
+	return " AND (rs.article_id IS NULL OR rs.read = 0)"
 }
 
 // --- Article metadata methods ---
@@ -3158,19 +3156,22 @@ func (s *SQLiteStore) MarkArticleImagesCached(articleID int64) error {
 func (s *SQLiteStore) SearchArticlesFTS(userID int64, query string, limit, offset int) ([]Article, error) {
 	rows, err := s.db.Query(`
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
-		       a.author, a.published_date, a.fetched_date
+		       a.author, a.published_date, a.fetched_date,
+		       COALESCE(a.security_flagged, 0) AS security_flagged,
+		       COALESCE(rs.read, 0) AS is_read, COALESCE(rs.starred, 0) AS is_starred
 		FROM articles a
 		JOIN articles_fts fts ON fts.rowid = a.id
 		JOIN user_feeds uf ON a.feed_id = uf.feed_id
+		LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = ?
 		WHERE uf.user_id = ? AND articles_fts MATCH ?
 		ORDER BY rank
 		LIMIT ? OFFSET ?`,
-		userID, query, limit, offset)
+		userID, userID, query, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("fts search: %w", err)
 	}
 	defer rows.Close()
-	return scanArticles(rows)
+	return scanArticlesWithReadState(rows)
 }
 
 // StoreArticleEmbedding upserts a successful embedding vector. Resets

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -547,7 +547,7 @@ func TestGetUnreadArticlesForUser(t *testing.T) {
 		URL: "https://example.com/b/1", PublishedDate: &now,
 	})
 
-	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, nil)
+	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, nil, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticlesForUser failed: %v", err)
 	}
@@ -556,6 +556,66 @@ func TestGetUnreadArticlesForUser(t *testing.T) {
 	}
 	if articles[0].Title != "Feed A Article" {
 		t.Errorf("expected Feed A Article, got %q", articles[0].Title)
+	}
+}
+
+func TestGetArticlesIncludeReadAndFlags(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	feed, _ := store.AddFeed("https://example.com/a", "Feed A", "")
+	store.SubscribeUserToFeed(1, feed)
+
+	now := time.Now()
+	readID, _ := store.AddArticle(&Article{
+		FeedID: feed, GUID: "r1", Title: "Read Article",
+		URL: "https://example.com/a/read", PublishedDate: &now,
+	})
+	unreadID, _ := store.AddArticle(&Article{
+		FeedID: feed, GUID: "u1", Title: "Unread Article",
+		URL: "https://example.com/a/unread", PublishedDate: &now,
+	})
+
+	// Mark one read and star it; leave the other untouched.
+	if err := store.UpdateReadState(1, readID, true, nil, nil, nil, nil); err != nil {
+		t.Fatalf("UpdateReadState: %v", err)
+	}
+	if err := store.UpdateStarred(1, readID, true); err != nil {
+		t.Fatalf("UpdateStarred: %v", err)
+	}
+
+	// Default (includeRead=false): only the unread article, flagged unread.
+	unread, err := store.GetUnreadArticlesForUser(1, 10, 0, nil, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticlesForUser(false): %v", err)
+	}
+	if len(unread) != 1 {
+		t.Fatalf("includeRead=false: expected 1 article, got %d", len(unread))
+	}
+	if unread[0].ID != unreadID {
+		t.Errorf("includeRead=false: expected unread article %d, got %d", unreadID, unread[0].ID)
+	}
+	if unread[0].Read {
+		t.Error("includeRead=false: unread article should have Read=false")
+	}
+
+	// includeRead=true: both articles, each carrying correct Read/Starred state.
+	all, err := store.GetUnreadArticlesForUser(1, 10, 0, nil, true)
+	if err != nil {
+		t.Fatalf("GetUnreadArticlesForUser(true): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("includeRead=true: expected 2 articles, got %d", len(all))
+	}
+	flags := map[int64]Article{}
+	for _, a := range all {
+		flags[a.ID] = a
+	}
+	if got := flags[readID]; !got.Read || !got.Starred {
+		t.Errorf("read article: expected Read && Starred, got Read=%v Starred=%v", got.Read, got.Starred)
+	}
+	if got := flags[unreadID]; got.Read || got.Starred {
+		t.Errorf("unread article: expected !Read && !Starred, got Read=%v Starred=%v", got.Read, got.Starred)
 	}
 }
 
@@ -1086,7 +1146,7 @@ func TestFilteredArticleQueries(t *testing.T) {
 	store.AddFilterRule(&FilterRule{UserID: 1, Axis: "category", Value: "Security", Score: 3})
 
 	// Without filter (nil threshold) — both articles returned
-	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, nil)
+	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, nil, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticlesForUser (nil threshold): %v", err)
 	}
@@ -1096,14 +1156,14 @@ func TestFilteredArticleQueries(t *testing.T) {
 
 	// With threshold=0 — both articles returned (0 means disabled)
 	zero := 0
-	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &zero)
+	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &zero, false)
 	if len(articles) != 2 {
 		t.Errorf("threshold=0: expected 2 articles, got %d", len(articles))
 	}
 
 	// With threshold=1 — only a1 passes (score 8 >= 1), a2 has score 0
 	one := 1
-	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &one)
+	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &one, false)
 	if len(articles) != 1 {
 		t.Errorf("threshold=1: expected 1 article, got %d", len(articles))
 	}
@@ -1113,7 +1173,7 @@ func TestFilteredArticleQueries(t *testing.T) {
 
 	// With threshold=10 — neither passes (max score is 8)
 	ten := 10
-	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &ten)
+	articles, _ = store.GetUnreadArticlesForUser(1, 10, 0, &ten, false)
 	if len(articles) != 0 {
 		t.Errorf("threshold=10: expected 0 articles, got %d", len(articles))
 	}
@@ -1135,7 +1195,7 @@ func TestFilteredQueriesNoRulesPassthrough(t *testing.T) {
 	// User has no filter rules, but threshold is set — should still pass through
 	// because NOT EXISTS (SELECT 1 FROM filter_rules WHERE user_id=1) is true
 	threshold := 5
-	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, &threshold)
+	articles, err := store.GetUnreadArticlesForUser(1, 10, 0, &threshold, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticlesForUser with threshold but no rules: %v", err)
 	}
@@ -1351,7 +1411,7 @@ func TestPostgresBackend(t *testing.T) {
 		store.AddFilterRule(&FilterRule{UserID: 2, Axis: "author", Value: "FilterAuthor", Score: 5})
 
 		one := 1
-		arts, err := store.GetUnreadArticlesForUser(2, 10, 0, &one)
+		arts, err := store.GetUnreadArticlesForUser(2, 10, 0, &one, false)
 		if err != nil {
 			t.Fatalf("GetUnreadArticlesForUser with filter: %v", err)
 		}
@@ -1476,7 +1536,7 @@ func TestMigrateStore(t *testing.T) {
 	dstArts, _ := dst.GetUnreadArticles(100)
 	_ = dstArts
 	// Find article in dst by feed
-	dstFeedArts, _ := dst.GetUnreadArticlesByFeed(1, dstFeedID, 10, 0, nil)
+	dstFeedArts, _ := dst.GetUnreadArticlesByFeed(1, dstFeedID, 10, 0, nil, false)
 	_ = dstFeedArts
 
 	pref, err := dst.GetUserPreference(1, "theme")
@@ -1639,7 +1699,7 @@ func TestGroupVirtualFeed(t *testing.T) {
 	store.AddArticleToGroup(groupID, art2)
 
 	// Verify grouped articles are excluded from feed queries
-	unread, err := store.GetUnreadArticlesForUser(1, 100, 0, nil)
+	unread, err := store.GetUnreadArticlesForUser(1, 100, 0, nil, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticlesForUser: %v", err)
 	}
@@ -1651,7 +1711,7 @@ func TestGroupVirtualFeed(t *testing.T) {
 	}
 
 	// Verify grouped articles excluded from feed-specific queries too
-	feedArticles, err := store.GetUnreadArticlesByFeed(1, feedID, 100, 0, nil)
+	feedArticles, err := store.GetUnreadArticlesByFeed(1, feedID, 100, 0, nil, false)
 	if err != nil {
 		t.Fatalf("GetUnreadArticlesByFeed: %v", err)
 	}
@@ -1660,7 +1720,7 @@ func TestGroupVirtualFeed(t *testing.T) {
 	}
 
 	// Verify group articles are returned by GetUnreadGroupArticles
-	groupArticles, err := store.GetUnreadGroupArticles(1, groupID, 100, 0, nil)
+	groupArticles, err := store.GetUnreadGroupArticles(1, groupID, 100, 0, nil, false)
 	if err != nil {
 		t.Fatalf("GetUnreadGroupArticles: %v", err)
 	}
@@ -1713,7 +1773,7 @@ func TestGroupVirtualFeed(t *testing.T) {
 	if err := store.DisbandGroup(groupID); err != nil {
 		t.Fatalf("DisbandGroup: %v", err)
 	}
-	unread, _ = store.GetUnreadArticlesForUser(1, 100, 0, nil)
+	unread, _ = store.GetUnreadArticlesForUser(1, 100, 0, nil, false)
 	if len(unread) != 3 {
 		t.Errorf("expected 3 articles after disband, got %d", len(unread))
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -122,8 +122,8 @@ type Store interface {
 	GetUnreadArticles(limit int) ([]Article, error)
 	GetArticle(articleID int64) (*Article, error)
 	GetArticlesByInterestScore(userID int64, threshold float64, limit, offset int, filterThreshold *int) ([]Article, []float64, error)
-	GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int) ([]Article, error)
-	GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int) ([]Article, error)
+	GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error)
+	GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error)
 	GetUnscoredArticleCount(userID int64) (int, error)
 	GetUnsummarizedArticleCount() (int, error)
 	GetUnsummarizedScoredArticles(securityThreshold float64, limit int) ([]Article, error)
@@ -185,7 +185,7 @@ type Store interface {
 	FindArticleGroup(articleID, userID int64) (*int64, error)
 
 	// Group virtual feed operations
-	GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int) ([]Article, error)
+	GetUnreadGroupArticles(userID, groupID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error)
 	GetGroupStats(userID int64) ([]GroupStats, error)
 	SetGroupMuted(groupID int64, muted bool) error
 	IsGroupMuted(groupID int64) (bool, error)

--- a/types.go
+++ b/types.go
@@ -55,6 +55,11 @@ type Article struct {
 	LinkedURL       string     `json:"linked_url,omitempty"`
 	LinkedContent   string     `json:"linked_content,omitempty"`
 	SecurityFlagged bool       `json:"security_flagged,omitempty"`
+	// Read and Starred reflect the requesting user's per-article state
+	// (from read_state). They are only populated by the list/search queries
+	// that select them; single-article fetches leave them zero.
+	Read    bool `json:"read,omitempty"`
+	Starred bool `json:"starred,omitempty"`
 }
 
 // Feed represents an RSS/Atom feed subscription.


### PR DESCRIPTION
Fixes the user-reported "hide/show read articles no longer works" and the related "a token refresh pulled me off the article I was reading."

## Background

Per-user read state was already persisted in `read_state`; the gap was read-*back*. Every list query hard-filtered `read = 0` and never selected the `read`/`starred` columns, so the UI could neither resurface a previously-read article nor render the per-row star indicator. Separately, an expiring OIDC session caused the periodic background sidebar refresh to redirect the whole page, wiping the reading pane.

## Changes

- **Keep the reading pane on session expiry.** A `htmx:beforeOnLoad` hook cancels any 401 response (which gates htmx's `HX-Redirect` handling) and shows a non-destructive "session expired -- reconnect" banner instead of navigating away. Navigation to login happens only on an explicit Reconnect click.
- **Surface per-user read/starred state.** List and FTS-search queries now select the flags into `Article` (new `scanArticlesWithReadState`, both SQLite and Postgres); an `includeRead` flag drops the unread-only filter. Also fixes the list star indicator, which was never populated.
- **Server-driven show/hide-read toggle.** The toggle was pure CSS and could only fade rows already on screen. It now drives `?show_read=1` via an `htmx:configRequest` hook that's authoritative for every `/articles` request (initial load, sidebar navigation, infinite scroll), so previously-read articles come back.
- **Per-article mark read/unread toggle** in the reading pane (`POST /articles/{id}/read` -> `Engine.SetArticleRead`), refreshing sidebar unread counts.

## Deferred

True silent token refresh requires refresh-token support that `oidclient` v0.3.1 lacks -- tracked in infodancer/oidclient#16. This PR ships the graceful-failure half so users stop losing their article in the meantime.

## Testing

- New storage test: `includeRead` returns read articles with correct `Read`/`Starred` flags; default still returns unread only.
- New handler test: `POST /articles/{id}/read` round-trips read/unread and the article re-enters/leaves the unread list accordingly.
- `go test -race`, `go vet`, and `golangci-lint` all clean.

Not browser-verified: the htmx `configRequest`/`beforeOnLoad` behavior and the banner have no automated JS test (no JS harness in the repo) -- worth one manual click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)