### PR TITLE
feeds: drop same-site self-links from the backlink index

### DIFF
--- a/internal/feeds/links.go
+++ b/internal/feeds/links.go
@@ -36,7 +36,7 @@ func (f *Fetcher) ExtractLinksForArticles(ctx context.Context) (int, error) {
 		if ctx.Err() != nil {
 			break
 		}
-		links := extractExternalLinks(a.Content, a.Summary)
+		links := extractExternalLinks(urlnorm.Host(a.URL), a.Content, a.Summary)
 		if err := f.store.StoreArticleLinks(a.ID, links); err != nil {
 			log.Printf("herald: store links for article %d: %v", a.ID, err)
 			continue
@@ -57,7 +57,14 @@ func (f *Fetcher) ExtractLinksForArticles(ctx context.Context) (int, error) {
 // urlnorm.Normalize. This is deliberately link-only: it does not try to resolve
 // relative URLs (no per-article base) -- the editorial outbound links we care
 // about are absolute.
-func extractExternalLinks(fragments ...string) []string {
+//
+// selfHost is the normalized host of the article being parsed (urlnorm.Host of
+// its URL). Links to that same host are dropped: a link-blog's own sidebar,
+// "recent posts", and archive widgets point back into the site on every page,
+// and counting them as citations swamps the "linked by" lookup with one feed
+// linking to itself. An empty selfHost (article URL not http(s)) disables the
+// filter, so nothing is lost when the host is unknown.
+func extractExternalLinks(selfHost string, fragments ...string) []string {
 	var out []string
 	seen := make(map[string]bool)
 
@@ -78,7 +85,9 @@ func extractExternalLinks(fragments ...string) []string {
 				href := strings.TrimSpace(nodeAttrs(n.Attr)["href"])
 				if norm := urlnorm.Normalize(href); norm != "" && !seen[norm] {
 					seen[norm] = true
-					out = append(out, norm)
+					if host, _, _ := strings.Cut(norm, "/"); host != selfHost {
+						out = append(out, norm)
+					}
 				}
 			}
 			for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/feeds/links_test.go
+++ b/internal/feeds/links_test.go
@@ -15,7 +15,8 @@ func TestExtractExternalLinks(t *testing.T) {
 	summary := `<a href="https://example.com/a">a again</a>
 	            <a href="https://summary-only.example/c">c</a>`
 
-	got := extractExternalLinks(body, summary)
+	// No self-host: nothing is filtered as same-site.
+	got := extractExternalLinks("", body, summary)
 
 	// Normalized, deduped (a/www.a/a-again collapse), relative+mailto dropped.
 	want := map[string]bool{
@@ -30,6 +31,24 @@ func TestExtractExternalLinks(t *testing.T) {
 		if !want[g] {
 			t.Errorf("unexpected link %q", g)
 		}
+	}
+}
+
+// TestExtractExternalLinks_DropsSameHost covers the sidebar/archive pollution
+// fix: a link-blog's own navigation points back into its own host on every page,
+// so links whose host matches the article's own host are dropped, leaving only
+// the editorial outbound citations. www. is stripped on both sides first.
+func TestExtractExternalLinks_DropsSameHost(t *testing.T) {
+	body := `<p>Today's post links
+	         <a href="https://wire.example/2026/06/story">an external story</a>.
+	         Sidebar: <a href="https://newsblog.example/archive/may">May archive</a>
+	         <a href="https://www.newsblog.example/about">About</a></p>`
+
+	got := extractExternalLinks("newsblog.example", body)
+
+	want := []string{"wire.example/2026/06/story"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("got %v, want %v (same-host self-links should be dropped)", got, want)
 	}
 }
 
@@ -67,5 +86,53 @@ func TestExtractLinksForArticles_EndToEnd(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].FeedTitle != "Instapundit" {
 		t.Fatalf("expected 1 backlink from Instapundit, got %+v", got)
+	}
+}
+
+// TestExtractLinksForArticles_DropsSelfLinks is the Postgres counterpart to the
+// sidebar-pollution fix: an article's links back into its own host (the link
+// blog's nav/archive widgets, which appear on every page) are never indexed, so
+// the feed doesn't show up as linking to itself. The one genuine outbound link
+// still is. Exercises the url column threaded through the extraction query.
+func TestExtractLinksForArticles_DropsSelfLinks(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	feedID, err := store.AddFeed("https://aceofspades.example/feed", "Ace of Spades", "")
+	if err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+	if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed: %v", err)
+	}
+	if _, err := store.AddArticle(&storage.Article{
+		FeedID: feedID, GUID: "ont", Title: "The ONT",
+		URL: "https://aceofspades.example/2026/06/the-ont",
+		Content: `<p>Read this <a href="https://wire.example/crocodile-story">elsewhere</a>.</p>
+		          <aside>Recent: <a href="https://aceofspades.example/2026/06/morning-report">Morning Report</a>
+		          <a href="https://www.aceofspades.example/archive">Archive</a></aside>`,
+	}); err != nil {
+		t.Fatalf("AddArticle: %v", err)
+	}
+
+	f := NewFetcher(store)
+	if _, err := f.ExtractLinksForArticles(context.Background()); err != nil {
+		t.Fatalf("ExtractLinksForArticles: %v", err)
+	}
+
+	// The genuine outbound link is indexed.
+	if got, err := store.GetArticleBacklinks(1, 0, "wire.example/crocodile-story", 50); err != nil {
+		t.Fatalf("GetArticleBacklinks(external): %v", err)
+	} else if len(got) != 1 {
+		t.Fatalf("expected 1 backlink to the external story, got %+v", got)
+	}
+
+	// The same-host sidebar self-links are not.
+	for _, self := range []string{"aceofspades.example/2026/06/morning-report", "aceofspades.example/archive"} {
+		if got, err := store.GetArticleBacklinks(1, 0, self, 50); err != nil {
+			t.Fatalf("GetArticleBacklinks(%q): %v", self, err)
+		} else if len(got) != 0 {
+			t.Fatalf("self-link %q should not be indexed, got %+v", self, got)
+		}
 	}
 }

--- a/internal/storage/db/article_link.sql.go
+++ b/internal/storage/db/article_link.sql.go
@@ -26,7 +26,7 @@ func (q *Queries) AddArticleLink(ctx context.Context, arg AddArticleLinkParams) 
 }
 
 const getArticlesNeedingLinkExtraction = `-- name: GetArticlesNeedingLinkExtraction :many
-SELECT id, content, summary
+SELECT id, url, content, summary
 FROM articles
 WHERE links_extracted = FALSE
 ORDER BY fetched_date DESC
@@ -35,11 +35,14 @@ LIMIT $1
 
 type GetArticlesNeedingLinkExtractionRow struct {
 	ID      int64
+	Url     string
 	Content *string
 	Summary *string
 }
 
-// Articles whose outbound links haven't been parsed yet (new + backfill).
+// Articles whose outbound links haven't been parsed yet (new + backfill). url is
+// the article's own address: the extractor drops same-host links (sidebars,
+// archive widgets) so a feed doesn't flood the backlink index linking to itself.
 func (q *Queries) GetArticlesNeedingLinkExtraction(ctx context.Context, lim int32) ([]GetArticlesNeedingLinkExtractionRow, error) {
 	rows, err := q.db.Query(ctx, getArticlesNeedingLinkExtraction, lim)
 	if err != nil {
@@ -49,7 +52,12 @@ func (q *Queries) GetArticlesNeedingLinkExtraction(ctx context.Context, lim int3
 	items := []GetArticlesNeedingLinkExtractionRow{}
 	for rows.Next() {
 		var i GetArticlesNeedingLinkExtractionRow
-		if err := rows.Scan(&i.ID, &i.Content, &i.Summary); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.Url,
+			&i.Content,
+			&i.Summary,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/db/queries/article_link.sql
+++ b/internal/storage/db/queries/article_link.sql
@@ -1,6 +1,8 @@
 -- name: GetArticlesNeedingLinkExtraction :many
--- Articles whose outbound links haven't been parsed yet (new + backfill).
-SELECT id, content, summary
+-- Articles whose outbound links haven't been parsed yet (new + backfill). url is
+-- the article's own address: the extractor drops same-host links (sidebars,
+-- archive widgets) so a feed doesn't flood the backlink index linking to itself.
+SELECT id, url, content, summary
 FROM articles
 WHERE links_extracted = FALSE
 ORDER BY fetched_date DESC

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 5 {
-		t.Errorf("goose max version = %d, want 5", maxVersion)
+	if maxVersion != 6 {
+		t.Errorf("goose max version = %d, want 6", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0006_reextract_article_links.sql
+++ b/internal/storage/migrations/0006_reextract_article_links.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+--
+-- Re-extract outbound links so same-host self-links are dropped (#206 follow-up).
+-- The first pass (0005) stored every absolute <a href> in an article, including
+-- a link-blog's own sidebar / "recent posts" / archive widgets, which point back
+-- into the same site on every page. Those swamped the "linked by" lookup with
+-- one feed linking to itself. The extractor now skips links whose host matches
+-- the article's own host, so wipe the index and reset the gate to rebuild it
+-- cleanly over the daemon's extraction cycles.
+DELETE FROM article_links;
+UPDATE articles SET links_extracted = FALSE;
+
+-- +goose Down
+-- No-op: the data is regenerated from article content, not lost. Reverting the
+-- extractor logic alone (without re-running extraction) leaves the index as the
+-- new code built it, which is harmless to the old query.
+SELECT 1;

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1290,7 +1290,7 @@ func (s *PostgresStore) GetArticlesNeedingLinkExtraction(limit int) ([]ArticleLi
 	}
 	out := make([]ArticleLinkSource, len(rows))
 	for i, r := range rows {
-		src := ArticleLinkSource{ID: r.ID}
+		src := ArticleLinkSource{ID: r.ID, URL: r.Url}
 		if r.Content != nil {
 			src.Content = *r.Content
 		}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -48,9 +48,11 @@ type ArticleSummary struct {
 }
 
 // ArticleLinkSource is the raw text the link-extraction stage parses outbound
-// links from: an article's body and summary.
+// links from: an article's body and summary, plus its own URL so same-host
+// self-links (sidebars, archives) can be dropped.
 type ArticleLinkSource struct {
 	ID      int64
+	URL     string
 	Content string
 	Summary string
 }

--- a/internal/urlnorm/urlnorm.go
+++ b/internal/urlnorm/urlnorm.go
@@ -13,24 +13,43 @@ import (
 	"strings"
 )
 
+// split parses an absolute http(s) URL into its normalized host (lower-cased,
+// leading "www." removed, port preserved) and path (lower-cased, trailing slash
+// trimmed). ok is false for anything that isn't an absolute http(s) URL
+// (relative, mailto:, javascript:, host-less, ...).
+func split(raw string) (host, path string, ok bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", "", false
+	}
+	host = strings.TrimPrefix(strings.ToLower(u.Host), "www.")
+	if host == "" {
+		return "", "", false
+	}
+	return host, strings.ToLower(strings.TrimRight(u.Path, "/")), true
+}
+
 // Normalize returns the canonical index key for an absolute http(s) URL:
 // lower-cased host (leading "www." removed) + lower-cased path with any trailing
 // slash trimmed, scheme/query/fragment dropped. Returns "" for anything that
 // isn't an absolute http(s) URL (relative, mailto:, javascript:, ...), which the
 // caller should skip. Used when indexing outbound links (hrefs are absolute).
 func Normalize(raw string) string {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
+	host, path, ok := split(raw)
+	if !ok {
 		return ""
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return ""
-	}
-	host := strings.TrimPrefix(strings.ToLower(u.Host), "www.")
-	if host == "" {
-		return ""
-	}
-	return host + strings.ToLower(strings.TrimRight(u.Path, "/"))
+	return host + path
+}
+
+// Host returns the normalized host of an absolute http(s) URL: lower-cased,
+// leading "www." removed, port preserved. It is the host half of the Normalize
+// key, exposed so callers can detect same-site links (an article's outbound
+// links whose host matches the article's own host are sidebar/archive widgets,
+// not editorial citations). Returns "" for non-http(s) or host-less input.
+func Host(raw string) string {
+	host, _, _ := split(raw)
+	return host
 }
 
 // QueryKey is the lenient counterpart used for lookups: it accepts a full URL, a

--- a/internal/urlnorm/urlnorm_test.go
+++ b/internal/urlnorm/urlnorm_test.go
@@ -22,6 +22,23 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
+func TestHost(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"https://example.com/p/123", "example.com"},
+		{"http://www.Example.com/Path", "example.com"}, // www stripped, lower-cased
+		{"https://sub.example.com", "sub.example.com"}, // non-www subdomain kept
+		{"https://example.com:8080/x", "example.com:8080"},
+		{"mailto:a@b.com", ""},
+		{"/relative", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := Host(c.raw); got != c.want {
+			t.Errorf("Host(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
 func TestQueryKey(t *testing.T) {
 	cases := []struct{ raw, want string }{
 		// Full URLs normalize to the same key as Normalize.


### PR DESCRIPTION
## Problem

The "Linked by" section was polluted by a blog's own navigation. For an Ace of Spades article, all 50 "Linked by" entries were *also* Ace of Spades -- the link extractor (`extractExternalLinks`, which despite the name only dropped *relative* links) was indexing sidebar / "recent posts" / archive widgets that link back into the same host on every page. One feed swamped the results instead of the cross-feed citations the feature is for.

## Fix

Filter same-host links at **extraction time** so the index stays clean for every consumer (article view + paste-a-URL search) with no query changes:

- `urlnorm.Host()` -- new helper exposing the host half of the `Normalize` key (lowercased, `www.` stripped, port kept); `Normalize` refactored to share a `split` helper so they can't drift.
- `extractExternalLinks(selfHost, ...)` drops links whose host matches the article's own host. Empty `selfHost` (non-http article URL) disables the filter -- nothing lost when the host is unknown.
- Threaded the article's `url` through `GetArticlesNeedingLinkExtraction` -> `ArticleLinkSource` -> extractor (regenerated sqlc).
- Migration `0006` wipes `article_links` and resets `links_extracted` so the daemon rebuilds the index cleanly under the new rule.

Same-host (not same-feed) is the mechanism: it's the actual "site" concept, needs only the `url` column the article already has, and catches one site publishing multiple feeds.

## Note

Genuine editorial self-references (a post linking to the author's own earlier post on the same site) are also dropped. For a cross-feed "who linked to this" feature that's noise, so it's treated as intended.

## Testing

Ran the full suite (incl. Postgres-backed tests against a pgvector container): `go test -race ./...`, `go vet`, `golangci-lint` all clean. New coverage: `TestHost`, `TestExtractExternalLinks_DropsSameHost`, and a Postgres end-to-end `TestExtractLinksForArticles_DropsSelfLinks` modeled on the screenshot (external link indexed, two same-host sidebar links not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)