### PR TITLE
Move search magnifier beside the input (fix text overlap)

### DIFF
--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -420,12 +420,27 @@
 .nav-search {
     flex: 0 1 16rem;
     margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.nav-search-icon {
+    flex: 0 0 auto;
+    color: var(--pico-muted-color);
 }
 .nav-search input[type="search"] {
     margin: 0;
+    /* Pico draws a magnifying glass inside the field and pads the text past it;
+       here the glass lives beside the field (.nav-search-icon), so drop the
+       in-field icon and its clearance padding to keep the text from sitting
+       under it. */
     padding: 0.3rem 0.5rem;
+    padding-inline-start: 0.5rem;
+    background-image: none;
     font-size: 0.85rem;
     height: auto;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 .search-banner {
     padding: 0.5rem 0.75rem;

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -27,6 +27,10 @@
         </div>
         {{block "nav" .}}{{end}}
         <form class="nav-search" onsubmit="return false;">
+            <svg class="nav-search-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+                <circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="2"/>
+                <line x1="16.5" y1="16.5" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
             <input type="search" name="q" placeholder="Search, or paste a URL to find who linked it"
                    hx-get="/search" hx-target="#article-list" hx-swap="innerHTML"
                    hx-trigger="input changed delay:300ms, search"


### PR DESCRIPTION
The search placeholder rendered under the magnifying glass (reported with a screenshot).

**Cause:** PicoCSS draws the magnifier as an in-field background image and pads the text past it via `padding-inline-start`. `.nav-search`'s `padding: 0.3rem 0.5rem` override reset that left padding, so the text sat under the icon — made obvious by the longer "Search, or paste a URL…" placeholder.

**Fix:** make `.nav-search` a flex row, place the magnifier as a sibling SVG to the **left** of the input (`.nav-search-icon`), and drop Pico's in-field icon (`background-image: none`) + its clearance padding. The glass now sits beside the field; the text is unobstructed.

CSS/template only; `go build` + web template/CSP tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)