### PR TITLE
fix(web): make htmx interactions work under the no-eval CSP

### DIFF
--- a/cmd/herald-web/csp_htmx_test.go
+++ b/cmd/herald-web/csp_htmx_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTemplatesAvoidEvalHTMX guards the CSP contract. The app's
+// Content-Security-Policy (see securityHeaders in middleware.go) deliberately
+// omits 'unsafe-eval'. htmx compiles hx-on attribute bodies and js:-prefixed
+// hx-vals via new Function(), which that CSP blocks -- so any such usage fails
+// silently in the browser (the bug that motivated this test: clicking an
+// article stopped marking it read because the row's hx-on never ran).
+//
+// Behaviors that previously used hx-on now live as delegated listeners in
+// static/herald.js, keyed off data-* attributes. If you reach for hx-on or
+// js: hx-vals again, this test fails on purpose: add the behavior to herald.js
+// instead, or grant 'unsafe-eval' (and weaken the CSP) consciously.
+func TestTemplatesAvoidEvalHTMX(t *testing.T) {
+	matches, err := filepath.Glob("templates/*.html")
+	if err != nil {
+		t.Fatalf("glob templates: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no templates found; wrong working directory?")
+	}
+
+	banned := []string{`hx-on`, `hx-vals="js:`, `hx-vals='js:`}
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		body := string(data)
+		for _, needle := range banned {
+			if strings.Contains(body, needle) {
+				t.Errorf("%s contains eval-dependent htmx %q, which the CSP (no 'unsafe-eval') blocks; "+
+					"move the behavior into static/herald.js as a delegated listener", filepath.Base(path), needle)
+			}
+		}
+	}
+}

--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -49,7 +49,10 @@
         }
     })();
 
-    // Intercept sidebar link clicks to capture the current selection
+    // Intercept sidebar link clicks to capture the current selection and clear
+    // the reading pane. (The clear replaces the per-link hx-on:click handlers,
+    // which the CSP -- no 'unsafe-eval' -- would otherwise block htmx from
+    // compiling. See the htmx:afterRequest dispatcher below.)
     document.addEventListener('click', function(e) {
         var link = e.target.closest('#sidebar nav a[hx-get]');
         if (!link) return;
@@ -57,6 +60,86 @@
         var qIdx = url.indexOf('?');
         window._heraldSidebarQuery = qIdx >= 0 ? url.substring(qIdx) : '';
         heraldUpdateSidebarRefreshURL();
+        window.heraldClearReadingPane();
+    });
+
+    // CSP-safe replacements for inline hx-on::after-request handlers. The app's
+    // Content-Security-Policy omits 'unsafe-eval', which htmx requires to
+    // compile hx-on attribute bodies via new Function(); those handlers fail
+    // silently. This single delegated listener reproduces each one without eval.
+    // Behaviors opt in via class or data-* attribute on the requesting element.
+    document.body.addEventListener('htmx:afterRequest', function(e) {
+        var d = e.detail || {};
+        var elt = d.elt;
+        if (!elt || !elt.matches) return;
+        var ok = d.successful;
+
+        // Article / summary row selection. Both row kinds carry .article-row;
+        // only real article rows (data-article-id) get marked read and refresh
+        // the sidebar counts.
+        if (elt.classList.contains('article-row')) {
+            document.querySelectorAll('.article-row').forEach(function(r) {
+                r.classList.remove('active');
+            });
+            elt.classList.add('active');
+            if (elt.hasAttribute('data-article-id')) {
+                elt.classList.add('read');
+                if (window.htmx) htmx.trigger(document.body, 'feeds-changed');
+            }
+        }
+
+        // Everything below only runs after a successful request.
+        if (!ok) return;
+
+        // Refresh sidebar unread counts (e.g. the reading-pane read/unread toggle).
+        if (elt.matches('[data-feeds-changed]') && window.htmx) {
+            htmx.trigger(document.body, 'feeds-changed');
+        }
+
+        // Transient "Saved!" confirmation on a settings/admin form.
+        if (elt.matches('[data-saved-feedback]')) {
+            var btn = elt.querySelector('[data-save-btn]');
+            if (btn) {
+                btn.textContent = 'Saved!';
+                setTimeout(function() { btn.textContent = 'Save'; }, 2000);
+            }
+        }
+
+        // "Mark all as read" summary button: confirm and lock.
+        if (elt.matches('[data-mark-read-feedback]')) {
+            elt.textContent = 'Marked read';
+            elt.disabled = true;
+        }
+
+        // OPML sync token regenerated: drop the new URL into its field and select it.
+        var tokenSel = elt.getAttribute('data-opml-token-field');
+        if (tokenSel && d.xhr) {
+            var field = document.querySelector(tokenSel);
+            if (field) {
+                field.value = d.xhr.responseText;
+                field.select();
+            }
+        }
+
+        // Reset a form after a successful submit.
+        if (elt.matches('[data-reset-on-success]') && typeof elt.reset === 'function') {
+            elt.reset();
+        }
+
+        // Filter add-rule form: reset and clear the dependent value field.
+        if (elt.matches('[data-filter-reset]')) {
+            if (typeof elt.reset === 'function') elt.reset();
+            var vf = document.getElementById('value-field');
+            if (vf) {
+                vf.innerHTML = '<select name="value" id="value-select" required>' +
+                    '<option value="">— select feed and axis first —</option></select>';
+            }
+        }
+
+        // Reload the page (run last; it tears everything down).
+        if (elt.matches('[data-reload-on-success]')) {
+            window.location.reload();
+        }
     });
 
     // Theme toggle

--- a/cmd/herald-web/templates/admin_digest.html
+++ b/cmd/herald-web/templates/admin_digest.html
@@ -5,8 +5,7 @@
     {{template "settings-subnav" .}}
     <h2>Digest Header &amp; Footer</h2>
     <p>Admin-only HTML wrapped around every generated digest at render and email time (e.g. a mandatory unsubscribe footer). Changes apply to existing digests without regenerating. Sanitized on output.</p>
-    <form hx-post="/admin/digest" hx-swap="none"
-          hx-on::after-request="if(event.detail.successful){var b=this.querySelector('[data-save-btn]');b.textContent='Saved!';setTimeout(()=>b.textContent='Save',2000);}">
+    <form hx-post="/admin/digest" hx-swap="none" data-saved-feedback>
         <label>Header HTML
             <textarea name="header" rows="6" style="font-family:monospace;font-size:0.85em;">{{.Header}}</textarea>
         </label>

--- a/cmd/herald-web/templates/admin_prompts.html
+++ b/cmd/herald-web/templates/admin_prompts.html
@@ -14,8 +14,7 @@
             <strong>{{.Label}}</strong>
             {{if .IsCustom}}<small style="color:var(--pico-primary);">&nbsp;(global override active)</small>{{else}}<small class="secondary">&nbsp;(using embedded default)</small>{{end}}
         </header>
-        <form hx-post="/admin/prompts/{{.Type}}" hx-swap="none"
-              hx-on::after-request="if(event.detail.successful){var b=this.querySelector('[data-save-btn]');b.textContent='Saved!';setTimeout(()=>b.textContent='Save',2000);}">
+        <form hx-post="/admin/prompts/{{.Type}}" hx-swap="none" data-saved-feedback>
             <textarea name="template" rows="8" style="font-family:monospace;font-size:0.85em;">{{.Template}}</textarea>
             <label style="margin-top:0.5rem;font-size:0.9em;">Model</label>
             {{if .AvailableModels}}
@@ -33,7 +32,7 @@
                 <button type="button" class="outline secondary" style="margin:0;"
                         hx-delete="/admin/prompts/{{.Type}}"
                         hx-confirm="Reset '{{.Label}}' to embedded default?"
-                        hx-on::after-request="if(event.detail.successful) window.location.reload();">
+                        data-reload-on-success>
                     Reset to Embedded Default
                 </button>
                 {{end}}

--- a/cmd/herald-web/templates/ai_summary_detail.html
+++ b/cmd/herald-web/templates/ai_summary_detail.html
@@ -20,7 +20,7 @@
     <hr>
     <button class="outline secondary" hx-post="/summary/{{.ID}}/mark-read" hx-swap="none"
             hx-confirm="Mark all {{.ArticleCount}} summarized articles as read?"
-            hx-on::after-request="if(event.detail.successful){this.textContent='Marked read';this.disabled=true;}">
+            data-mark-read-feedback>
         Mark all {{.ArticleCount}} as read
     </button>
     {{end}}

--- a/cmd/herald-web/templates/ai_summary_list.html
+++ b/cmd/herald-web/templates/ai_summary_list.html
@@ -19,7 +19,6 @@
         <div class="article-row{{if ne .Status "done"}} read{{end}}" data-summary-id="{{.ID}}"
              {{if eq .Status "done"}}
              hx-get="/summary/{{.ID}}" hx-target="#reading-pane" hx-swap="innerHTML"
-             hx-on::after-request="document.querySelectorAll('.article-row').forEach(r => r.classList.remove('active')); this.classList.add('active');"
              {{end}}>
             <h4>{{if .ConfigName}}{{.ConfigName}}{{else}}AI Summary{{end}} &mdash; {{.Label}}</h4>
             <div class="meta">

--- a/cmd/herald-web/templates/article_row.html
+++ b/cmd/herald-web/templates/article_row.html
@@ -2,8 +2,7 @@
 <div class="article-row {{if .Read}}read{{end}}" data-article-id="{{.ID}}"
      hx-get="/articles/{{.ID}}"
      hx-target="#reading-pane"
-     hx-swap="innerHTML"
-     hx-on::after-request="this.classList.add('read'); document.querySelectorAll('.article-row').forEach(r => r.classList.remove('active')); this.classList.add('active'); htmx.trigger(document.body, 'feeds-changed');">
+     hx-swap="innerHTML">
     <h4>
         {{if .Starred}}<span class="starred" aria-label="starred">&#9733;</span> {{end}}
         {{if .SecurityFlagged}}<span class="security-flag" title="Security flagged — not AI-summarized, pending audit" aria-label="security flagged">&#9888;</span> {{end}}

--- a/cmd/herald-web/templates/article_view.html
+++ b/cmd/herald-web/templates/article_view.html
@@ -53,7 +53,7 @@
             hx-post="/articles/{{.ID}}/read"
             hx-swap="outerHTML"
             hx-vals='{"read":"{{if .Read}}false{{else}}true{{end}}"}'
-            hx-on::after-request="htmx.trigger(document.body, 'feeds-changed')">
+            data-feeds-changed>
         {{if .Read}}Mark unread{{else}}Mark read{{end}}
     </button>
 </div>

--- a/cmd/herald-web/templates/feed_sidebar.html
+++ b/cmd/herald-web/templates/feed_sidebar.html
@@ -1,27 +1,19 @@
 {{define "feed_sidebar_content"}}
 <nav>
-    <a href="#" hx-get="/articles" hx-target="#article-list" hx-swap="innerHTML"
-       hx-on:click="heraldClearReadingPane()"
-       class="{{if and (not .ActiveFeed) (not .ActiveStarred) (not .ActiveGroup)}}active{{end}}">
+    <a href="#" hx-get="/articles" hx-target="#article-list" hx-swap="innerHTML"       class="{{if and (not .ActiveFeed) (not .ActiveStarred) (not .ActiveGroup)}}active{{end}}">
         All Articles
         {{if .TotalUnread}}<span class="unread-count">{{.TotalUnread}}</span>{{end}}
     </a>
-    <a href="#" hx-get="/articles?starred=1" hx-target="#article-list" hx-swap="innerHTML"
-       hx-on:click="heraldClearReadingPane()"
-       class="{{if .ActiveStarred}}active{{end}}">
+    <a href="#" hx-get="/articles?starred=1" hx-target="#article-list" hx-swap="innerHTML"       class="{{if .ActiveStarred}}active{{end}}">
         Starred
     </a>
-    <a href="#" hx-get="/summary" hx-target="#article-list" hx-swap="innerHTML"
-       hx-on:click="heraldClearReadingPane()"
-       class="{{if .ActiveSummary}}active{{end}}">
+    <a href="#" hx-get="/summary" hx-target="#article-list" hx-swap="innerHTML"       class="{{if .ActiveSummary}}active{{end}}">
         AI Summary
     </a>
     {{if .Groups}}
     <hr>
     {{range .Groups}}
-    <a href="#" hx-get="/articles?group_id={{.GroupID}}" hx-target="#article-list" hx-swap="innerHTML"
-       hx-on:click="heraldClearReadingPane()"
-       class="{{if eq $.ActiveGroup .GroupID}}active{{end}}"
+    <a href="#" hx-get="/articles?group_id={{.GroupID}}" hx-target="#article-list" hx-swap="innerHTML"       class="{{if eq $.ActiveGroup .GroupID}}active{{end}}"
        data-group-id="{{.GroupID}}" data-group-title="{{.DisplayName}}">
         {{.DisplayName}}
         {{if .UnreadArticles}}<span class="unread-count">{{.UnreadArticles}}</span>{{end}}
@@ -30,9 +22,7 @@
     {{end}}
     <hr>
     {{range .Feeds}}
-    <a href="#" hx-get="/articles?feed_id={{.FeedID}}" hx-target="#article-list" hx-swap="innerHTML"
-       hx-on:click="heraldClearReadingPane()"
-       class="{{if eq $.ActiveFeed .FeedID}}active{{end}}"
+    <a href="#" hx-get="/articles?feed_id={{.FeedID}}" hx-target="#article-list" hx-swap="innerHTML"       class="{{if eq $.ActiveFeed .FeedID}}active{{end}}"
        data-feed-id="{{.FeedID}}" data-feed-title="{{.FeedTitle}}">
         {{.FeedTitle}}
         {{if .UnreadArticles}}<span class="unread-count">{{.UnreadArticles}}</span>{{end}}

--- a/cmd/herald-web/templates/feeds_manage.html
+++ b/cmd/herald-web/templates/feeds_manage.html
@@ -57,7 +57,7 @@
     <form style="display:inline-flex;margin:0;" autocomplete="off"
           hx-post="/feeds/{{.FeedID}}/tags"
           hx-target="#feed-tags-cell-{{.FeedID}}" hx-swap="outerHTML"
-          hx-on::after-request="if(event.detail.successful) this.reset();">
+          data-reset-on-success>
         <input type="text" name="tag" placeholder="+ tag" list="all-tags-list" maxlength="50"
                style="margin:0;padding:0.1rem 0.4rem;font-size:0.75rem;width:7rem;">
     </form>
@@ -73,7 +73,7 @@
     <article>
         <header><h3>Subscribe to Feed</h3></header>
         <form hx-post="/feeds/discover" hx-target="#subscribe-result" hx-swap="innerHTML"
-              hx-on::after-request="if(event.detail.successful) this.reset();">
+              data-reset-on-success>
             <div class="grid">
                 {{/* Not type="url": browser validation would reject scheme-less
                      input, but the server tries https:// then http:// itself. */}}

--- a/cmd/herald-web/templates/filters.html
+++ b/cmd/herald-web/templates/filters.html
@@ -29,7 +29,7 @@
     <article>
         <header><h3>Add Rule</h3></header>
         <form hx-post="/filters" hx-target="#rules-list" hx-swap="innerHTML"
-              hx-on::after-request="if(event.detail.successful && event.detail.elt === this) { this.reset(); document.getElementById('value-field').innerHTML='<select name=\'value\' id=\'value-select\' required><option value=\'\'>— select feed and axis first —</option></select>'; }">
+              data-filter-reset>
             <div class="grid">
                 <div>
                     <label for="rule-feed">Feed (optional)</label>
@@ -85,12 +85,11 @@
         <header><h3>Discover Metadata</h3></header>
         <p class="secondary">Select a feed to see available authors and categories.</p>
         <label for="meta_feed">Feed</label>
-        <select id="meta_feed"
+        <select id="meta_feed" name="feed_id"
                 hx-get="/feeds/metadata"
                 hx-target="#metadata-result"
                 hx-swap="innerHTML"
-                hx-trigger="change"
-                hx-vals="js:{feed_id: this.value}">
+                hx-trigger="change">
             <option value="">— select a feed —</option>
             {{range .Feeds}}
             <option value="{{.ID}}">{{.Title}}</option>

--- a/cmd/herald-web/templates/settings_prompts.html
+++ b/cmd/herald-web/templates/settings_prompts.html
@@ -15,8 +15,7 @@
             <strong>{{.Label}}</strong>
             {{if .IsCustom}}<small style="color:var(--pico-primary);">&nbsp;(customized)</small>{{end}}
         </header>
-        <form hx-post="/settings/prompts/{{.Type}}" hx-swap="none"
-              hx-on::after-request="if(event.detail.successful){var b=this.querySelector('[data-save-btn]');b.textContent='Saved!';setTimeout(()=>b.textContent='Save',2000);}">
+        <form hx-post="/settings/prompts/{{.Type}}" hx-swap="none" data-saved-feedback>
             <textarea name="template" rows="6" style="font-family:monospace;font-size:0.85em;">{{.Template}}</textarea>
             <label style="margin-top:0.5rem;font-size:0.9em;">Model</label>
             {{if .AvailableModels}}
@@ -34,7 +33,7 @@
                 <button type="button" class="outline secondary" style="margin:0;"
                         hx-delete="/settings/prompts/{{.Type}}"
                         hx-confirm="Reset '{{.Label}}' to default?"
-                        hx-on::after-request="if(event.detail.successful) window.location.reload();">
+                        data-reload-on-success>
                     Reset to Default
                 </button>
                 {{end}}

--- a/cmd/herald-web/templates/settings_sync.html
+++ b/cmd/herald-web/templates/settings_sync.html
@@ -16,13 +16,13 @@
     <button class="outline secondary" style="font-size:0.85em;"
             hx-post="/settings/opml-token"
             hx-swap="none"
-            hx-on::after-request="if(event.detail.successful){document.querySelector('#opml-url-field').value=event.detail.xhr.responseText; document.querySelector('#opml-url-field').select();}">
+            data-opml-token-field="#opml-url-field">
         Regenerate URL
     </button>
     {{else}}
     <button hx-post="/settings/opml-token"
             hx-swap="none"
-            hx-on::after-request="if(event.detail.successful) window.location.reload();">
+            data-reload-on-success>
         Generate sync URL
     </button>
     {{end}}
@@ -49,7 +49,7 @@
                         class="outline secondary" style="margin:0;"
                         hx-delete="/settings/fever" hx-swap="none"
                         hx-confirm="Remove Fever API access?"
-                        hx-on::after-request="if(event.detail.successful) window.location.reload();">
+                        data-reload-on-success>
                     Remove
                 </button>
             </div>


### PR DESCRIPTION
## Problem

The CSP added in \`19040be\` ("add securityHeaders middleware") sets `script-src 'self' 'unsafe-inline'` with **no `'unsafe-eval'`**. htmx compiles `hx-on` attribute bodies (and `js:`-prefixed `hx-vals`) via `new Function()`, which CSP gates behind `'unsafe-eval'` — so every `hx-on` handler has been failing silently in the browser since that shipped to prod (image built today ~08:00 UTC).

The visible fallout, as reported: **clicking an article no longer marked it read.** The plain `hx-get` needs no eval, so the article still opened and the server still auto-marked it read (the prod DB confirms reads are landing) — but the inline `hx-on::after-request` that adds the `read` class never ran. So titles stopped dimming and read rows stopped disappearing. The star toggle, "Saved!" feedback, form resets, the OPML-token field, and the sidebar reading-pane clear were dead the same way.

## Fix

Move every `hx-on` behavior into a single delegated `htmx:afterRequest` listener in `herald.js` (a loaded `<script src>` from `'self'`, so no eval), keyed off `data-*` attributes / classes. Replace the one `js:` `hx-vals` (filters metadata select) with a native `name="feed_id"` so htmx includes it without eval.

**The CSP is left intact — no `'unsafe-eval'`.** We stop relying on the capability the policy correctly forbids, rather than granting it back.

### Behaviors ported (11 templates)
- article rows → add `read`, set active, fire `feeds-changed` (the dim + disappear)
- summary rows → set active only
- `data-feeds-changed` → sidebar refresh (read/unread toggle)
- `data-saved-feedback` → "Saved!" button flash
- `data-reload-on-success` → page reload
- `data-mark-read-feedback` → summary "Marked read" lock
- `data-opml-token-field` → regenerated URL into its field
- `data-reset-on-success` / `data-filter-reset` → form resets
- sidebar nav clicks → clear reading pane

## Test

`csp_htmx_test.go` fails if any template reintroduces `hx-on` or `js:` `hx-vals`, encoding the CSP contract so this cannot silently regress.

Build OK, `golangci-lint` clean, `node --check` on herald.js OK, full `go test -race ./...` green.

## Verification needed

Go tests render the templates (markup change verified) but don't run a JS engine. Please click through the PR preview in Brave — the `unsafe-eval` console errors should be gone and article titles should dim / disappear on read again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)