### PR TITLE
Switch TOML parser to pelletier/go-toml/v2 with strict decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TOML parser switched to `pelletier/go-toml/v2`; unknown config keys now
+  rejected.** Replaces `BurntSushi/toml` (the project standard for new code).
+  Config loading runs in strict mode: a key present in the file but absent from
+  the schema -- a typo, or a stale pre-unification layout like a top-level
+  `[webauth]` that now lives under `[web.webauth]` -- is a hard startup error
+  naming the offending key, rather than being silently ignored. Duration keys
+  (`timeout`) keep their `"5m"` string form via a wrapper type. (#199)
+
 - **Unified binary: `herald serve` replaces separate `herald-web`.** The web UI is now
   a subcommand of the single `herald` binary (`herald daemon` + `herald serve`).
   One build artifact, smaller images, single config entrypoint. Config standardized

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	embedding "github.com/matthewjhunter/go-embedding"
 	herald "github.com/matthewjhunter/herald"
 	"github.com/matthewjhunter/herald/internal/ai"
@@ -16,6 +16,7 @@ import (
 	"github.com/matthewjhunter/herald/internal/output"
 	"github.com/matthewjhunter/herald/internal/pipeline"
 	"github.com/matthewjhunter/herald/internal/storage"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -137,23 +138,21 @@ func loadConfig() error {
 	}
 
 	cfg = storage.DefaultConfig()
-	md, err := toml.Decode(string(data), cfg)
-	if err != nil {
-		return fmt.Errorf("failed to parse config: %w", err)
-	}
-
-	// Warn loudly about keys present in the file but not in the config
-	// struct. These are silently ignored by the decoder, so without this a
-	// typo (security_modle) or a stale pre-unification layout (a top-level
-	// [webauth] that now lives under [web.webauth]) leaves the setting at its
-	// default with no clue why. See #197: the web keys moved under [web].
-	if undecoded := md.Undecoded(); len(undecoded) > 0 {
-		keys := make([]string, len(undecoded))
-		for i, k := range undecoded {
-			keys[i] = k.String()
+	// DisallowUnknownFields turns a key that exists in the file but not in the
+	// Config struct into a hard parse error instead of a silent no-op. This
+	// catches typos (security_modle) and stale pre-unification layouts (a
+	// top-level [webauth] that now lives under [web.webauth] -- see #197) at
+	// boot, matching the fail-loud stance of the missing-file check above.
+	dec := toml.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(cfg); err != nil {
+		// StrictMissingError.String() pinpoints each offending key with a
+		// source excerpt; plain Error() only says "fields ... are missing".
+		var strict *toml.StrictMissingError
+		if errors.As(err, &strict) {
+			return fmt.Errorf("invalid config %s (unknown or misplaced key):\n%s", configPath, strict.String())
 		}
-		fmt.Fprintf(os.Stderr, "Warning: ignoring %d unknown config key(s) in %s: %s\n",
-			len(keys), configPath, strings.Join(keys, ", "))
+		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
 	return nil

--- a/cmd/herald/main_test.go
+++ b/cmd/herald/main_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // loadConfig and the configPath/cfg globals are package-level state.
@@ -90,76 +90,48 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 	})
 }
 
-// captureStderr runs fn with os.Stderr redirected to a pipe and returns what
-// was written. Used to assert on loadConfig's unknown-key warning.
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	saved := os.Stderr
-	os.Stderr = w
-	t.Cleanup(func() { os.Stderr = saved })
-
-	fn()
-	_ = w.Close()
-	os.Stderr = saved
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read captured stderr: %v", err)
-	}
-	return string(data)
-}
-
-func TestLoadConfig_WarnsOnUnknownKeys(t *testing.T) {
+func TestLoadConfig_RejectsUnknownKeys(t *testing.T) {
 	withGlobals(t, func() {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "config.toml")
-		// A stale pre-unification layout: [webauth] is now [web.webauth], and
-		// security_modle is a typo. Both decode into nothing and must be warned.
-		body := []byte("[webauth]\nissuer_url = \"https://idp.example.com\"\n\n" +
-			"[ollama]\nsecurity_modle = \"gemma4\"\n")
+		// A typo'd key. With DisallowUnknownFields the decoder fails loudly
+		// instead of silently leaving the field at its default. (A stale
+		// pre-unification [webauth] block -- now [web.webauth] -- fails the
+		// same way; see #197.)
+		body := []byte("[ollama]\nsecurity_modle = \"gemma4\"\n")
 		if err := os.WriteFile(path, body, 0o644); err != nil {
 			t.Fatalf("write tmp config: %v", err)
 		}
 		configPath = path
 
-		var loadErr error
-		out := captureStderr(t, func() { loadErr = loadConfig() })
-		if loadErr != nil {
-			t.Fatalf("loadConfig with unknown keys should not error, got: %v", loadErr)
+		err := loadConfig()
+		if err == nil {
+			t.Fatal("loadConfig with an unknown key should error, got nil")
 		}
-		if !strings.Contains(out, "unknown config key") {
-			t.Errorf("expected unknown-key warning on stderr, got: %q", out)
-		}
-		// Both offending keys should be named so the operator can fix them.
-		for _, want := range []string{"webauth.issuer_url", "ollama.security_modle"} {
-			if !strings.Contains(out, want) {
-				t.Errorf("warning should name %q, got: %q", want, out)
-			}
+		// The error must name the offending key so the operator can fix it.
+		if !strings.Contains(err.Error(), "security_modle") {
+			t.Errorf("error should name the unknown key, got: %q", err.Error())
 		}
 	})
 }
 
-func TestLoadConfig_NoWarningOnCleanFile(t *testing.T) {
+func TestLoadConfig_ParsesDurationString(t *testing.T) {
 	withGlobals(t, func() {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "config.toml")
-		body := []byte("[database]\npath = \"/tmp/test.db\"\n")
+		// pelletier/go-toml has no native time.Duration support; the
+		// storage.Duration wrapper parses the "30s" string via ParseDuration.
+		body := []byte("[ollama]\ntimeout = \"30s\"\n")
 		if err := os.WriteFile(path, body, 0o644); err != nil {
 			t.Fatalf("write tmp config: %v", err)
 		}
 		configPath = path
 
-		out := captureStderr(t, func() {
-			if err := loadConfig(); err != nil {
-				t.Fatalf("loadConfig on valid file: %v", err)
-			}
-		})
-		if strings.Contains(out, "unknown config key") {
-			t.Errorf("clean config should produce no unknown-key warning, got: %q", out)
+		if err := loadConfig(); err != nil {
+			t.Fatalf("loadConfig with a duration string: %v", err)
+		}
+		if got := time.Duration(cfg.Ollama.Timeout); got != 30*time.Second {
+			t.Errorf("Ollama.Timeout: got %v, want 30s", got)
 		}
 	})
 }

--- a/engine.go
+++ b/engine.go
@@ -107,7 +107,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	if storeCfg.Summary.BaseURL != "" {
 		summarizer = ai.NewCloudSummarizer(
 			storeCfg.Summary.BaseURL, cfg.SummaryAPIKey,
-			storeCfg.Summary.Model, storeCfg.Summary.Timeout,
+			storeCfg.Summary.Model, time.Duration(storeCfg.Summary.Timeout),
 			storeCfg.Summary.DisableThinking,
 		)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.4
 
 require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
-	github.com/BurntSushi/toml v1.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/infodancer/oidclient v0.6.0
 	github.com/infodancer/smoke v0.1.0
@@ -12,6 +11,7 @@ require (
 	github.com/matthewjhunter/go-embedding v0.4.6
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mmcdole/gofeed v1.3.0
+	github.com/pelletier/go-toml/v2 v2.4.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgvector/pgvector-go/pgx v0.4.0
 	github.com/pressly/goose/v3 v3.27.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 codeberg.org/readeck/go-readability/v2 v2.1.1 h1:1tEwxFuUqDRP5JABzDHXGWRx5p9S7TElS3U8qQwXC5Y=
 codeberg.org/readeck/go-readability/v2 v2.1.1/go.mod h1:x3WG9GpWWnkRb7ajP1NmOKSHbafxNUb736lrDZXeXrs=
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
@@ -71,6 +69,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
+github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pgvector/pgvector-go v0.4.0 h1:879hQCnuix1bkfa5TQISnnK9ik4Fo+cHj2vuZSgW5v4=
 github.com/pgvector/pgvector-go v0.4.0/go.mod h1:4fSXyjl1TYAIdByAql6JazKWRr2s7J0g4hcRY5cBFCk=
 github.com/pgvector/pgvector-go/pgx v0.4.0 h1:wHFoQRtCksVfmrBaHoxeT8IkonmnxlvnLzz3T4EW9Y0=

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -61,7 +61,7 @@ func NewAIProcessor(baseURL, securityModel, curationModel string, store any, con
 			apiKey = cfg.Ollama.APIKey
 		}
 		if cfg.Ollama.Timeout > 0 {
-			callTimeout = cfg.Ollama.Timeout
+			callTimeout = time.Duration(cfg.Ollama.Timeout)
 		}
 		maxConcurrent = cfg.Ollama.MaxConcurrent
 	}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -1,6 +1,32 @@
 package storage
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// Duration wraps time.Duration so it (un)marshals from a TOML string like
+// "5m" via time.ParseDuration. pelletier/go-toml/v2 has no native Duration
+// support (it would try to read the string into the underlying int64 and
+// fail), so the config exposes this TextMarshaler/TextUnmarshaler type for
+// every duration-valued key. Callers convert with time.Duration(d) at use.
+type Duration time.Duration
+
+// MarshalText renders the duration in Go's canonical form (e.g. "5m0s") so a
+// written-back config (herald init-config) round-trips through UnmarshalText.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+// UnmarshalText parses a duration string such as "30s" or "5m".
+func (d *Duration) UnmarshalText(b []byte) error {
+	v, err := time.ParseDuration(string(b))
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", string(b), err)
+	}
+	*d = Duration(v)
+	return nil
+}
 
 type Config struct {
 	DefaultUserID int64 `toml:"default_user_id"`
@@ -12,12 +38,12 @@ type Config struct {
 	} `toml:"database"`
 
 	Ollama struct {
-		BaseURL       string        `toml:"base_url"`
-		APIKey        string        `toml:"api_key"`
-		SecurityModel string        `toml:"security_model"`
-		CurationModel string        `toml:"curation_model"`
-		Timeout       time.Duration `toml:"timeout"`
-		MaxParallel   int           `toml:"max_parallel"`
+		BaseURL       string   `toml:"base_url"`
+		APIKey        string   `toml:"api_key"`
+		SecurityModel string   `toml:"security_model"`
+		CurationModel string   `toml:"curation_model"`
+		Timeout       Duration `toml:"timeout"`
+		MaxParallel   int      `toml:"max_parallel"`
 		// MaxConcurrent bounds the number of in-flight generate() calls in this
 		// process. <= 0 means unbounded (no gate).
 		MaxConcurrent int `toml:"max_concurrent"`
@@ -96,14 +122,14 @@ type Config struct {
 	// from config — it comes from the HERALD_SUMMARY_API_KEY environment variable
 	// so the secret is never committed.
 	Summary struct {
-		BaseURL          string        `toml:"base_url"`           // OpenAI-compatible /v1 endpoint
-		Model            string        `toml:"model"`              // e.g. claude-sonnet-4-6
-		MinInterestScore float64       `toml:"min_interest_score"` // interest floor for included articles
-		MinSecurityScore float64       `toml:"min_security_score"` // security floor (gate)
-		MaxInputTokens   int           `toml:"max_input_tokens"`   // budget bound; trims oldest overflow
-		BodyCharCap      int           `toml:"body_char_cap"`      // per-article body truncation
-		MaxOutputTokens  int           `toml:"max_output_tokens"`  // completion cap
-		Timeout          time.Duration `toml:"timeout"`
+		BaseURL          string   `toml:"base_url"`           // OpenAI-compatible /v1 endpoint
+		Model            string   `toml:"model"`              // e.g. claude-sonnet-4-6
+		MinInterestScore float64  `toml:"min_interest_score"` // interest floor for included articles
+		MinSecurityScore float64  `toml:"min_security_score"` // security floor (gate)
+		MaxInputTokens   int      `toml:"max_input_tokens"`   // budget bound; trims oldest overflow
+		BodyCharCap      int      `toml:"body_char_cap"`      // per-article body truncation
+		MaxOutputTokens  int      `toml:"max_output_tokens"`  // completion cap
+		Timeout          Duration `toml:"timeout"`
 		// DisableThinking turns off a reasoning backend's thinking pass (Qwen3 via
 		// Lemonade) so the completion is real content, not reasoning_content.
 		DisableThinking bool `toml:"disable_thinking"`
@@ -140,7 +166,7 @@ func DefaultConfig() *Config {
 	cfg.Ollama.BaseURL = "http://localhost:11434"
 	cfg.Ollama.SecurityModel = "gemma3:4b"
 	cfg.Ollama.CurationModel = "llama3.1:8b"
-	cfg.Ollama.Timeout = 2 * time.Minute
+	cfg.Ollama.Timeout = Duration(2 * time.Minute)
 	cfg.Ollama.MaxConcurrent = 8
 	cfg.Summarization.MinArticleLength = 200
 	cfg.Summarization.MaxSummaryLength = 500
@@ -168,6 +194,6 @@ func DefaultConfig() *Config {
 	cfg.Summary.MaxInputTokens = 170000
 	cfg.Summary.BodyCharCap = 6000
 	cfg.Summary.MaxOutputTokens = 16000
-	cfg.Summary.Timeout = 5 * time.Minute
+	cfg.Summary.Timeout = Duration(5 * time.Minute)
 	return cfg
 }


### PR DESCRIPTION
Closes #199.

## What

Replaces `github.com/BurntSushi/toml` (introduced in #197) with `github.com/pelletier/go-toml/v2`, the project standard for new Go code.

## Behavior change: strict unknown-key rejection

Config decoding now uses pelletier's `DisallowUnknownFields()`. A key present in the file but absent from the `Config` struct is a **hard startup error** that names the offending key, instead of being silently ignored.

This supersedes the lenient warn-on-unknown-keys path added on the #197 branch and is the fail-loud counterpart to the existing missing-file hard error. It catches:
- typos (`security_modle`)
- stale pre-unification layouts (a top-level `[webauth]` that now lives under `[web.webauth]`)

Error output pinpoints the key with a source excerpt (pelletier's `StrictMissingError.String()`):
```
invalid config ./config/config.toml (unknown or misplaced key):
strict mode: fields in the document are missing in the target struct
2| [ollama]
3| security_modle = "gemma4"
 | ~~~~~~~~~~~~~~ missing field
```

## time.Duration handling

pelletier has no native `time.Duration` support (it would try to read the `"5m"` string into the underlying int64 and fail). `storage.Duration` wraps `time.Duration` with `Text(Un)Marshaler` so the `"5m"` string form in config is preserved. The two `timeout` fields (`[ollama]`, `[summary]`) use it; the two call sites convert with `time.Duration()` at use. `herald init-config` round-trips (`timeout = '2m0s'`).

## Tests

- `TestLoadConfig_RejectsUnknownKeys` -- unknown key is a hard error naming the key.
- `TestLoadConfig_ParsesDurationString` -- `"30s"` decodes to `30 * time.Second`.
- Existing valid/missing-file tests unchanged.

`go test -race ./...`, `go vet`, `gofmt`, `golangci-lint`, and `govulncheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)