### PR TITLE
deps: bump oidclient v0.4.0 → v0.5.0 (end_session logout)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/infodancer/oidclient v0.4.0
+	github.com/infodancer/oidclient v0.5.0
 	github.com/infodancer/smoke v0.1.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/matthewjhunter/go-embedding v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infodancer/oidclient v0.4.0 h1:i3qDzysjzx9K1ATi2+2UKlXdYR3mN+c0EjDXm/tH2Y0=
 github.com/infodancer/oidclient v0.4.0/go.mod h1:jSK2NXUBlH+ntfz4eD+4hL/I2+U+7A7vMhxUugt5MrU=
+github.com/infodancer/oidclient v0.5.0 h1:ymi01dQEPNTTSvBKAMuQFP3ZyrR/JtuEzY6kIbqwygM=
+github.com/infodancer/oidclient v0.5.0/go.mod h1:jSK2NXUBlH+ntfz4eD+4hL/I2+U+7A7vMhxUugt5MrU=
 github.com/infodancer/smoke v0.1.0 h1:meBKkJHVtkFwV0NZ2YzOHTn9Fc+JG4flkRfrNd/30yU=
 github.com/infodancer/smoke v0.1.0/go.mod h1:zh5UdP94gj1koedPhrzaaXJbysCyv1x7NiJpWQiSloc=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
Bumps oidclient to **v0.5.0**, whose `LogoutURL()` returns the IdP's discovered `end_session_endpoint` (OIDC RP-Initiated Logout) instead of the fabricated `WebauthURL + /logout` path that 404'd.

Paired with webauth now serving that endpoint (infodancer/webauth #82), this is the final piece so the reading-pane **Log out** link actually reaches webauth and terminates the SSO session — the prod behavior caught while smoke-testing #173.

No code changes needed — `handleLogout` already calls `LogoutURL()`; only its resolved value changes.

## Testing
`go test -race ./...`, web tests, `golangci-lint` (0 issues), and `govulncheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)