### PR TITLE
Discover Substack feeds from profile URLs (#109)

### DIFF
--- a/internal/feeds/discovery.go
+++ b/internal/feeds/discovery.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/matthewjhunter/herald/internal/storage"
@@ -110,11 +111,80 @@ func (f *Fetcher) DiscoverFeeds(ctx context.Context, pageURL string) ([]Discover
 		}
 	}
 
+	// Substack profile URLs (substack.com/@user, /profile/...) carry no
+	// autodiscovery, and the feed lives on a publication subdomain that
+	// path-probing the apex host can't reach. Recover the subdomain(s) from the
+	// profile body and probe <pub>.substack.com/feed. (#109)
+	if found := f.substackProfileFeeds(ctx, base, body); len(found) > 0 {
+		return found, nil
+	}
+
 	// Fallback: probe common feed paths under the same host.
 	if base != nil {
 		return f.probeFeedPaths(ctx, base), nil
 	}
 	return nil, nil
+}
+
+// substackSubdomainRe matches "<sub>.substack.com" hostnames embedded anywhere
+// in a page body (links, embedded JSON, etc.), capturing the subdomain label.
+var substackSubdomainRe = regexp.MustCompile(`(?i)([a-z0-9][a-z0-9-]{0,62})\.substack\.com`)
+
+// substackInfraSubdomains are *.substack.com hosts that are platform
+// infrastructure, not publications, so they must never be probed for a feed.
+var substackInfraSubdomains = map[string]bool{
+	"www": true, "cdn": true, "images": true, "assets": true, "static": true,
+	"api": true, "email": true, "links": true, "substackcdn": true, "on": true,
+}
+
+// isSubstackProfile reports whether u is a Substack profile page (on the apex
+// host, path /@handle or /profile/...), as opposed to a publication subdomain
+// (which already works via standard autodiscovery).
+func isSubstackProfile(u *url.URL) bool {
+	host := strings.ToLower(u.Host)
+	if host != "substack.com" && host != "www.substack.com" {
+		return false
+	}
+	return strings.HasPrefix(u.Path, "/@") || strings.HasPrefix(u.Path, "/profile/")
+}
+
+// extractSubstackSubdomains returns the distinct publication subdomains
+// referenced in a Substack profile body, in first-seen order, excluding
+// platform-infrastructure hosts and capped at maxFeedProbes.
+func extractSubstackSubdomains(body []byte) []string {
+	var subs []string
+	seen := make(map[string]bool)
+	for _, m := range substackSubdomainRe.FindAllSubmatch(body, -1) {
+		sub := strings.ToLower(string(m[1]))
+		if substackInfraSubdomains[sub] || seen[sub] {
+			continue
+		}
+		seen[sub] = true
+		subs = append(subs, sub)
+		if len(subs) >= maxFeedProbes {
+			break
+		}
+	}
+	return subs
+}
+
+// substackProfileFeeds handles the Substack-profile special case: it extracts
+// the publication subdomains from the profile body and verifies
+// <pub>.substack.com/feed for each. Returns nil (falling through to generic
+// behaviour) when base is not a Substack profile or no publication is found.
+func (f *Fetcher) substackProfileFeeds(ctx context.Context, base *url.URL, body []byte) []DiscoveredFeed {
+	if base == nil || !isSubstackProfile(base) {
+		return nil
+	}
+	subs := extractSubstackSubdomains(body)
+	if len(subs) == 0 {
+		return nil
+	}
+	candidates := make([]string, 0, len(subs))
+	for _, s := range subs {
+		candidates = append(candidates, "https://"+s+".substack.com/feed")
+	}
+	return f.verifyFeedCandidates(ctx, candidates)
 }
 
 // verifyFeedCandidates fetches each candidate URL and returns those that parse

--- a/internal/feeds/discovery_test.go
+++ b/internal/feeds/discovery_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -17,6 +18,48 @@ const testHTMLWithFeeds = `<!DOCTYPE html>
 
 const testHTMLNoFeeds = `<!DOCTYPE html>
 <html><head><title>No Feeds Here</title></head><body><p>Nothing</p></body></html>`
+
+// substackProfileBody mimics a substack.com/@user profile page: no
+// autodiscovery <link> tags, but the publication subdomain appears in embedded
+// JSON, alongside platform-infrastructure hosts that must be filtered out.
+const substackProfileBody = `<!DOCTYPE html>
+<html><head><title>Jeffro Johnson</title></head><body>
+<script>window.__data = {"publicationUrl":"https://jeffrojohnson.substack.com",
+"logo":"https://cdn.substack.com/image/x.png",
+"avatar":"https://images.substack.com/y.png"};</script>
+<a href="https://substackcdn.com/z">cdn</a>
+<a href="https://jeffrojohnson.substack.com/p/post-one">a post</a>
+</body></html>`
+
+func TestExtractSubstackSubdomains(t *testing.T) {
+	got := extractSubstackSubdomains([]byte(substackProfileBody))
+	if len(got) != 1 || got[0] != "jeffrojohnson" {
+		t.Fatalf("got %v, want [jeffrojohnson] (cdn/images infra subdomains filtered)", got)
+	}
+}
+
+func TestIsSubstackProfile(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"https://substack.com/@jeffrojohnson", true},
+		{"https://www.substack.com/@jeffrojohnson", true},
+		{"https://substack.com/profile/12345-jeffro", true},
+		{"https://jeffrojohnson.substack.com/", false}, // publication: standard discovery works
+		{"https://substack.com/about", false},          // apex non-profile page
+		{"https://example.com/@someone", false},        // not substack
+	}
+	for _, c := range cases {
+		u, err := url.Parse(c.raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.raw, err)
+		}
+		if got := isSubstackProfile(u); got != c.want {
+			t.Errorf("isSubstackProfile(%q) = %v, want %v", c.raw, got, c.want)
+		}
+	}
+}
 
 func TestDiscoverFeeds_HTMLLinks(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #109.

## Problem

Subscribing to a Substack **profile** URL (`https://substack.com/@user`) returned "no feeds found". Profile pages live on the apex `substack.com` host, carry no `<link rel=alternate>` autodiscovery, and the feed lives on a publication **subdomain** (`<pub>.substack.com/feed`) that path-probing the apex can't reach.

## Fix

`DiscoverFeeds` now recognises a Substack profile (apex host + `/@handle` or `/profile/...` path) and, after standard autodiscovery/anchor probing finds nothing:

1. Extracts the `<pub>.substack.com` subdomains referenced anywhere in the profile body (links, embedded JSON) via regex.
2. Filters out platform-infrastructure hosts (`cdn`, `images`, `assets`, ...).
3. Verifies `https://<pub>.substack.com/feed` for each (reusing `verifyFeedCandidates`), returning all that parse. A profile fronting multiple publications yields multiple feeds.

It falls through to the existing generic behaviour when the URL isn't a Substack profile or no publication is found, so it degrades gracefully if Substack changes its markup (the caveat the issue called out).

## Tests

- `TestExtractSubstackSubdomains` — pulls `jeffrojohnson` from a profile-like body, filtering `cdn`/`images`/`substackcdn` infra hosts.
- `TestIsSubstackProfile` — apex `/@user`, `www.`, `/profile/...` are profiles; a publication subdomain and apex non-profile pages are not.

Pure-function tests (no network); `go test -race ./internal/feeds/`, vet, lint, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)