### PR TITLE
Show AI summary inline in the article list (#188)

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -257,6 +257,15 @@ func (e *Engine) GetArticleForUser(userID, articleID int64) (*Article, error) {
 	return &result, nil
 }
 
+// GetArticleSummaries batch-fetches non-empty AI summaries for the given
+// article ids, keyed by id, so a list page can render inline summaries without
+// an N+1 of GetArticleForUser. Access control is the caller's: pass ids the
+// user is entitled to (a page of the user's own list), since summaries are
+// per-article, not per-user (#162).
+func (e *Engine) GetArticleSummaries(articleIDs []int64) (map[int64]string, error) {
+	return e.store.GetArticleSummaries(articleIDs)
+}
+
 // GetHighInterestArticles returns unread articles scored above the threshold.
 func (e *Engine) GetHighInterestArticles(userID int64, threshold float64, limit, offset int) ([]Article, []float64, error) {
 	articles, scores, err := e.store.GetArticlesByInterestScore(userID, threshold, limit, offset, e.resolveFilterThreshold(userID))

--- a/internal/storage/db/article_summary.sql.go
+++ b/internal/storage/db/article_summary.sql.go
@@ -10,6 +10,38 @@ import (
 	"time"
 )
 
+const getArticleSummaries = `-- name: GetArticleSummaries :many
+SELECT article_id, ai_summary
+FROM article_summaries
+WHERE article_id = ANY($1::bigint[])
+  AND ai_summary <> ''
+`
+
+type GetArticleSummariesRow struct {
+	ArticleID int64
+	AiSummary string
+}
+
+func (q *Queries) GetArticleSummaries(ctx context.Context, articleIds []int64) ([]GetArticleSummariesRow, error) {
+	rows, err := q.db.Query(ctx, getArticleSummaries, articleIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetArticleSummariesRow{}
+	for rows.Next() {
+		var i GetArticleSummariesRow
+		if err := rows.Scan(&i.ArticleID, &i.AiSummary); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getArticleSummary = `-- name: GetArticleSummary :one
 SELECT article_id, ai_summary, generated_at
 FROM article_summaries

--- a/internal/storage/db/queries/article_summary.sql
+++ b/internal/storage/db/queries/article_summary.sql
@@ -17,3 +17,9 @@ ON CONFLICT (article_id) DO UPDATE SET
 SELECT article_id, ai_summary, generated_at
 FROM article_summaries
 WHERE article_id = @article_id;
+
+-- name: GetArticleSummaries :many
+SELECT article_id, ai_summary
+FROM article_summaries
+WHERE article_id = ANY(@article_ids::bigint[])
+  AND ai_summary <> '';

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1254,6 +1254,24 @@ func (s *PostgresStore) GetArticleSummary(articleID int64) (*ArticleSummary, err
 	}, nil
 }
 
+// GetArticleSummaries batch-fetches non-empty AI summaries for the given
+// article ids in a single query, returning a map keyed by article id. Ids with
+// no summary (or a skipped/empty one) are absent from the map.
+func (s *PostgresStore) GetArticleSummaries(articleIDs []int64) (map[int64]string, error) {
+	out := make(map[int64]string, len(articleIDs))
+	if len(articleIDs) == 0 {
+		return out, nil
+	}
+	rows, err := s.q.GetArticleSummaries(context.Background(), articleIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get article summaries: %w", err)
+	}
+	for _, r := range rows {
+		out[r.ArticleID] = r.AiSummary
+	}
+	return out, nil
+}
+
 // --- Feed stats ---
 
 // GetProcessingStats returns an aggregate snapshot of the AI pipeline state for a

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -178,6 +178,11 @@ type Store interface {
 	UpdateArticleAISummary(articleID int64, aiSummary string) error
 	MarkSummarizationSkipped(articleID int64, reason string) error
 	GetArticleSummary(articleID int64) (*ArticleSummary, error)
+	// GetArticleSummaries batch-fetches non-empty AI summaries for the given
+	// article ids, keyed by article id, so a list page can populate inline
+	// summaries in one query instead of N. Articles with no summary (or a
+	// skipped/empty one) are simply absent from the map.
+	GetArticleSummaries(articleIDs []int64) (map[int64]string, error)
 
 	// Feed stats
 	GetFeedStats(userID int64) ([]FeedStats, error)

--- a/internal/storage/summary_perarticle_test.go
+++ b/internal/storage/summary_perarticle_test.go
@@ -46,6 +46,58 @@ func TestArticleSummarySharedAcrossUsers(t *testing.T) {
 	})
 }
 
+// TestGetArticleSummariesBatch covers the batch lookup that backs inline list
+// summaries (#188): it returns one map entry per article that has a non-empty
+// summary, omits skipped (empty) summaries and unknown ids, and tolerates an
+// empty id list.
+func TestGetArticleSummariesBatch(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now()
+		summarized, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "sum", Title: "sum",
+			URL: "https://example.com/sum", PublishedDate: &now})
+		skipped, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "skip", Title: "skip",
+			URL: "https://example.com/skip2", PublishedDate: &now})
+		bare, _ := store.AddArticle(&Article{FeedID: feedID, GUID: "bare", Title: "bare",
+			URL: "https://example.com/bare", PublishedDate: &now})
+
+		if err := store.UpdateArticleAISummary(summarized, "inline summary"); err != nil {
+			t.Fatalf("UpdateArticleAISummary: %v", err)
+		}
+		if err := store.MarkSummarizationSkipped(skipped, "too short"); err != nil {
+			t.Fatalf("MarkSummarizationSkipped: %v", err)
+		}
+
+		// Empty input is a no-op, not an error.
+		if got, err := store.GetArticleSummaries(nil); err != nil || len(got) != 0 {
+			t.Fatalf("GetArticleSummaries(nil) = %v err=%v, want empty", got, err)
+		}
+
+		got, err := store.GetArticleSummaries([]int64{summarized, skipped, bare, 999999})
+		if err != nil {
+			t.Fatalf("GetArticleSummaries: %v", err)
+		}
+		if got[summarized] != "inline summary" {
+			t.Errorf("summarized article: got %q, want %q", got[summarized], "inline summary")
+		}
+		if _, ok := got[skipped]; ok {
+			t.Error("skipped (empty) summary must be omitted from the batch result")
+		}
+		if _, ok := got[bare]; ok {
+			t.Error("article with no summary row must be omitted")
+		}
+		if _, ok := got[999999]; ok {
+			t.Error("unknown id must be omitted")
+		}
+		if len(got) != 1 {
+			t.Errorf("expected exactly one entry, got %d: %v", len(got), got)
+		}
+	})
+}
+
 // TestSummarizationSkipSharedAcrossUsers verifies a skip marker is shared the
 // same way: one MarkSummarizationSkipped keeps the article out of the global
 // queue with no per-user retry.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -224,6 +224,7 @@ type articleRow struct {
 	Author           string
 	FeedTitle        string
 	PublishedDateFmt string
+	AISummary        string
 	Read             bool
 	Starred          bool
 	SecurityFlagged  bool
@@ -598,6 +599,21 @@ func (h *handlers) handleSettingsPrompts(w http.ResponseWriter, r *http.Request)
 
 // --- htmx fragment handlers ---
 
+// articleSummaries batch-fetches inline AI summaries for a page of article ids,
+// keyed by id. Summaries are decorative, so a lookup error is logged and
+// degrades to no inline summaries rather than failing the list render.
+func (h *handlers) articleSummaries(ids []int64) map[int64]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	summaries, err := h.engine.GetArticleSummaries(ids)
+	if err != nil {
+		log.Printf("herald-web: batch article summaries: %v", err)
+		return nil
+	}
+	return summaries
+}
+
 func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
 	limit := parseIntParam(r, "limit", 30, maxPageLimit)
@@ -657,6 +673,13 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Batch-fetch AI summaries for the page in one query (avoid N+1).
+	ids := make([]int64, len(articles))
+	for i, a := range articles {
+		ids[i] = a.ID
+	}
+	summaries := h.articleSummaries(ids)
+
 	for _, a := range articles {
 		data.Articles = append(data.Articles, articleRow{
 			ID:               a.ID,
@@ -664,6 +687,7 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 			Author:           a.Author,
 			FeedTitle:        feedTitles[a.FeedID],
 			PublishedDateFmt: formatDate(bestDate(a.PublishedDate, &a.FetchedDate)),
+			AISummary:        summaries[a.ID],
 			SecurityFlagged:  a.SecurityFlagged,
 			Read:             a.Read,
 			Starred:          a.Starred,
@@ -723,6 +747,12 @@ func (h *handlers) handleSearch(w http.ResponseWriter, r *http.Request) {
 		HasMore:    hasMore,
 		NextOffset: offset + limit,
 	}
+	ids := make([]int64, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+	summaries := h.articleSummaries(ids)
+
 	for _, r := range results {
 		data.Articles = append(data.Articles, articleRow{
 			ID:               r.ID,
@@ -730,6 +760,7 @@ func (h *handlers) handleSearch(w http.ResponseWriter, r *http.Request) {
 			Author:           r.Author,
 			FeedTitle:        feedTitles[r.FeedID],
 			PublishedDateFmt: formatDate(bestDate(r.PublishedDate, &r.FetchedDate)),
+			AISummary:        summaries[r.ID],
 		})
 	}
 

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -510,6 +510,40 @@ func TestHandleArticleList_Default(t *testing.T) {
 	}
 }
 
+func TestHandleArticleList_InlineAISummary(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	const summary = "Batch-fetched inline summary for the list."
+	if err := tf.store.UpdateArticleAISummary(tf.articleID, summary); err != nil {
+		t.Fatalf("UpdateArticleAISummary: %v", err)
+	}
+
+	rr := authedRequest(t, tf, "GET", "/articles", map[string]string{"HX-Request": "true"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, summary) {
+		t.Error("article list should render the inline AI summary text")
+	}
+	if !strings.Contains(body, "ai-summary-inline") {
+		t.Error("inline summary should use the .ai-summary-inline class")
+	}
+}
+
+func TestHandleArticleList_NoSummaryNoInlineBlock(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	// The seeded article has no AI summary, so the inline block must be absent.
+	rr := authedRequest(t, tf, "GET", "/articles", map[string]string{"HX-Request": "true"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if strings.Contains(rr.Body.String(), "ai-summary-inline") {
+		t.Error("article without a summary should not render an inline summary block")
+	}
+}
+
 func TestHandleArticleList_ByFeed(t *testing.T) {
 	tf := newTestFixtures(t)
 

--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -184,6 +184,21 @@
     color: gold;
 }
 
+/* Inline AI summary under the row meta. Clamped to keep list scan density;
+   the full summary still shows in the reading pane (.reading-pane .ai-summary). */
+.article-row .ai-summary-inline {
+    margin: 0.35rem 0 0;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    color: var(--pico-muted-color);
+    border-left: 2px solid var(--pico-primary);
+    padding-left: 0.5rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
 /* Reading pane content */
 .reading-pane .article-header {
     margin-bottom: 1.5rem;

--- a/internal/web/templates/article_row.html
+++ b/internal/web/templates/article_row.html
@@ -13,5 +13,6 @@
         {{if .Author}}{{.Author}} &middot; {{end}}
         {{.PublishedDateFmt}}
     </div>
+    {{if .AISummary}}<p class="ai-summary-inline">{{.AISummary}}</p>{{end}}
 </div>
 {{end}}


### PR DESCRIPTION
Closes #188.

## What

The per-article AI summary previously appeared only in the reading pane after clicking an article. This surfaces it directly in each article-list row, under the headline and byline, so you can triage without opening each item. The reading pane keeps its full `.ai-summary` block (the inline one is clamped).

## How

- **storage**: new `GetArticleSummaries(ids []int64) (map[int64]string, error)` — a sqlc `:many` over `ANY(@article_ids::bigint[])` that filters out empty/skipped summaries. One query per page instead of an N+1 of `GetArticleSummary`. Engine passthrough added.
- **web**: `articleRow` gains `AISummary`, populated in both `handleArticleList` and `handleSearch` via a shared `articleSummaries()` helper. Summaries are decorative, so a lookup error logs and degrades to no inline summary rather than failing the list render.
- **template / css**: `article_row.html` renders `.ai-summary-inline` conditionally after the meta line; CSS clamps it to 3 lines (`-webkit-line-clamp`) to keep list scan density.

Note: `article_summaries` is keyed per-article (not per-user, #162), so the batch lookup takes ids only; access control is the caller's (a page of the user's own list).

## Tests (run against `HERALD_TEST_DB_DSN`)

- `TestHandleArticleList_InlineAISummary` — list renders the summary text + `.ai-summary-inline`.
- `TestHandleArticleList_NoSummaryNoInlineBlock` — no summary → no inline block.
- `TestGetArticleSummariesBatch` — omits skipped (empty), missing-row, and unknown ids; empty input is a no-op.

`go test -race ./...`, `go vet`, `golangci-lint`, `gofmt`, and `sqlc generate` (committed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)