### PR TITLE
Serialize startup migrations with a Postgres advisory lock (#195)

### DIFF
--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -17,13 +18,42 @@ var migrationFS embed.FS
 // (including per-schema test stores), so concurrent callers must not race on it.
 var migrateMu sync.Mutex
 
+// migrationsAdvisoryLockKey is the Postgres advisory-lock key held while
+// migrating. Value is ASCII "herald" as a big-endian integer -- an arbitrary
+// fixed key, unique to this purpose within the database. Every herald process
+// uses the same key, so exactly one migrates at a time.
+const migrationsAdvisoryLockKey int64 = 0x686572616c64 // "herald"
+
 // runMigrations brings the database up to the latest embedded goose migration.
 // It is idempotent: an already-current database (production, or a store reopened
 // in tests) is left untouched. Migrations run in whatever schema the connection's
 // search_path selects, so the per-test isolated schemas migrate independently.
+//
+// herald-web and herald-fetcher (and any future replica) each open the store and
+// run this on startup. They share one database, so concurrent goose.Up runs would
+// race -- and on a migration that locks rows (0003's DELETE over a populated
+// table) they deadlock outright (#195). A session-level Postgres advisory lock
+// serializes them across processes: the first to start migrates while the others
+// block here, then find the schema already current and no-op. The in-process
+// migrateMu still guards goose's global state within a single process.
 func runMigrations(db *sql.DB) error {
 	migrateMu.Lock()
 	defer migrateMu.Unlock()
+
+	ctx := context.Background()
+
+	// Hold the advisory lock on one dedicated connection for the whole of
+	// goose.Up. Closing the connection releases the session lock even if the
+	// explicit unlock never runs, so the lock cannot outlive a crash mid-migrate.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("migration lock: acquire connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationsAdvisoryLockKey); err != nil {
+		return fmt.Errorf("migration lock: %w", err)
+	}
+	defer conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationsAdvisoryLockKey) //nolint:errcheck // best-effort; conn.Close releases the session lock regardless
 
 	goose.SetBaseFS(migrationFS)
 	goose.SetLogger(goose.NopLogger())

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -1,8 +1,10 @@
 package storage
 
 import (
+	"context"
 	"database/sql"
 	"testing"
+	"time"
 )
 
 // TestMigrationsBuildAndAreIdempotent verifies the goose baseline: the first
@@ -84,5 +86,61 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	}
 	if len(feeds) != 1 {
 		t.Errorf("expected 1 feed to survive reopen, got %d", len(feeds))
+	}
+}
+
+// TestRunMigrationsAdvisoryLockSerializes verifies the cross-process guard from
+// #195: while one session holds the migration advisory lock (standing in for a
+// peer herald process mid-migrate), runMigrations on a separate pool must block
+// rather than run goose.Up concurrently, and must proceed once the lock frees.
+func TestRunMigrationsAdvisoryLockSerializes(t *testing.T) {
+	dsn, drop := testDSN(t)
+	defer drop()
+	ctx := context.Background()
+
+	// Holder pool: grab the migration lock on a dedicated connection and keep it.
+	holder, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	defer holder.Close()
+	hconn, err := holder.Conn(ctx)
+	if err != nil {
+		t.Fatalf("holder conn: %v", err)
+	}
+	if _, err := hconn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationsAdvisoryLockKey); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+
+	// runMigrations on a second pool (a distinct session, like another process)
+	// must block while the lock is held.
+	db2, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	defer db2.Close()
+	done := make(chan error, 1)
+	go func() { done <- runMigrations(db2) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("runMigrations completed while the lock was held (err=%v); advisory lock not honoured", err)
+	case <-time.After(500 * time.Millisecond):
+		// Expected: still blocked on the lock.
+	}
+
+	// Release the lock; runMigrations must now complete and build the schema.
+	if _, err := hconn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationsAdvisoryLockKey); err != nil {
+		t.Fatalf("release lock: %v", err)
+	}
+	hconn.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runMigrations after unlock: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("runMigrations did not complete after the lock was released")
 	}
 }


### PR DESCRIPTION
Fixes #195.

`herald-web` and `herald-fetcher` both open the store and run `goose up` on startup. Sharing one database, their concurrent `goose.Up` runs raced; on `0003`'s `DELETE` over a populated `article_embeddings` they deadlocked, failing one container's start (it recovered only via `restart=unless-stopped` once the other committed).

This wraps `goose.Up` in a session-level `pg_advisory_lock` held on a dedicated connection, so exactly one process migrates at a time and the rest block then no-op. Chosen over a single designated migrator because it stays correct if `herald-web` is ever scaled to multiple replicas. The session lock is released explicitly, with `conn.Close` as a backstop so it can't outlive a crash mid-migrate; the in-process `migrateMu` still guards goose's global state.

`TestRunMigrationsAdvisoryLockSerializes` holds the lock from a separate pool and asserts `runMigrations` blocks until release (verified it fails without the lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)