### PR TITLE
fix(web): add a Log out link to the nav

### DIFF
--- a/cmd/herald-web/handlers_test.go
+++ b/cmd/herald-web/handlers_test.go
@@ -452,6 +452,11 @@ func TestHandleHome(t *testing.T) {
 	if !strings.Contains(body, "Test Feed") {
 		t.Error("home page should contain feed title")
 	}
+	// The shared nav must expose a way to end the session (#173 made logout
+	// revoke the server-side session; without this link it is unreachable).
+	if !strings.Contains(body, `href="/auth/logout"`) {
+		t.Error("home page nav should contain a log out link")
+	}
 }
 
 func TestHandleHome_Unauthenticated(t *testing.T) {

--- a/cmd/herald-web/templates/nav.html
+++ b/cmd/herald-web/templates/nav.html
@@ -6,5 +6,6 @@
     <a href="/stats"{{if eq . "stats"}} aria-current="page"{{end}}>Stats</a>
     <a href="/status"{{if eq . "status"}} aria-current="page"{{end}}>Status</a>
     <a href="/settings"{{if eq . "settings"}} aria-current="page"{{end}}>Settings</a>
+    <a href="/auth/logout" style="margin-left:auto;">Log out</a>
 </nav>
 {{end}}


### PR DESCRIPTION
The `/auth/logout` route exists but nothing in the UI linked to it — the only way to log out was to type the URL manually. #173 made logout revoke the server-side session, so a reachable control matters: this is now the only way for a user to actively end a session from the browser.

Adds a right-aligned **Log out** link to the shared nav (`nav.html`), so it appears on every authenticated page. Covered by a render assertion on the home page.

Found while smoke-testing #173 on prod — login/session renewal worked end-to-end, but there was no way to trigger logout from the UI.

## Testing
- `go test ./cmd/herald-web/` green; `golangci-lint` 0 issues.
- `TestHandleHome` now asserts the rendered nav contains `href="/auth/logout"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)