### PR TITLE
fix(web): read articles dim in place instead of vanishing on click

### DIFF
--- a/cmd/herald-web/static/herald.css
+++ b/cmd/herald-web/static/herald.css
@@ -162,13 +162,11 @@
     border-left: 3px solid var(--pico-primary);
 }
 
+/* Read articles only dim; they stay in place until the list is refetched
+   (e.g. switching feeds), at which point the server-side unread filter drops
+   them in hide-read mode. Clicking an article never removes it in-session. */
 .article-row.read {
     opacity: 0.6;
-}
-
-/* Hide read articles when toggle active */
-#article-list.hide-read .article-row.read {
-    display: none;
 }
 
 .article-row h4 {

--- a/cmd/herald-web/static/herald.js
+++ b/cmd/herald-web/static/herald.js
@@ -424,20 +424,18 @@
     // scroll) via the htmx:configRequest hook below, so it survives navigation.
     (function() {
         var STORAGE_KEY = 'herald-hide-read';
-        var list = document.getElementById('article-list');
         var btn = document.getElementById('hide-read-btn');
 
         function isHiding() {
             return localStorage.getItem(STORAGE_KEY) !== 'false';
         }
 
+        // Reflect the current mode in the button label. Read articles are not
+        // hidden in-session -- a clicked article stays, dimmed, until the list
+        // is refetched (configRequest below drops show_read in hide-read mode,
+        // so the server-side unread filter removes it on the next fetch).
         function applyState() {
-            var hiding = isHiding();
-            // The CSS class still hides rows marked read in-session (the
-            // hx-on::after-request handler on each row), so an article you open
-            // while hiding disappears without a refetch.
-            if (list) list.classList.toggle('hide-read', hiding);
-            if (btn) btn.textContent = hiding ? 'Show read' : 'Hide read';
+            if (btn) btn.textContent = isHiding() ? 'Show read' : 'Hide read';
         }
 
         // Make the toggle authoritative for every article-list request,


### PR DESCRIPTION
## Problem

Follow-up to #171. With htmx interactions working again, a new issue surfaced (and was reported): clicking an article made it **vanish from the list immediately**, even in "show read" mode — instead of dimming and staying put until the list is next refreshed.

Cause: the row got the `read` class on click, and a CSS rule hid it in-session:

```css
#article-list.hide-read .article-row.read { display: none; }
```

That in-session hiding predates server-side `show_read` (added in read-status, #169) and is now both redundant and wrong.

## Desired behavior (per report)

A read article should **dim and stay in place** until the article list is actually refetched — usually by clicking another feed in the left pane — at which point the server-side unread filter removes it (in hide-read mode) or keeps it faded (in show-read mode). Clicking an article should never remove it in-session.

## Fix

- Remove the `display:none` rule so `read` only dims (`opacity: 0.6`).
- Drop the now-dead `hide-read` class toggle in `herald.js`; the `htmx:configRequest` hook already keys off the `herald-hide-read` localStorage flag, not the CSS class.

Read state on refresh is unchanged: hide-read excludes read articles server-side, show-read renders them faded.

## Test

Build OK, `golangci-lint` clean, `node --check` OK, `go test ./cmd/herald-web/` green. The CSP guard test (#171) still passes.

Needs a click-through in Brave to confirm: read articles dim and persist, and only clear on a feed switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)