### PR TITLE
Negative-cache favicon failures to stop per-cycle retries (#112)

### DIFF
--- a/internal/feeds/favicon.go
+++ b/internal/feeds/favicon.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -43,16 +44,62 @@ func (f *Fetcher) FetchFaviconsForFeeds(ctx context.Context) (int, error) {
 		}
 		data, mimeType, err := fetchFavicon(ctx, f.client, feed.URL)
 		if err != nil {
-			log.Printf("herald: favicon fetch failed for feed %d (%s): %v", feed.ID, feed.URL, err)
+			// Negative-cache the failure so a permanently-broken favicon isn't
+			// re-fetched and re-logged every cycle (#112). The retry query gates
+			// on the backoff window, so this log line now fires at most once per
+			// window per feed instead of every 5 minutes.
+			kind := classifyFaviconFailure(err)
+			log.Printf("herald: favicon fetch failed for feed %d (%s) [%s]: %v", feed.ID, feed.URL, kind, err)
+			if rerr := f.store.RecordFaviconFailure(feed.ID, kind); rerr != nil {
+				log.Printf("herald: failed to record favicon failure for feed %d: %v", feed.ID, rerr)
+			}
 			continue
 		}
 		if err := f.store.StoreFeedFavicon(feed.ID, data, mimeType); err != nil {
 			log.Printf("herald: failed to store favicon for feed %d: %v", feed.ID, err)
 			continue
 		}
+		// Clear any prior failure marker now that the favicon is cached.
+		if err := f.store.ClearFaviconFailure(feed.ID); err != nil {
+			log.Printf("herald: failed to clear favicon failure for feed %d: %v", feed.ID, err)
+		}
 		stored++
 	}
 	return stored, nil
+}
+
+// faviconHTTPError carries the HTTP status of a failed favicon fetch so the
+// failure can be classified (permanent vs transient) without string-parsing.
+type faviconHTTPError struct {
+	status int
+	url    string
+}
+
+func (e *faviconHTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d for %s", e.status, e.url)
+}
+
+// errEmptyFavicon marks a 200 response with an empty body -- treated as a
+// permanent failure (the server stably serves nothing).
+var errEmptyFavicon = errors.New("empty favicon")
+
+// classifyFaviconFailure labels a favicon fetch error "permanent" (won't change
+// on retry: 404/403/410/451/401 or an empty body) or "transient" (5xx,
+// timeouts, network/DNS errors, parse failures) so the negative cache can pick
+// a backoff window.
+func classifyFaviconFailure(err error) string {
+	if errors.Is(err, errEmptyFavicon) {
+		return "permanent"
+	}
+	var he *faviconHTTPError
+	if errors.As(err, &he) {
+		switch he.status {
+		case http.StatusNotFound, http.StatusForbidden, http.StatusGone,
+			http.StatusUnavailableForLegalReasons, http.StatusUnauthorized:
+			return "permanent"
+		}
+	}
+	return "transient"
 }
 
 // fetchFavicon fetches the best favicon for the site at feedURL.
@@ -170,7 +217,7 @@ func fetchAndNormalize(ctx context.Context, client *http.Client, iconURL string)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, iconURL)
+		return nil, "", &faviconHTTPError{status: resp.StatusCode, url: iconURL}
 	}
 
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxFaviconBytes))
@@ -178,7 +225,7 @@ func fetchAndNormalize(ctx context.Context, client *http.Client, iconURL string)
 		return nil, "", fmt.Errorf("read favicon: %w", err)
 	}
 	if len(data) == 0 {
-		return nil, "", fmt.Errorf("empty favicon at %s", iconURL)
+		return nil, "", fmt.Errorf("%w at %s", errEmptyFavicon, iconURL)
 	}
 
 	ct := strings.ToLower(resp.Header.Get("Content-Type"))

--- a/internal/feeds/favicon_test.go
+++ b/internal/feeds/favicon_test.go
@@ -16,6 +16,31 @@ import (
 	"github.com/matthewjhunter/herald/internal/storage"
 )
 
+func TestClassifyFaviconFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"404", &faviconHTTPError{status: 404}, "permanent"},
+		{"403", &faviconHTTPError{status: 403}, "permanent"},
+		{"410", &faviconHTTPError{status: 410}, "permanent"},
+		{"451", &faviconHTTPError{status: 451}, "permanent"},
+		{"401", &faviconHTTPError{status: 401}, "permanent"},
+		{"500", &faviconHTTPError{status: 500}, "transient"},
+		{"503", &faviconHTTPError{status: 503}, "transient"},
+		{"429", &faviconHTTPError{status: 429}, "transient"},
+		{"empty", fmt.Errorf("%w at https://x/favicon.ico", errEmptyFavicon), "permanent"},
+		{"wrapped-404", fmt.Errorf("fetch: %w", &faviconHTTPError{status: 404}), "permanent"},
+		{"network", fmt.Errorf("dial tcp: i/o timeout"), "transient"},
+	}
+	for _, c := range cases {
+		if got := classifyFaviconFailure(c.err); got != c.want {
+			t.Errorf("%s: classifyFaviconFailure = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 // --- extractIconHref tests ---
 
 func TestExtractIconHref_BasicIcon(t *testing.T) {

--- a/internal/storage/db/favicon.sql.go
+++ b/internal/storage/db/favicon.sql.go
@@ -9,6 +9,16 @@ import (
 	"context"
 )
 
+const clearFaviconFailure = `-- name: ClearFaviconFailure :exec
+UPDATE feeds SET favicon_failed_at = NULL, favicon_fail_kind = ''
+WHERE id = $1
+`
+
+func (q *Queries) ClearFaviconFailure(ctx context.Context, feedID int64) error {
+	_, err := q.db.Exec(ctx, clearFaviconFailure, feedID)
+	return err
+}
+
 const getAllFeedFavicons = `-- name: GetAllFeedFavicons :many
 SELECT feed_id, data, mime_type, fetched_at FROM feed_favicons
 `
@@ -55,13 +65,22 @@ func (q *Queries) GetFeedFavicon(ctx context.Context, feedID int64) (FeedFavicon
 }
 
 const getSubscribedFeedsWithoutFavicons = `-- name: GetSubscribedFeedsWithoutFavicons :many
-SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status FROM feeds f
+SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status, f.favicon_failed_at, f.favicon_fail_kind FROM feeds f
 JOIN user_feeds uf ON f.id = uf.feed_id
 LEFT JOIN feed_favicons ff ON f.id = ff.feed_id
 WHERE ff.feed_id IS NULL
+  AND (
+    f.favicon_failed_at IS NULL
+    OR (f.favicon_fail_kind = 'transient' AND f.favicon_failed_at < NOW() - INTERVAL '6 hours')
+    OR (f.favicon_fail_kind = 'permanent' AND f.favicon_failed_at < NOW() - INTERVAL '30 days')
+  )
 ORDER BY f.id
 `
 
+// Feeds a user subscribes to that have no cached favicon AND are not inside a
+// failure backoff window (#112): permanent failures retry at most every 30 days,
+// transient ones every 6 hours. A feed with a cached favicon (feed_favicons row)
+// is always excluded.
 func (q *Queries) GetSubscribedFeedsWithoutFavicons(ctx context.Context) ([]Feed, error) {
 	rows, err := q.db.Query(ctx, getSubscribedFeedsWithoutFavicons)
 	if err != nil {
@@ -86,6 +105,8 @@ func (q *Queries) GetSubscribedFeedsWithoutFavicons(ctx context.Context) ([]Feed
 			&i.ConsecutiveErrors,
 			&i.NextFetchAt,
 			&i.Status,
+			&i.FaviconFailedAt,
+			&i.FaviconFailKind,
 		); err != nil {
 			return nil, err
 		}
@@ -95,6 +116,21 @@ func (q *Queries) GetSubscribedFeedsWithoutFavicons(ctx context.Context) ([]Feed
 		return nil, err
 	}
 	return items, nil
+}
+
+const recordFaviconFailure = `-- name: RecordFaviconFailure :exec
+UPDATE feeds SET favicon_failed_at = NOW(), favicon_fail_kind = $1::text
+WHERE id = $2
+`
+
+type RecordFaviconFailureParams struct {
+	FailKind string
+	FeedID   int64
+}
+
+func (q *Queries) RecordFaviconFailure(ctx context.Context, arg RecordFaviconFailureParams) error {
+	_, err := q.db.Exec(ctx, recordFaviconFailure, arg.FailKind, arg.FeedID)
+	return err
 }
 
 const storeFeedFavicon = `-- name: StoreFeedFavicon :exec

--- a/internal/storage/db/feed.sql.go
+++ b/internal/storage/db/feed.sql.go
@@ -30,7 +30,7 @@ func (q *Queries) AddFeed(ctx context.Context, arg AddFeedParams) (int64, error)
 }
 
 const getActiveFeedsToFetch = `-- name: GetActiveFeedsToFetch :many
-SELECT id, url, title, description, site_url, last_fetched, last_error, etag, last_modified, enabled, created_at, consecutive_errors, next_fetch_at, status FROM feeds
+SELECT id, url, title, description, site_url, last_fetched, last_error, etag, last_modified, enabled, created_at, consecutive_errors, next_fetch_at, status, favicon_failed_at, favicon_fail_kind FROM feeds
 WHERE enabled = TRUE AND status = 'active'
   AND (next_fetch_at IS NULL OR next_fetch_at <= NOW())
 `
@@ -59,6 +59,8 @@ func (q *Queries) GetActiveFeedsToFetch(ctx context.Context) ([]Feed, error) {
 			&i.ConsecutiveErrors,
 			&i.NextFetchAt,
 			&i.Status,
+			&i.FaviconFailedAt,
+			&i.FaviconFailKind,
 		); err != nil {
 			return nil, err
 		}
@@ -71,7 +73,7 @@ func (q *Queries) GetActiveFeedsToFetch(ctx context.Context) ([]Feed, error) {
 }
 
 const getFeed = `-- name: GetFeed :one
-SELECT id, url, title, description, site_url, last_fetched, last_error, etag, last_modified, enabled, created_at, consecutive_errors, next_fetch_at, status FROM feeds WHERE id = $1
+SELECT id, url, title, description, site_url, last_fetched, last_error, etag, last_modified, enabled, created_at, consecutive_errors, next_fetch_at, status, favicon_failed_at, favicon_fail_kind FROM feeds WHERE id = $1
 `
 
 func (q *Queries) GetFeed(ctx context.Context, id int64) (Feed, error) {
@@ -92,6 +94,8 @@ func (q *Queries) GetFeed(ctx context.Context, id int64) (Feed, error) {
 		&i.ConsecutiveErrors,
 		&i.NextFetchAt,
 		&i.Status,
+		&i.FaviconFailedAt,
+		&i.FaviconFailKind,
 	)
 	return i, err
 }

--- a/internal/storage/db/models.go
+++ b/internal/storage/db/models.go
@@ -138,6 +138,8 @@ type Feed struct {
 	ConsecutiveErrors int64
 	NextFetchAt       *time.Time
 	Status            string
+	FaviconFailedAt   *time.Time
+	FaviconFailKind   string
 }
 
 type FeedFavicon struct {

--- a/internal/storage/db/queries/favicon.sql
+++ b/internal/storage/db/queries/favicon.sql
@@ -11,8 +11,25 @@ SELECT * FROM feed_favicons WHERE feed_id = @feed_id;
 SELECT * FROM feed_favicons;
 
 -- name: GetSubscribedFeedsWithoutFavicons :many
+-- Feeds a user subscribes to that have no cached favicon AND are not inside a
+-- failure backoff window (#112): permanent failures retry at most every 30 days,
+-- transient ones every 6 hours. A feed with a cached favicon (feed_favicons row)
+-- is always excluded.
 SELECT DISTINCT f.* FROM feeds f
 JOIN user_feeds uf ON f.id = uf.feed_id
 LEFT JOIN feed_favicons ff ON f.id = ff.feed_id
 WHERE ff.feed_id IS NULL
+  AND (
+    f.favicon_failed_at IS NULL
+    OR (f.favicon_fail_kind = 'transient' AND f.favicon_failed_at < NOW() - INTERVAL '6 hours')
+    OR (f.favicon_fail_kind = 'permanent' AND f.favicon_failed_at < NOW() - INTERVAL '30 days')
+  )
 ORDER BY f.id;
+
+-- name: RecordFaviconFailure :exec
+UPDATE feeds SET favicon_failed_at = NOW(), favicon_fail_kind = @fail_kind::text
+WHERE id = @feed_id;
+
+-- name: ClearFaviconFailure :exec
+UPDATE feeds SET favicon_failed_at = NULL, favicon_fail_kind = ''
+WHERE id = @feed_id;

--- a/internal/storage/db/subscription.sql.go
+++ b/internal/storage/db/subscription.sql.go
@@ -53,7 +53,7 @@ func (q *Queries) DeleteOrphanedFeed(ctx context.Context, feedID int64) (int64, 
 }
 
 const getAllActiveSubscribedFeeds = `-- name: GetAllActiveSubscribedFeeds :many
-SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status FROM feeds f
+SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status, f.favicon_failed_at, f.favicon_fail_kind FROM feeds f
 JOIN user_feeds uf ON f.id = uf.feed_id
 WHERE f.enabled = TRUE
 ORDER BY f.title
@@ -83,6 +83,8 @@ func (q *Queries) GetAllActiveSubscribedFeeds(ctx context.Context) ([]Feed, erro
 			&i.ConsecutiveErrors,
 			&i.NextFetchAt,
 			&i.Status,
+			&i.FaviconFailedAt,
+			&i.FaviconFailKind,
 		); err != nil {
 			return nil, err
 		}
@@ -95,7 +97,7 @@ func (q *Queries) GetAllActiveSubscribedFeeds(ctx context.Context) ([]Feed, erro
 }
 
 const getAllSubscribedFeeds = `-- name: GetAllSubscribedFeeds :many
-SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status FROM feeds f
+SELECT DISTINCT f.id, f.url, f.title, f.description, f.site_url, f.last_fetched, f.last_error, f.etag, f.last_modified, f.enabled, f.created_at, f.consecutive_errors, f.next_fetch_at, f.status, f.favicon_failed_at, f.favicon_fail_kind FROM feeds f
 JOIN user_feeds uf ON f.id = uf.feed_id
 WHERE f.enabled = TRUE AND f.status = 'active'
   AND (f.next_fetch_at IS NULL OR f.next_fetch_at <= NOW())
@@ -126,6 +128,8 @@ func (q *Queries) GetAllSubscribedFeeds(ctx context.Context) ([]Feed, error) {
 			&i.ConsecutiveErrors,
 			&i.NextFetchAt,
 			&i.Status,
+			&i.FaviconFailedAt,
+			&i.FaviconFailKind,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/storage/favicon_test.go
+++ b/internal/storage/favicon_test.go
@@ -1,0 +1,87 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+func faviconEligible(t *testing.T, store Store, feedID int64) bool {
+	t.Helper()
+	feeds, err := store.GetSubscribedFeedsWithoutFavicons()
+	if err != nil {
+		t.Fatalf("GetSubscribedFeedsWithoutFavicons: %v", err)
+	}
+	for _, f := range feeds {
+		if f.ID == feedID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFaviconFailureBackoff covers the negative cache (#112): a recorded failure
+// removes a feed from the favicon retry set until its backoff window elapses,
+// clearing the failure restores eligibility, and a cached favicon excludes the
+// feed regardless of failure state.
+func TestFaviconFailureBackoff(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+		if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+			t.Fatal(err)
+		}
+
+		// No favicon, no failure -> eligible for a fetch attempt.
+		if !faviconEligible(t, store, feedID) {
+			t.Fatal("feed without favicon or failure should be eligible")
+		}
+
+		// A recorded failure removes it from the retry set within the window.
+		if err := store.RecordFaviconFailure(feedID, "permanent"); err != nil {
+			t.Fatalf("RecordFaviconFailure: %v", err)
+		}
+		if faviconEligible(t, store, feedID) {
+			t.Error("permanently-failed favicon must be skipped within its backoff window")
+		}
+
+		// A transient failure is likewise skipped within its (shorter) window.
+		if err := store.RecordFaviconFailure(feedID, "transient"); err != nil {
+			t.Fatalf("RecordFaviconFailure(transient): %v", err)
+		}
+		if faviconEligible(t, store, feedID) {
+			t.Error("transient failure must be skipped within its backoff window")
+		}
+
+		// Backdate the failure past the transient window (6h): it becomes
+		// eligible again. Backdate is test-only; the production path just waits.
+		pg, ok := store.(*PostgresStore)
+		if !ok {
+			t.Fatalf("expected *PostgresStore, got %T", store)
+		}
+		if _, err := pg.pool.Exec(context.Background(),
+			"UPDATE feeds SET favicon_failed_at = NOW() - INTERVAL '7 hours' WHERE id = $1", feedID); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+		if !faviconEligible(t, store, feedID) {
+			t.Error("transient failure older than its window should be retried")
+		}
+
+		// Clearing the failure restores eligibility immediately.
+		if err := store.RecordFaviconFailure(feedID, "permanent"); err != nil {
+			t.Fatalf("RecordFaviconFailure: %v", err)
+		}
+		if err := store.ClearFaviconFailure(feedID); err != nil {
+			t.Fatalf("ClearFaviconFailure: %v", err)
+		}
+		if !faviconEligible(t, store, feedID) {
+			t.Error("cleared failure should make the feed eligible again")
+		}
+
+		// A cached favicon excludes the feed regardless of any failure state.
+		if err := store.StoreFeedFavicon(feedID, []byte{0x89, 0x50, 0x4e, 0x47}, "image/png"); err != nil {
+			t.Fatalf("StoreFeedFavicon: %v", err)
+		}
+		if faviconEligible(t, store, feedID) {
+			t.Error("feed with a cached favicon must never be in the retry set")
+		}
+	})
+}

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("goose max version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("goose max version = %d, want 4", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0004_favicon_failure_tracking.sql
+++ b/internal/storage/migrations/0004_favicon_failure_tracking.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+--
+-- Negative-cache favicon fetch failures so a permanently-broken favicon
+-- (404/403/empty) is not re-fetched and re-logged every poll cycle (#112). The
+-- favicon success cache stays in feed_favicons; this records *failure* state on
+-- the feed itself so GetSubscribedFeedsWithoutFavicons can apply a backoff:
+--
+--   favicon_failed_at  -- when the last favicon fetch failed (NULL = no failure
+--                         on record, e.g. never attempted or last attempt cached)
+--   favicon_fail_kind  -- 'permanent' (404/403/410/451/empty) or 'transient'
+--                         (5xx/timeout/network); '' when no failure on record.
+--
+-- A successful fetch clears both (and inserts the feed_favicons row, which is
+-- what actually excludes the feed from the retry query).
+ALTER TABLE feeds ADD COLUMN favicon_failed_at TIMESTAMPTZ;
+ALTER TABLE feeds ADD COLUMN favicon_fail_kind TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE feeds DROP COLUMN favicon_fail_kind;
+ALTER TABLE feeds DROP COLUMN favicon_failed_at;

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1654,6 +1654,23 @@ func (s *PostgresStore) StoreFeedFavicon(feedID int64, data []byte, mimeType str
 	})
 }
 
+func (s *PostgresStore) RecordFaviconFailure(feedID int64, kind string) error {
+	if err := s.q.RecordFaviconFailure(context.Background(), db.RecordFaviconFailureParams{
+		FeedID:   feedID,
+		FailKind: kind,
+	}); err != nil {
+		return fmt.Errorf("record favicon failure: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ClearFaviconFailure(feedID int64) error {
+	if err := s.q.ClearFaviconFailure(context.Background(), feedID); err != nil {
+		return fmt.Errorf("clear favicon failure: %w", err)
+	}
+	return nil
+}
+
 func (s *PostgresStore) GetFeedFavicon(feedID int64) (*FeedFavicon, error) {
 	r, err := s.q.GetFeedFavicon(context.Background(), feedID)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -282,6 +282,11 @@ type Store interface {
 
 	// Feed favicons
 	StoreFeedFavicon(feedID int64, data []byte, mimeType string) error
+	// RecordFaviconFailure negative-caches a favicon fetch failure so the feed
+	// is skipped until its backoff window elapses (kind: "permanent" or
+	// "transient"). ClearFaviconFailure resets it on a later success. (#112)
+	RecordFaviconFailure(feedID int64, kind string) error
+	ClearFaviconFailure(feedID int64) error
 	GetFeedFavicon(feedID int64) (*FeedFavicon, error)
 	GetAllFeedFavicons() ([]FeedFavicon, error)
 	GetSubscribedFeedsWithoutFavicons() ([]Feed, error)


### PR DESCRIPTION
Closes #112.

## Problem

Favicons that 404/403/return-empty were re-fetched and re-logged every 5-minute poll cycle — 598 failure lines from 13 feeds in 24h of prod logs, ~46 retries/day per failing feed, permanently. Second-largest source of log noise.

## Fix

Negative-cache the failure on the feed and gate the retry query on a backoff window:

- **Migration 0004** adds `favicon_failed_at` + `favicon_fail_kind` to `feeds`. The favicon *success* cache stays in `feed_favicons`; this records *failure* state, keeping the two concerns separate (and the web handler untouched).
- `GetSubscribedFeedsWithoutFavicons` now excludes feeds inside their backoff window: **permanent** (404/403/410/451/401/empty body) retry at most every **30 days**, **transient** (5xx/timeout/network/parse) every **6 hours**.
- Failures are classified from a typed `faviconHTTPError` (carries the status code) plus an `errEmptyFavicon` sentinel — no string-parsing of error text.
- A successful fetch clears the marker; a cached favicon excludes the feed as before.
- Because the retry query skips backed-off feeds, the per-cycle log line now fires at most **once per window per feed** instead of every cycle.

## Tests (against `HERALD_TEST_DB_DSN`)

- `TestClassifyFaviconFailure` — status codes / empty body → permanent; 5xx/429/network → transient; wrapping respected.
- `TestFaviconFailureBackoff` — excluded within window; retried once the (backdated) window elapses; restored on clear; always excluded when a favicon is cached.
- Updated `TestMigrationsBuildAndAreIdempotent` max-version assertion (3 → 4).

`go test -race ./...`, vet, lint, gofmt, `sqlc generate` (committed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)