### PR TITLE
feeds: exact-match article-view backlinks; keep ?p= permalink identity

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -274,6 +274,21 @@ func (e *Engine) GetArticleBacklinks(userID, articleID int64, targetURL string) 
 	return e.store.GetArticleBacklinks(userID, articleID, needle, maxBacklinks)
 }
 
+// GetArticleBacklinksExact answers the article view's "which of the user's feeds
+// linked to THIS post?" -- the same question as GetArticleBacklinks but matched
+// exactly. The needle is built with Normalize (targetURL is a real article URL,
+// not a search fragment) and compared for equality, so a post whose normalized
+// key is just its host (a WordPress ?p= permalink, say) isn't matched by every
+// other link to the same site. Returns nil when targetURL isn't an absolute
+// http(s) URL.
+func (e *Engine) GetArticleBacklinksExact(userID, articleID int64, targetURL string) ([]storage.Backlink, error) {
+	needle := urlnorm.Normalize(targetURL)
+	if needle == "" {
+		return nil, nil
+	}
+	return e.store.GetArticleBacklinksExact(userID, articleID, needle, maxBacklinks)
+}
+
 // GetArticleSummaries batch-fetches non-empty AI summaries for the given
 // article ids, keyed by id, so a list page can render inline summaries without
 // an N+1 of GetArticleForUser. Access control is the caller's: pass ids the

--- a/internal/storage/backlink_test.go
+++ b/internal/storage/backlink_test.go
@@ -91,6 +91,55 @@ func TestGetArticleBacklinks(t *testing.T) {
 	})
 }
 
+// TestGetArticleBacklinksExact_QueryPermalinks reproduces the BattleSwarm bug:
+// two distinct WordPress ?p= posts share the host, so the substring path matched
+// every link to that host (10 unrelated "Linked by" entries). The exact path,
+// fed a full Normalize key (host+query), returns only links to the one post.
+func TestGetArticleBacklinksExact_QueryPermalinks(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		now := time.Now()
+		linkFeed, _ := store.AddFeed("https://instapundit.com/feed", "Instapundit", "")
+		if err := store.SubscribeUserToFeed(1, linkFeed); err != nil {
+			t.Fatal(err)
+		}
+		mk := func(guid string, links ...string) int64 {
+			id, err := store.AddArticle(&Article{FeedID: linkFeed, GUID: guid, Title: guid,
+				URL: "https://instapundit.com/" + guid, PublishedDate: &now})
+			if err != nil {
+				t.Fatalf("AddArticle %s: %v", guid, err)
+			}
+			if err := store.StoreArticleLinks(id, links); err != nil {
+				t.Fatalf("StoreArticleLinks %s: %v", guid, err)
+			}
+			return id
+		}
+		// Two posts on the same host, distinguished only by their ?p= id, each
+		// linked by a different Instapundit post.
+		a := mk("a", urlnorm.Normalize("https://www.battleswarmblog.com/?p=58410"))
+		mk("b", urlnorm.Normalize("https://www.battleswarmblog.com/?p=99999"))
+
+		needle := urlnorm.Normalize("https://www.battleswarmblog.com/?p=58410")
+		got, err := store.GetArticleBacklinksExact(1, 0, needle, 50)
+		if err != nil {
+			t.Fatalf("GetArticleBacklinksExact: %v", err)
+		}
+		if len(got) != 1 || got[0].ArticleID != a {
+			t.Fatalf("exact backlinks = %+v; want exactly article a(%d) that links ?p=58410", got, a)
+		}
+
+		// The lenient substring path collapses both posts to the bare host and
+		// returns both -- the over-match the article view must avoid by using the
+		// exact variant. (QueryKey strips the query, so this is the host needle.)
+		dom, err := store.GetArticleBacklinks(1, 0, "battleswarmblog.com", 50)
+		if err != nil {
+			t.Fatalf("GetArticleBacklinks (host): %v", err)
+		}
+		if len(dom) != 2 {
+			t.Fatalf("substring host match = %d; want 2 (documents the over-match exact fixes)", len(dom))
+		}
+	})
+}
+
 // TestGetArticleBacklinks_CaseInsensitivePrefix proves matching is
 // case-insensitive: a mixed-case link is found by a lower-cased prefix (the
 // form urlnorm.QueryKey always produces).

--- a/internal/storage/db/backlink.sql.go
+++ b/internal/storage/db/backlink.sql.go
@@ -80,3 +80,70 @@ func (q *Queries) GetArticleBacklinks(ctx context.Context, arg GetArticleBacklin
 	}
 	return items, nil
 }
+
+const getArticleBacklinksExact = `-- name: GetArticleBacklinksExact :many
+SELECT DISTINCT a.id, a.title, a.url,
+       COALESCE(uf.user_title, f.title) AS feed_title,
+       a.published_date, a.fetched_date
+FROM article_links al
+JOIN articles a ON a.id = al.article_id
+JOIN feeds f ON f.id = a.feed_id
+JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = $1
+WHERE al.url_norm = $2::text
+  AND a.id <> $3
+ORDER BY a.published_date DESC NULLS LAST, a.fetched_date DESC
+LIMIT $4
+`
+
+type GetArticleBacklinksExactParams struct {
+	UserID    int64
+	Needle    string
+	ExcludeID int64
+	Lim       int32
+}
+
+type GetArticleBacklinksExactRow struct {
+	ID            int64
+	Title         string
+	Url           string
+	FeedTitle     string
+	PublishedDate *time.Time
+	FetchedDate   time.Time
+}
+
+// "Which of my feeds linked to THIS exact article?" -- the article-view variant
+// of GetArticleBacklinks. Matches @needle (a full urlnorm.Normalize key) for
+// EQUALITY, not as a substring, so a post whose identity lives in the bare host
+// (e.g. a WordPress ?p= site whose key is "blog.example?p=58410") does not match
+// every other link to the same host. The target article itself is excluded.
+func (q *Queries) GetArticleBacklinksExact(ctx context.Context, arg GetArticleBacklinksExactParams) ([]GetArticleBacklinksExactRow, error) {
+	rows, err := q.db.Query(ctx, getArticleBacklinksExact,
+		arg.UserID,
+		arg.Needle,
+		arg.ExcludeID,
+		arg.Lim,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetArticleBacklinksExactRow{}
+	for rows.Next() {
+		var i GetArticleBacklinksExactRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Title,
+			&i.Url,
+			&i.FeedTitle,
+			&i.PublishedDate,
+			&i.FetchedDate,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/storage/db/queries/backlink.sql
+++ b/internal/storage/db/queries/backlink.sql
@@ -19,3 +19,21 @@ WHERE strpos(al.url_norm, @needle::text) > 0
   AND a.id <> @exclude_id
 ORDER BY a.published_date DESC NULLS LAST, a.fetched_date DESC
 LIMIT @lim;
+
+-- name: GetArticleBacklinksExact :many
+-- "Which of my feeds linked to THIS exact article?" -- the article-view variant
+-- of GetArticleBacklinks. Matches @needle (a full urlnorm.Normalize key) for
+-- EQUALITY, not as a substring, so a post whose identity lives in the bare host
+-- (e.g. a WordPress ?p= site whose key is "blog.example?p=58410") does not match
+-- every other link to the same host. The target article itself is excluded.
+SELECT DISTINCT a.id, a.title, a.url,
+       COALESCE(uf.user_title, f.title) AS feed_title,
+       a.published_date, a.fetched_date
+FROM article_links al
+JOIN articles a ON a.id = al.article_id
+JOIN feeds f ON f.id = a.feed_id
+JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = @user_id
+WHERE al.url_norm = @needle::text
+  AND a.id <> @exclude_id
+ORDER BY a.published_date DESC NULLS LAST, a.fetched_date DESC
+LIMIT @lim;

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1283,6 +1283,33 @@ func (s *PostgresStore) GetArticleBacklinks(userID, excludeID int64, needle stri
 	return out, nil
 }
 
+func (s *PostgresStore) GetArticleBacklinksExact(userID, excludeID int64, needle string, limit int) ([]Backlink, error) {
+	if needle == "" {
+		return nil, nil
+	}
+	rows, err := s.q.GetArticleBacklinksExact(context.Background(), db.GetArticleBacklinksExactParams{
+		UserID:    userID,
+		ExcludeID: excludeID,
+		Needle:    needle,
+		Lim:       int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get article backlinks (exact): %w", err)
+	}
+	out := make([]Backlink, len(rows))
+	for i, r := range rows {
+		out[i] = Backlink{
+			ArticleID:     r.ID,
+			Title:         r.Title,
+			URL:           r.Url,
+			FeedTitle:     r.FeedTitle,
+			PublishedDate: r.PublishedDate,
+			FetchedDate:   r.FetchedDate,
+		}
+	}
+	return out, nil
+}
+
 func (s *PostgresStore) GetArticlesNeedingLinkExtraction(limit int) ([]ArticleLinkSource, error) {
 	rows, err := s.q.GetArticlesNeedingLinkExtraction(context.Background(), int32(limit))
 	if err != nil {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -182,8 +182,14 @@ type Store interface {
 	// GetArticleBacklinks returns articles in the user's feeds with an extracted
 	// outbound link (article_links) whose normalized form contains needle as a
 	// substring (urlnorm.QueryKey output -- a domain, partial URL, or full URL),
-	// excluding excludeID. Answers "which of my feeds linked to this?".
+	// excluding excludeID. Powers the lenient search box ("paste a URL or
+	// domain"). Answers "which of my feeds linked to anything matching this?".
 	GetArticleBacklinks(userID, excludeID int64, needle string, limit int) ([]Backlink, error)
+	// GetArticleBacklinksExact is the article-view variant: it matches needle (a
+	// full urlnorm.Normalize key) for EQUALITY, not as a substring, so it returns
+	// only links to that exact article and a host-only key doesn't sweep in every
+	// link to the same site. Answers "which of my feeds linked to THIS post?".
+	GetArticleBacklinksExact(userID, excludeID int64, needle string, limit int) ([]Backlink, error)
 	// Outbound-link extraction (#206): GetArticlesNeedingLinkExtraction drives
 	// the stage (new + backfill), StoreArticleLinks records the normalized links
 	// parsed from an article's body/summary, MarkArticleLinksExtracted closes it.

--- a/internal/urlnorm/urlnorm.go
+++ b/internal/urlnorm/urlnorm.go
@@ -1,11 +1,17 @@
 // Package urlnorm canonicalizes URLs for link matching. Outbound links are
-// indexed with Normalize; lookups use QueryKey, which is lenient (a bare domain
-// or partial URL is fine) and yields a needle matched against the index as a
-// substring. Both lower-case host and path and drop scheme/"www."/query/
-// fragment/trailing-slash, so matching is case-insensitive and ignores session
-// params (e.g. Substack's ?r=...&triedRedirect=true). The search is a substring
-// match: "substack.com" finds links to every *.substack.com publication, and a
-// full URL finds that page.
+// indexed with Normalize. There are two lookup modes against that index:
+//
+//   - The article view ("which feeds linked to THIS post?") builds its needle
+//     with Normalize and matches it for equality, so it returns only links to
+//     that exact article.
+//   - The search box ("paste a URL or domain") builds its needle with QueryKey,
+//     which is lenient (a bare domain or partial URL is fine) and is matched as a
+//     substring, so "substack.com" finds links to every *.substack.com page.
+//
+// Both lower-case host and path and drop scheme/"www."/fragment/trailing-slash,
+// so matching is case-insensitive. Normalize drops the query too, except when
+// the path is empty (WordPress ?p= permalinks carry the article identity in the
+// query); QueryKey always drops the query, keeping the search box lenient.
 package urlnorm
 
 import (
@@ -14,32 +20,58 @@ import (
 )
 
 // split parses an absolute http(s) URL into its normalized host (lower-cased,
-// leading "www." removed, port preserved) and path (lower-cased, trailing slash
-// trimmed). ok is false for anything that isn't an absolute http(s) URL
+// leading "www." removed, port preserved), path (lower-cased, trailing slash
+// trimmed), and query. The query is "" unless the path is empty, in which case
+// the canonicalized query is kept with a leading "?": some sites put the whole
+// article identity in the query (WordPress's default permalinks, e.g.
+// battleswarmblog.com/?p=58410), so dropping it would collapse every post to the
+// bare host and make distinct articles indistinguishable. When there IS a path,
+// the query is almost always tracking/session junk (Substack's
+// ?r=...&triedRedirect=true) and is dropped so a canonical URL matches its
+// tracked variants. ok is false for anything that isn't an absolute http(s) URL
 // (relative, mailto:, javascript:, host-less, ...).
-func split(raw string) (host, path string, ok bool) {
+func split(raw string) (host, path, query string, ok bool) {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		return "", "", false
+		return "", "", "", false
 	}
 	host = strings.TrimPrefix(strings.ToLower(u.Host), "www.")
 	if host == "" {
-		return "", "", false
+		return "", "", "", false
 	}
-	return host, strings.ToLower(strings.TrimRight(u.Path, "/")), true
+	path = strings.ToLower(strings.TrimRight(u.Path, "/"))
+	if path == "" && u.RawQuery != "" {
+		if q := canonicalQuery(u.RawQuery); q != "" {
+			query = "?" + q
+		}
+	}
+	return host, path, query, true
+}
+
+// canonicalQuery sorts and lower-cases a raw query string so that param order
+// and case don't yield different keys (?b=2&a=1 == ?a=1&b=2). Returns "" for an
+// unparseable or empty query.
+func canonicalQuery(raw string) string {
+	v, err := url.ParseQuery(raw)
+	if err != nil || len(v) == 0 {
+		return ""
+	}
+	return strings.ToLower(v.Encode())
 }
 
 // Normalize returns the canonical index key for an absolute http(s) URL:
 // lower-cased host (leading "www." removed) + lower-cased path with any trailing
-// slash trimmed, scheme/query/fragment dropped. Returns "" for anything that
-// isn't an absolute http(s) URL (relative, mailto:, javascript:, ...), which the
-// caller should skip. Used when indexing outbound links (hrefs are absolute).
+// slash trimmed, scheme/fragment dropped. The query is dropped too EXCEPT when
+// the path is empty, in which case the canonicalized query is kept (see split).
+// Returns "" for anything that isn't an absolute http(s) URL (relative, mailto:,
+// javascript:, ...), which the caller should skip. Used when indexing outbound
+// links (hrefs are absolute).
 func Normalize(raw string) string {
-	host, path, ok := split(raw)
+	host, path, query, ok := split(raw)
 	if !ok {
 		return ""
 	}
-	return host + path
+	return host + path + query
 }
 
 // Host returns the normalized host of an absolute http(s) URL: lower-cased,
@@ -48,7 +80,7 @@ func Normalize(raw string) string {
 // links whose host matches the article's own host are sidebar/archive widgets,
 // not editorial citations). Returns "" for non-http(s) or host-less input.
 func Host(raw string) string {
-	host, _, _ := split(raw)
+	host, _, _, _ := split(raw)
 	return host
 }
 
@@ -58,7 +90,8 @@ func Host(raw string) string {
 // input doesn't begin with a host-like token (no dot before the first slash, or
 // it contains whitespace) -- the caller treats that as "not a link search" and
 // falls back to full-text search. The result is lower-cased and stripped the
-// same way Normalize strips, so a full URL produces the same key either way.
+// same way Normalize strips a path-bearing URL (the query is dropped), so the
+// search box stays lenient even when Normalize would keep a path-empty query.
 func QueryKey(raw string) string {
 	s := strings.ToLower(strings.TrimSpace(raw))
 	if s == "" || strings.ContainsAny(s, " \t\r\n") {

--- a/internal/urlnorm/urlnorm_test.go
+++ b/internal/urlnorm/urlnorm_test.go
@@ -5,11 +5,18 @@ import "testing"
 func TestNormalize(t *testing.T) {
 	cases := []struct{ raw, want string }{
 		{"https://hollymathnerd.substack.com/p/the-government-sets-the-trap", "hollymathnerd.substack.com/p/the-government-sets-the-trap"},
-		{"https://hollymathnerd.substack.com/p/the-government-sets-the-trap?r=wm1qp&triedRedirect=true", "hollymathnerd.substack.com/p/the-government-sets-the-trap"},
+		{"https://hollymathnerd.substack.com/p/the-government-sets-the-trap?r=wm1qp&triedRedirect=true", "hollymathnerd.substack.com/p/the-government-sets-the-trap"}, // path present -> query (tracking) dropped
 		{"http://www.hollymathnerd.substack.com/p/the-government-sets-the-trap/", "hollymathnerd.substack.com/p/the-government-sets-the-trap"},
 		{"https://EXAMPLE.com/Path#section", "example.com/path"}, // host AND path lower-cased, fragment dropped
 		{"https://example.com", "example.com"},
 		{"https://example.com/", "example.com"},
+		// Path-empty query carries article identity (WordPress ?p= permalinks):
+		// kept so distinct posts get distinct keys instead of collapsing to host.
+		{"https://www.battleswarmblog.com/?p=58410", "battleswarmblog.com?p=58410"},
+		{"https://battleswarmblog.com/?p=58410", "battleswarmblog.com?p=58410"},
+		{"https://battleswarmblog.com/?p=99999", "battleswarmblog.com?p=99999"}, // distinct from 58410
+		{"https://example.com/?b=2&a=1", "example.com?a=1&b=2"},                 // kept query is sorted+lower-cased
+		{"https://example.com/article?utm_source=x", "example.com/article"},     // path present -> tracking query still dropped
 		{"mailto:a@b.com", ""},
 		{"javascript:void(0)", ""},
 		{"/relative/path", ""},

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -881,8 +881,10 @@ func (h *handlers) handleArticleView(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// "Linked by": other feeds whose link-blog posts point at this article.
-	if links, err := h.engine.GetArticleBacklinks(uid, article.ID, article.URL); err != nil {
+	// "Linked by": other feeds whose link-blog posts point at this exact article.
+	// Exact (not substring) match so sites that carry their article id in the
+	// query (e.g. WordPress ?p= permalinks) don't match every link to the host.
+	if links, err := h.engine.GetArticleBacklinksExact(uid, article.ID, article.URL); err != nil {
 		log.Printf("herald-web: backlinks for article %d: %v", article.ID, err)
 	} else {
 		for _, b := range links {


### PR DESCRIPTION
## Problem

The article-view "Linked by" section over-matched: viewing a BattleSwarm post showed ten unrelated Instapundit links. Two compounding causes:

1. `urlnorm.Normalize` dropped the query string, so WordPress default-permalink posts (`battleswarmblog.com/?p=58410`) -- whose identity lives only in the query -- all collapsed to the bare host.
2. The article view reused the search box's lenient **substring** lookup (`strpos`), so a host-only needle matched every link to that site.

## Fix

- **`urlnorm`**: keep the query when the path is empty (sorted + lower-cased); keep dropping it when a path is present (Substack's `?r=...&triedRedirect=true` tracking junk). Distinct `?p=` posts now get distinct keys. Folded into `split()` so `Normalize` and `Host` share it.
- **Exact lookup**: new `GetArticleBacklinksExact` (`url_norm = needle`) + engine wrapper that builds the needle with `Normalize` (not `QueryKey`); the article view uses it. The search box keeps its substring behavior.

## Tests

- `urlnorm`: `?p=` preservation, path-present tracker drop, query sorting.
- `storage`: regression test -- two `?p=` posts on one host linked by different articles; exact returns only the right one, and documents that the substring path returned both.

Full suite green against Postgres (pgvector). No sqlc drift.

## Note

The fix removes the wrong entries at deploy with no migration (stale host-only index rows can't satisfy an exact host+query needle). Recovering legitimately-missing `?p=` backlinks on already-indexed content needs a one-time re-extraction (`DELETE FROM article_links; UPDATE articles SET links_extracted = FALSE;`) -- optional, low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)