### PR TITLE
web: public landing/marketing page at /

### DIFF
--- a/internal/web/degraded_test.go
+++ b/internal/web/degraded_test.go
@@ -40,7 +40,10 @@ func TestRouterDegradesWhileIdPUnreachable(t *testing.T) {
 		want         int
 	}{
 		{"GET", "/health", http.StatusOK},
-		{"GET", "/", http.StatusServiceUnavailable},
+		// The public landing page is static and must stay up through an IdP
+		// outage; only sign-in itself (/login) and the authed app degrade.
+		{"GET", "/", http.StatusOK},
+		{"GET", "/login", http.StatusServiceUnavailable},
 		{"GET", "/articles", http.StatusServiceUnavailable},
 		{"GET", "/auth/callback?code=x&state=y", http.StatusServiceUnavailable},
 	}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -28,13 +29,14 @@ import (
 
 // handlers holds dependencies for all HTTP handler methods.
 type handlers struct {
-	engine     *herald.Engine
-	validator  *oidclient.Client
-	sessions   *session.Manager              // server-side OIDC session lifecycle (#173)
-	pages      map[string]*template.Template // per-page template sets
-	pagesOnce  sync.Once                     // guards lazy template parsing
-	adminRole  string                        // JWT role value that grants admin access (default: "admin")
-	adminUsers []string                      // fallback email list when the IdP does not issue role claims
+	engine      *herald.Engine
+	validator   *oidclient.Client
+	sessions    *session.Manager              // server-side OIDC session lifecycle (#173)
+	pages       map[string]*template.Template // per-page (authenticated) template sets
+	publicPages map[string]*template.Template // unauthenticated pages (landing); base_public.html layout
+	pagesOnce   sync.Once                     // guards lazy template parsing
+	adminRole   string                        // JWT role value that grants admin access (default: "admin")
+	adminUsers  []string                      // fallback email list when the IdP does not issue role claims
 }
 
 // isAdminCtx reports whether the request context carries admin privileges.
@@ -188,8 +190,36 @@ func (h *handlers) parseTemplates() {
 		t := template.Must(template.New("").Funcs(funcMap).ParseFS(tmplFS, files...))
 		built[page] = t
 	}
+
+	// Public (unauthenticated) pages use a standalone layout with no app nav,
+	// search box, or htmx -- so they share none of the app partials above.
+	publicPages := []string{"landing.html"}
+	builtPublic := make(map[string]*template.Template, len(publicPages))
+	for _, page := range publicPages {
+		t := template.Must(template.New("").Funcs(funcMap).ParseFS(tmplFS, "base_public.html", page))
+		builtPublic[page] = t
+	}
+
 	// Publish only once fully built so no reader sees a partial map.
 	h.pages = built
+	h.publicPages = builtPublic
+}
+
+// renderPublicPage renders an unauthenticated full page using the base_public.html
+// layout. Unlike renderPage it never falls back to an htmx fragment -- public
+// pages are plain document loads.
+func (h *handlers) renderPublicPage(w http.ResponseWriter, name string, data any) {
+	h.init()
+	t, ok := h.publicPages[name]
+	if !ok {
+		log.Printf("herald-web: unknown public page template: %s", name)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := t.ExecuteTemplate(w, "base_public.html", data); err != nil {
+		log.Printf("herald-web: template error: %v", err)
+	}
 }
 
 // --- Template data types ---
@@ -474,6 +504,65 @@ func (h *handlers) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// it lapses at webauth on its own TTL.
 	h.sessions.Destroy(w, r)
 	http.Redirect(w, r, h.validator.LogoutURL(), http.StatusFound)
+}
+
+// handleRoot is the public front door at "/". Logged-in visitors get their
+// reader (handleHome); everyone else gets the marketing landing page. Unlike the
+// auth-wrapped app routes, it never triggers the OIDC redirect -- an anonymous
+// visit to the landing page must show the pitch, not bounce to the IdP.
+func (h *handlers) handleRoot(w http.ResponseWriter, r *http.Request) {
+	// No session manager (e.g. the manifest-only router) -> treat as anonymous.
+	if h.sessions == nil {
+		h.renderPublicPage(w, "landing.html", nil)
+		return
+	}
+	claims, err := h.sessions.Authenticate(r)
+	if err != nil {
+		// ErrNoSession is the normal anonymous case; log anything else so a real
+		// fault is diagnosable, but serve the public page either way -- we never
+		// render app content without a valid session.
+		if !errors.Is(err, session.ErrNoSession) {
+			log.Printf("herald-web: root authenticate: %v", err)
+		}
+		h.renderPublicPage(w, "landing.html", nil)
+		return
+	}
+	user, err := h.engine.GetOrProvisionOIDCUser(claims.Sub, claims.Name, claims.Email)
+	if err != nil {
+		log.Printf("herald-web: provision user: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	ctx := withClaims(withUser(r.Context(), user), claims)
+	h.handleHome(w, r.WithContext(ctx))
+}
+
+// handleLogin initiates the OIDC sign-in flow from the landing-page CTA and
+// redirects to the IdP. Sign-up and sign-in are one flow: a first-time user is
+// provisioned automatically on the post-callback request (see requireAuth). The
+// post-login destination defaults to "/" (the reader, once authenticated); an
+// optional return_to is accepted only if it is a same-origin relative path.
+func (h *handlers) handleLogin(w http.ResponseWriter, r *http.Request) {
+	returnTo := "/"
+	if rt := localPath(r.URL.Query().Get("return_to")); rt != "" {
+		returnTo = rt
+	}
+	if h.validator == nil || !h.validator.Ready() {
+		http.Error(w, "sign-in temporarily unavailable -- please try again shortly", http.StatusServiceUnavailable)
+		return
+	}
+	var loginURL string
+	if h.validator.FlowConfigured() {
+		state, verifier, err := oidclient.GetOrCreateFlow(w, r, returnTo)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		loginURL = h.validator.AuthorizeURL(state, verifier)
+	} else {
+		loginURL = h.validator.LoginURL(returnTo)
+	}
+	http.Redirect(w, r, loginURL, http.StatusFound)
 }
 
 func (h *handlers) handleHome(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -412,17 +412,26 @@ func authedRequestForm(t *testing.T, tf *testFixtures, method, path string, form
 
 // --- Auth tests ---
 
-func TestHandleRoot_UnauthenticatedRedirectsToWebauth(t *testing.T) {
+func TestHandleRoot_UnauthenticatedServesLanding(t *testing.T) {
 	tf := newTestFixtures(t)
 
-	// No JWT cookie → should redirect to webauth login.
+	// No JWT cookie → the public landing page, served in place (not a redirect to
+	// the IdP). This is the "accessible without logging in" guarantee.
 	rr := request(t, tf.router, "GET", "/", nil)
-	if rr.Code != http.StatusFound {
-		t.Errorf("status: got %d, want %d", rr.Code, http.StatusFound)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d (landing must not redirect anonymous visitors)", rr.Code, http.StatusOK)
 	}
-	loc := rr.Header().Get("Location")
-	if loc == "" {
-		t.Error("expected Location header for unauthenticated redirect")
+	body := rr.Body.String()
+	if !strings.Contains(body, "Read the news without reading the attacks") {
+		t.Error("landing page should contain the hero headline")
+	}
+	if !strings.Contains(body, `href="/login"`) {
+		t.Error("landing page should link to the /login sign-in CTA")
+	}
+	// The public layout must not carry app chrome (the reader's search box posts
+	// to an authenticated route); its absence proves base_public.html was used.
+	if strings.Contains(body, "nav-search") {
+		t.Error("landing page should not render the app search box")
 	}
 }
 
@@ -488,12 +497,17 @@ func TestHandleHome(t *testing.T) {
 	}
 }
 
-func TestHandleHome_Unauthenticated(t *testing.T) {
+func TestHandleLogin_RedirectsToIdP(t *testing.T) {
 	tf := newTestFixtures(t)
 
-	rr := request(t, tf.router, "GET", "/", nil)
+	// The landing-page CTA initiates the OIDC flow: /login always redirects to
+	// the IdP (the redirect that used to live on an unauthenticated "/").
+	rr := request(t, tf.router, "GET", "/login", nil)
 	if rr.Code != http.StatusFound {
-		t.Errorf("status: got %d, want %d", rr.Code, http.StatusFound)
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusFound)
+	}
+	if loc := rr.Header().Get("Location"); loc == "" {
+		t.Error("expected a Location header pointing at the IdP login URL")
 	}
 }
 

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -18,8 +18,10 @@ func TestRequireAuth_ReusesExistingFlow(t *testing.T) {
 	validator := newTestValidatorWithOIDC(t, nil)
 	router := NewRouter(tf.engine, validator, "", nil)
 
-	// First unauthenticated request starts a flow.
-	req1 := httptest.NewRequest("GET", "/", nil)
+	// First unauthenticated request to an auth-wrapped route starts a flow.
+	// ("/" is now the public landing page; use a protected route to drive
+	// requireAuth, which is what this test covers.)
+	req1 := httptest.NewRequest("GET", "/feeds", nil)
 	rr1 := httptest.NewRecorder()
 	router.ServeHTTP(rr1, req1)
 
@@ -46,7 +48,7 @@ func TestRequireAuth_ReusesExistingFlow(t *testing.T) {
 
 	// Second request carrying those cookies must redirect with the same state
 	// and leave the flow cookies alone.
-	req2 := httptest.NewRequest("GET", "/", nil)
+	req2 := httptest.NewRequest("GET", "/feeds", nil)
 	for _, c := range flowCookies {
 		req2.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
 	}

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -97,8 +97,16 @@ func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.HandleFunc("GET /auth/logout", h.handleLogout,
 		smoke.Skip("destructive: deletes the caller's server-side session"))
 
+	// Public front door: the marketing landing page for anonymous visitors, the
+	// reader for authenticated ones. No auth wrapper -- handleRoot decides.
+	mux.HandleFunc("GET /{$}", h.handleRoot)
+
+	// Sign-in CTA from the landing page; initiates the OIDC flow (sign-up and
+	// sign-in are the same flow -- first-time users are provisioned on callback).
+	mux.HandleFunc("GET /login", h.handleLogin,
+		smoke.Skip("initiates an OIDC authorize redirect to the external IdP"))
+
 	// Full-page routes.
-	mux.Handle("GET /{$}", auth(http.HandlerFunc(h.handleHome)))
 	mux.Handle("GET /feeds", auth(http.HandlerFunc(h.handleFeedsManage)))
 	mux.Handle("GET /settings", auth(http.HandlerFunc(h.handleSettings)))
 	mux.Handle("GET /settings/sync", auth(http.HandlerFunc(h.handleSettingsSync)))

--- a/internal/web/smoke-manifest.json
+++ b/internal/web/smoke-manifest.json
@@ -344,6 +344,13 @@
     },
     {
       "method": "GET",
+      "pattern": "/login",
+      "effect": "read_only",
+      "skip": "initiates an OIDC authorize redirect to the external IdP",
+      "complete": true
+    },
+    {
+      "method": "GET",
       "pattern": "/newsletters",
       "effect": "read_only",
       "complete": true

--- a/internal/web/static/landing.css
+++ b/internal/web/static/landing.css
@@ -1,0 +1,247 @@
+/* landing.css -- styles for the public, unauthenticated landing page.
+   Loaded only by base_public.html, so it never touches the app reader.
+   Built on Pico's CSS custom properties so light/dark themes both work. */
+
+body.public {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* --- Public nav --- */
+.public-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem clamp(1rem, 5vw, 3rem);
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.public-nav nav {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.public-brand {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    text-decoration: none;
+    color: var(--pico-color);
+}
+
+.public-nav-link {
+    text-decoration: none;
+    color: var(--pico-muted-color);
+}
+
+.public-nav-link:hover {
+    color: var(--pico-color);
+}
+
+.public-signin {
+    padding: 0.35rem 1rem;
+    margin: 0;
+    white-space: nowrap;
+}
+
+.public-nav .theme-toggle {
+    padding: 0.35rem 0.6rem;
+    margin: 0;
+}
+
+/* --- Layout shell --- */
+.landing {
+    flex: 1;
+    width: 100%;
+    max-width: 60rem;
+    margin: 0 auto;
+    padding: 0 clamp(1rem, 5vw, 3rem);
+}
+
+.landing section {
+    padding: clamp(2.5rem, 7vw, 5rem) 0;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.landing section:last-child {
+    border-bottom: none;
+}
+
+/* --- Hero --- */
+.hero {
+    text-align: center;
+}
+
+.hero h1 {
+    font-size: clamp(2rem, 6vw, 3.25rem);
+    line-height: 1.1;
+    letter-spacing: -0.03em;
+    margin-bottom: 1rem;
+}
+
+.hero-sub {
+    font-size: clamp(1.05rem, 2.5vw, 1.3rem);
+    color: var(--pico-muted-color);
+    max-width: 42rem;
+    margin: 0 auto 2rem;
+}
+
+.hero-sub em {
+    color: var(--pico-color);
+    font-style: italic;
+}
+
+.hero-cta {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.hero-cta [role="button"] {
+    margin: 0;
+}
+
+.hero-note {
+    margin-top: 1.25rem;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+}
+
+/* --- Pillars --- */
+.pillars {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.pillar {
+    margin: 0;
+    padding: 1.5rem;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+}
+
+.pillar h2 {
+    font-size: 1.15rem;
+    margin-bottom: 0.5rem;
+}
+
+.pillar p {
+    margin: 0;
+    color: var(--pico-muted-color);
+    font-size: 0.95rem;
+}
+
+/* --- How it works --- */
+.how-steps {
+    list-style: none;
+    counter-reset: step;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.how-steps li {
+    counter-increment: step;
+    position: relative;
+    padding-left: 3rem;
+    color: var(--pico-muted-color);
+}
+
+.how-steps li::before {
+    content: counter(step);
+    position: absolute;
+    left: 0;
+    top: -0.15rem;
+    width: 2rem;
+    height: 2rem;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    font-weight: 700;
+    color: var(--pico-primary-inverse);
+    background: var(--pico-primary);
+}
+
+.how-steps li strong {
+    color: var(--pico-color);
+}
+
+/* --- Why / prose sections --- */
+.why p,
+.closing p {
+    color: var(--pico-muted-color);
+    max-width: 44rem;
+}
+
+.why em {
+    color: var(--pico-color);
+    font-style: italic;
+}
+
+/* --- Features --- */
+.feature-grid {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.6rem 1.5rem;
+}
+
+.feature-grid li {
+    position: relative;
+    padding-left: 1.6rem;
+    color: var(--pico-muted-color);
+}
+
+.feature-grid li::before {
+    content: "+";
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+    color: var(--pico-primary);
+}
+
+/* --- Closing CTA --- */
+.closing {
+    text-align: center;
+}
+
+.closing [role="button"] {
+    margin-top: 0.5rem;
+}
+
+/* --- Footer --- */
+.public-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 1.5rem clamp(1rem, 5vw, 3rem);
+    border-top: 1px solid var(--pico-muted-border-color);
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+}
+
+.public-footer a {
+    color: var(--pico-muted-color);
+}
+
+/* --- Responsive --- */
+@media (max-width: 48rem) {
+    .pillars {
+        grid-template-columns: 1fr;
+    }
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/internal/web/templates/base_public.html
+++ b/internal/web/templates/base_public.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="auto">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{block "title" .}}Herald{{end}}</title>
+    <meta name="description" content="{{block "description" .}}Herald is a self-hosted, AI-powered feed reader that screens every article for prompt injection before it is curated, then ranks stories by your interests -- not an engagement algorithm.{{end}}">
+    <link rel="stylesheet" href="/static/pico.min.css?v={{assetVersion}}" integrity="sha384-L1dWfspMTHU/ApYnFiMz2QID/PlP1xCW9visvBdbEkOLkSSWsP6ZJWhPw6apiXxU" crossorigin="anonymous">
+    <link rel="stylesheet" href="/static/herald.css?v={{assetVersion}}">
+    <link rel="stylesheet" href="/static/landing.css?v={{assetVersion}}">
+    <script>
+        (function() {
+            var t = localStorage.getItem('herald-theme');
+            if (t) document.documentElement.setAttribute('data-theme', t);
+        })();
+    </script>
+</head>
+<body class="public">
+    <header class="public-nav">
+        <a class="public-brand" href="/">Herald</a>
+        <nav>
+            <a class="public-nav-link" href="https://github.com/matthewjhunter/herald" rel="noopener">Source</a>
+            <a class="public-signin contrast" href="/login" role="button">Sign in</a>
+            <button id="theme-toggle" class="theme-toggle outline" type="button" aria-label="Toggle theme">&#9728;</button>
+        </nav>
+    </header>
+    {{block "content" .}}{{end}}
+    <footer class="public-footer">
+        <span>Herald &middot; Apache-2.0 &middot; self-hosted</span>
+        <a href="https://github.com/matthewjhunter/herald" rel="noopener">github.com/matthewjhunter/herald</a>
+    </footer>
+    <script>
+        (function() {
+            var btn = document.getElementById('theme-toggle');
+            if (!btn) return;
+            btn.addEventListener('click', function() {
+                var cur = document.documentElement.getAttribute('data-theme');
+                var next = cur === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                localStorage.setItem('herald-theme', next);
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/internal/web/templates/landing.html
+++ b/internal/web/templates/landing.html
@@ -1,0 +1,100 @@
+{{define "title"}}Herald -- a feed reader that screens before it curates{{end}}
+{{define "content"}}
+<main class="landing">
+
+  <section class="hero">
+    <h1>Read the news without reading the attacks.</h1>
+    <p class="hero-sub">
+      Herald is a self-hosted, AI-powered feed reader. It screens every article
+      for prompt injection and adversarial manipulation <em>before</em> anything
+      curates it, then ranks what is left by your interests -- not by an
+      engagement algorithm.
+    </p>
+    <div class="hero-cta">
+      <a class="contrast" href="/login" role="button">Create your account</a>
+      <a class="outline" href="#how" role="button">See how it works</a>
+    </div>
+    <p class="hero-note">Free account. Bring your own OPML. Read on the web or sync to your existing RSS client.</p>
+  </section>
+
+  <section class="pillars">
+    <article class="pillar">
+      <h2>Screened first</h2>
+      <p>
+        Feeds are untrusted input. A dedicated security model inspects every
+        article for prompt injection and content engineered to manipulate
+        downstream AI -- and it is deliberately conservative: when in doubt, it
+        flags. Anything that fails is recorded with its reasoning and kept out
+        of curation entirely.
+      </p>
+    </article>
+    <article class="pillar">
+      <h2>Curated, not steered</h2>
+      <p>
+        A separate model scores what survives screening against <em>your</em>
+        keywords and thresholds. It judges relevance, not category, so nothing
+        is buried for being off-trend or boosted for being divisive. You set the
+        bar; Herald ranks to it.
+      </p>
+    </article>
+    <article class="pillar">
+      <h2>Stories, not duplicates</h2>
+      <p>
+        The same event from a dozen sources collapses into one cluster. Herald
+        groups related articles across feeds with vector embeddings, so you read
+        the story once instead of scrolling past ten copies of it.
+      </p>
+    </article>
+  </section>
+
+  <section id="how" class="how">
+    <h2>How it works</h2>
+    <ol class="how-steps">
+      <li><strong>Subscribe.</strong> Import your existing subscriptions from OPML, or add feeds one at a time. RSS and Atom both work.</li>
+      <li><strong>Screen.</strong> Each fetched article is checked for manipulation before it goes any further. Unsafe content is quarantined, not curated.</li>
+      <li><strong>Score.</strong> Cleared articles are ranked against your interest keywords and a threshold you control.</li>
+      <li><strong>Cluster.</strong> Related coverage is grouped across sources so you see one story, not ten.</li>
+      <li><strong>Read anywhere.</strong> Browse in the web reader, or sync via OPML and the Fever API into the RSS client you already use.</li>
+    </ol>
+  </section>
+
+  <section class="why">
+    <h2>Why two models instead of one</h2>
+    <p>
+      Most AI news tools either skip security -- leaving them open to poisoned
+      feeds -- or fold safety and editorial judgment into a single model, where
+      the two fight each other. A safety-trained model curates defensively and
+      buries anything it finds sensitive; a relevance-tuned model has no
+      defenses at all.
+    </p>
+    <p>
+      Herald splits the jobs at the architecture level. One model is responsible
+      only for whether content is <em>safe</em>. A different one is responsible
+      only for whether it is <em>interesting to you</em>. Neither has to
+      compromise, so you get real protection and neutral ranking at the same
+      time.
+    </p>
+  </section>
+
+  <section class="features">
+    <h2>What you get</h2>
+    <ul class="feature-grid">
+      <li>Prompt-injection screening on every article</li>
+      <li>Neutral interest scoring with your own keywords and thresholds</li>
+      <li>Cross-source clustering of related stories</li>
+      <li>OPML import and export</li>
+      <li>Sync to existing RSS clients (OPML URL + Fever API)</li>
+      <li>Per-article summaries</li>
+      <li>Filter rules by author, category, or tag</li>
+      <li>Per-account feeds, preferences, and read state</li>
+    </ul>
+  </section>
+
+  <section class="closing">
+    <h2>Start reading on your terms.</h2>
+    <p>Sign in to create your account -- it takes a few seconds and your feeds are private to you.</p>
+    <a class="contrast" href="/login" role="button">Create your account</a>
+  </section>
+
+</main>
+{{end}}


### PR DESCRIPTION
## What

A public, no-login landing page that describes Herald and drives account sign-up. It **takes over `/`**: anonymous visitors get the marketing page, authenticated visitors get their reader.

## Page

- `templates/landing.html` -- hero, three pillars (screened-first / curated-not-steered / stories-not-duplicates), a "how it works" walkthrough, "why two models", a feature grid, and sign-up CTAs.
- `templates/base_public.html` -- standalone public layout: wordmark, Source link, **Sign in** button, theme toggle, footer. No app nav, search box, or htmx.
- `static/landing.css` -- built on Pico's theme variables (light/dark both work), responsive.
- Copy is **model-agnostic** by request -- specific model names rotate too fast for marketing material.

## Routing

- `GET /` -> public `handleRoot`: landing page for anonymous, reader for authenticated. Never bounces anonymous visitors to the IdP.
- `GET /login` -> new public CTA target that starts the OIDC flow (sign-up and sign-in are one flow; first-time users are provisioned on callback). `return_to` accepted only as a same-origin relative path.

## Behavior change

The landing page is static, so `/` now stays up through an IdP outage; only `/login` and the authed app degrade to 503. Tests updated accordingly: the IdP-redirect assertion moved from `/` to `/login`, `requireAuth`'s flow-reuse test drives `/feeds`, and the degraded-IdP test expects `/` = 200.

## Tests

New `TestHandleRoot_UnauthenticatedServesLanding` and `TestHandleLogin_RedirectsToIdP`. Smoke manifest regenerated (`/login` added, skipped like the other auth-redirect routes). Full suite green; gofmt/vet clean. Rendered HTML verified (all sections, all three stylesheets, three CTAs, zero app chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)