### PR TITLE
Add optional Umami analytics on the public landing page

### DIFF
--- a/cmd/herald/serve.go
+++ b/cmd/herald/serve.go
@@ -97,7 +97,10 @@ user sessions, article browsing, admin, Fever API, etc.`,
 			}
 			defer engine.Close()
 
-			mux := web.NewRouter(engine, validator, cfg.Web.Admin.Role, cfg.Web.Admin.Users)
+			mux := web.NewRouter(engine, validator, cfg.Web.Admin.Role, cfg.Web.Admin.Users, web.AnalyticsConfig{
+				UmamiSrc:  cfg.Web.Analytics.UmamiSrc,
+				WebsiteID: cfg.Web.Analytics.WebsiteID,
+			})
 
 			// Sweep expired sessions hourly for the lifetime of the server (#173).
 			sweepCtx, stopSweep := context.WithCancel(context.Background())

--- a/config/config.docker.toml
+++ b/config/config.docker.toml
@@ -40,3 +40,9 @@ addr = ":8080"
 # [web.admin]
 # role = "admin"
 # users = ["dev@example.com"]
+#
+# Optional public-landing-page analytics (off by default). Point at your own
+# Umami instance; both keys required. See docs/analytics.md.
+# [web.analytics]
+# umami_src  = "https://umami.example.com/script.js"
+# website_id = "00000000-0000-0000-0000-000000000000"

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -91,3 +91,11 @@ cookie = "infodancer_jwt"
 [web.admin]
 role = "admin"
 # users = ["admin@example.com"]  # fallback when no role claim
+
+# Optional, privacy-respecting analytics on the PUBLIC LANDING PAGE only (never
+# the authenticated reader). Omit this section entirely for zero tracking (the
+# default). Point it at your own Umami instance -- nothing is sent to the Herald
+# project. Both keys are required to enable it. See docs/analytics.md.
+# [web.analytics]
+# umami_src  = "https://umami.example.com/script.js"  # full tracker script URL
+# website_id = "00000000-0000-0000-0000-000000000000" # Umami site UUID

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,95 @@
+# Analytics
+
+Herald ships with **no analytics and no tracking of any kind**. Nothing is sent
+anywhere by default -- not to the Herald project, not to any third party. This is
+the correct setting for a private, self-hosted install and you never have to
+touch it.
+
+If you run a public-facing instance and want to know how many people find your
+landing page, Herald can optionally load a single [Umami](https://umami.is/)
+tracker script. Umami is open source, self-hostable, cookieless, and does not
+collect personal data -- which is why it is the only integration Herald supports.
+You point it at **your own** Umami server; Herald has no hosted analytics and no
+default endpoint.
+
+## What is (and is not) tracked
+
+- **Only the public landing page** (`/`, shown to anonymous visitors) is ever
+  instrumented. That is the acquisition surface -- "did anyone discover Herald" --
+  and it contains no private data.
+- **The authenticated reader is never tracked.** Once a visitor signs in, every
+  page they see is served under Herald's strict Content-Security-Policy with no
+  analytics script and no off-origin connections. Your feeds, article IDs, search
+  queries, and read state never reach an analytics host. This boundary is
+  structural: the tracker snippet lives only in the public page layout
+  (`base_public.html`), and the CSP is only widened on public-page responses.
+
+## Enabling it
+
+Add a `[web.analytics]` section to your config. **Both** keys are required; if
+either is missing or the URL is malformed, analytics stays off and Herald logs a
+one-line warning at startup rather than failing to boot.
+
+```toml
+[web.analytics]
+# Full URL of the Umami tracker script served by YOUR Umami instance.
+umami_src  = "https://umami.example.com/script.js"
+# The website UUID Umami assigns when you add a site (its data-website-id).
+website_id = "00000000-0000-0000-0000-000000000000"
+```
+
+To get these values:
+
+1. Stand up Umami (Docker image, `ghcr.io/umami-software/umami`) behind TLS.
+2. In the Umami dashboard, **Settings -> Websites -> Add website**. Use your
+   Herald landing page's public hostname as the domain.
+3. Copy the **website ID** (a UUID) into `website_id`.
+4. Your `umami_src` is your Umami base URL plus `/script.js`.
+
+Restart `herald serve`. The landing page will now include, in its `<head>`:
+
+```html
+<script defer src="https://umami.example.com/script.js"
+        data-website-id="00000000-0000-0000-0000-000000000000"></script>
+```
+
+To turn analytics back off, delete the `[web.analytics]` section (or blank either
+key) and restart. There is no other state to clean up.
+
+## Security model
+
+Herald serves a deliberately strict Content-Security-Policy: `default-src
+'self'`, no off-origin scripts, no off-origin connections. Loading an external
+tracker would normally be blocked by that policy -- correctly.
+
+When (and only when) analytics is enabled, Herald relaxes the CSP **for
+public-page responses only**, and by the minimum needed:
+
+- the tracker's origin (scheme + host, e.g. `https://umami.example.com` -- never
+  the full URL, never a wildcard) is added to `script-src`, so the browser will
+  load the script;
+- the same origin is added to `connect-src`, so the script may POST pageview
+  events back to your Umami server;
+- nothing else changes, and the origin appears in no other directive.
+
+The authenticated app's CSP is byte-for-byte identical whether or not analytics
+is configured. The origin is parsed and validated once at startup, so a
+malformed value can never inject into the header, and a bad setting degrades to
+"analytics off" instead of taking the reader down.
+
+## Why only Umami, and why client-side
+
+- **Umami**, because it is privacy-respecting by design (no cookies, no
+  cross-site identifiers, aggregate-only) and self-hostable, so you are not
+  handing your visitors to a third-party ad-tech network to answer a simple
+  question.
+- **Client-side** (a script the browser runs), rather than server-side log
+  parsing, because the goal is counting *human discovery*. A script that only
+  runs in real browsers filters out the bots and crawlers that dominate raw
+  request logs, and because it lives solely in the public page template it is
+  inherently scoped to exactly the page you want measured -- no request-path
+  filtering to configure and get wrong.
+
+If you would rather do server-side tracking at your reverse proxy (for example
+the `traefik-umami-feeder` plugin), that is entirely outside Herald: leave
+`[web.analytics]` unset and Herald's CSP stays fully locked down.

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -155,6 +155,18 @@ type Config struct {
 			// Users is fallback list of emails for admin when IdP omits roles.
 			Users []string `toml:"users"`
 		} `toml:"admin"`
+		// Analytics configures optional, privacy-respecting web analytics on the
+		// public landing page only (never the authenticated reader). Both fields
+		// must be set to enable it; empty (the default) means no tracking of any
+		// kind. Point these at your own Umami instance -- nothing is sent to the
+		// Herald project. See docs/analytics.md.
+		Analytics struct {
+			// UmamiSrc is the full URL of the Umami tracker script, e.g.
+			// "https://umami.example.com/script.js". Empty disables analytics.
+			UmamiSrc string `toml:"umami_src"`
+			// WebsiteID is the Umami site UUID (rendered as data-website-id).
+			WebsiteID string `toml:"website_id"`
+		} `toml:"analytics,omitempty"`
 	} `toml:"web"`
 }
 

--- a/internal/web/analytics.go
+++ b/internal/web/analytics.go
@@ -1,0 +1,56 @@
+package web
+
+import (
+	"log"
+	"net/url"
+)
+
+// AnalyticsConfig is the raw, unvalidated analytics configuration handed to
+// NewRouter (typically from cfg.Web.Analytics). Both fields empty means no
+// analytics -- the default. Only the public landing page is ever instrumented;
+// the authenticated reader is never tracked.
+type AnalyticsConfig struct {
+	// UmamiSrc is the full Umami tracker script URL, e.g.
+	// "https://umami.example.com/script.js".
+	UmamiSrc string
+	// WebsiteID is the Umami site UUID (data-website-id).
+	WebsiteID string
+}
+
+// analyticsView is the validated, render-ready form of AnalyticsConfig. It is
+// built once at router construction and reused for every landing-page render, so
+// no per-request URL parsing happens. The zero value (Enabled false) renders
+// nothing and leaves the strict Content-Security-Policy untouched.
+type analyticsView struct {
+	// Enabled reports whether a well-formed script URL and website ID are set.
+	Enabled bool
+	// Src is the tracker script URL, emitted verbatim into the <script src>.
+	Src string
+	// WebsiteID is the data-website-id attribute value.
+	WebsiteID string
+	// Origin is scheme://host of Src, added to script-src and connect-src in the
+	// landing page's CSP so the browser will load the script and let it POST
+	// events. Never the full URL -- just the origin.
+	Origin string
+}
+
+// newAnalyticsView validates c and returns a render-ready view. If either field
+// is empty, or the script URL does not parse into an http(s) origin, analytics
+// is disabled (and a misconfiguration is logged rather than failing boot -- a
+// bad analytics setting must never take the reader offline).
+func newAnalyticsView(c AnalyticsConfig) analyticsView {
+	if c.UmamiSrc == "" || c.WebsiteID == "" {
+		return analyticsView{}
+	}
+	u, err := url.Parse(c.UmamiSrc)
+	if err != nil || u.Host == "" || (u.Scheme != "https" && u.Scheme != "http") {
+		log.Printf("herald-web: ignoring invalid analytics umami_src %q (need an http(s) URL): %v", c.UmamiSrc, err)
+		return analyticsView{}
+	}
+	return analyticsView{
+		Enabled:   true,
+		Src:       c.UmamiSrc,
+		WebsiteID: c.WebsiteID,
+		Origin:    u.Scheme + "://" + u.Host,
+	}
+}

--- a/internal/web/analytics_test.go
+++ b/internal/web/analytics_test.go
@@ -1,0 +1,119 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// strictCSP is the exact Content-Security-Policy served on every response that
+// does not opt into analytics. Pinned so a change here is a conscious edit --
+// the authenticated app must never gain an off-origin allowance.
+const strictCSP = "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'"
+
+func TestContentSecurityPolicy(t *testing.T) {
+	if got := contentSecurityPolicy(""); got != strictCSP {
+		t.Errorf("empty origin CSP changed:\n got  %q\n want %q", got, strictCSP)
+	}
+
+	got := contentSecurityPolicy("https://umami.example.test")
+	if !strings.Contains(got, "script-src 'self' 'unsafe-inline' https://umami.example.test") {
+		t.Errorf("script-src not widened for analytics origin: %q", got)
+	}
+	if !strings.Contains(got, "connect-src 'self' https://umami.example.test") {
+		t.Errorf("connect-src not widened for analytics origin: %q", got)
+	}
+	// The origin must appear nowhere but those two directives.
+	if strings.Count(got, "umami.example.test") != 2 {
+		t.Errorf("analytics origin leaked into other directives: %q", got)
+	}
+}
+
+func TestNewAnalyticsView(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        AnalyticsConfig
+		wantOn     bool
+		wantOrigin string
+	}{
+		{"both empty", AnalyticsConfig{}, false, ""},
+		{"missing website id", AnalyticsConfig{UmamiSrc: "https://u.example/script.js"}, false, ""},
+		{"missing src", AnalyticsConfig{WebsiteID: "abc"}, false, ""},
+		{"valid https", AnalyticsConfig{UmamiSrc: "https://u.example.test/script.js", WebsiteID: "abc-123"}, true, "https://u.example.test"},
+		{"valid http", AnalyticsConfig{UmamiSrc: "http://u.example.test:3000/script.js", WebsiteID: "abc"}, true, "http://u.example.test:3000"},
+		{"non-http scheme", AnalyticsConfig{UmamiSrc: "ftp://u.example.test/script.js", WebsiteID: "abc"}, false, ""},
+		{"relative url has no host", AnalyticsConfig{UmamiSrc: "/script.js", WebsiteID: "abc"}, false, ""},
+		{"garbage url", AnalyticsConfig{UmamiSrc: "://not a url", WebsiteID: "abc"}, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := newAnalyticsView(tt.cfg)
+			if v.Enabled != tt.wantOn {
+				t.Fatalf("Enabled: got %v, want %v", v.Enabled, tt.wantOn)
+			}
+			if v.Origin != tt.wantOrigin {
+				t.Errorf("Origin: got %q, want %q", v.Origin, tt.wantOrigin)
+			}
+		})
+	}
+}
+
+// getLanding drives an anonymous GET / through SecurityHeaders + the router,
+// which serves the public landing page (sessions is nil with a nil validator).
+func getLanding(t *testing.T, analytics AnalyticsConfig) *httptest.ResponseRecorder {
+	t.Helper()
+	router := NewRouter(nil, nil, "", nil, analytics)
+	wrapped := SecurityHeaders(router)
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, httptest.NewRequest("GET", "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /: got %d, want 200", rr.Code)
+	}
+	return rr
+}
+
+func TestLandingAnalytics_Disabled(t *testing.T) {
+	rr := getLanding(t, AnalyticsConfig{})
+
+	if strings.Contains(rr.Body.String(), "data-website-id") {
+		t.Error("disabled analytics must not emit the tracker script")
+	}
+	if got := rr.Header().Get("Content-Security-Policy"); got != strictCSP {
+		t.Errorf("CSP must stay strict when analytics is off:\n got  %q\n want %q", got, strictCSP)
+	}
+}
+
+func TestLandingAnalytics_Enabled(t *testing.T) {
+	rr := getLanding(t, AnalyticsConfig{
+		UmamiSrc:  "https://umami.example.test/script.js",
+		WebsiteID: "site-uuid-42",
+	})
+
+	body := rr.Body.String()
+	if !strings.Contains(body, `src="https://umami.example.test/script.js"`) {
+		t.Errorf("landing page missing tracker src; body:\n%s", body)
+	}
+	if !strings.Contains(body, `data-website-id="site-uuid-42"`) {
+		t.Error("landing page missing data-website-id")
+	}
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "script-src 'self' 'unsafe-inline' https://umami.example.test") {
+		t.Errorf("landing CSP did not whitelist the tracker in script-src: %q", csp)
+	}
+	if !strings.Contains(csp, "connect-src 'self' https://umami.example.test") {
+		t.Errorf("landing CSP did not whitelist the tracker in connect-src: %q", csp)
+	}
+}
+
+func TestLandingAnalytics_InvalidSrcDisabled(t *testing.T) {
+	rr := getLanding(t, AnalyticsConfig{UmamiSrc: "not-a-url", WebsiteID: "abc"})
+
+	if strings.Contains(rr.Body.String(), "data-website-id") {
+		t.Error("invalid umami_src must disable analytics, not emit a broken script")
+	}
+	if got := rr.Header().Get("Content-Security-Policy"); got != strictCSP {
+		t.Errorf("CSP must stay strict when analytics config is invalid: %q", got)
+	}
+}

--- a/internal/web/degraded_test.go
+++ b/internal/web/degraded_test.go
@@ -33,7 +33,7 @@ func TestRouterDegradesWhileIdPUnreachable(t *testing.T) {
 		t.Fatalf("NewLazy with the IdP down must not fail: %v", err)
 	}
 
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	cases := []struct {
 		method, path string

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -37,6 +37,7 @@ type handlers struct {
 	pagesOnce   sync.Once                     // guards lazy template parsing
 	adminRole   string                        // JWT role value that grants admin access (default: "admin")
 	adminUsers  []string                      // fallback email list when the IdP does not issue role claims
+	analytics   analyticsView                 // optional landing-page analytics (disabled zero value = no tracking)
 }
 
 // isAdminCtx reports whether the request context carries admin privileges.
@@ -216,10 +217,26 @@ func (h *handlers) renderPublicPage(w http.ResponseWriter, name string, data any
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+	// When analytics is enabled, widen this response's CSP to permit the one
+	// configured tracker origin. This overrides the strict default set by the
+	// SecurityHeaders middleware, and only for public pages -- the authenticated
+	// app's CSP is never relaxed.
+	if h.analytics.Enabled {
+		w.Header().Set("Content-Security-Policy", contentSecurityPolicy(h.analytics.Origin))
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := t.ExecuteTemplate(w, "base_public.html", data); err != nil {
+	pd := publicPageData{Analytics: h.analytics, Data: data}
+	if err := t.ExecuteTemplate(w, "base_public.html", pd); err != nil {
 		log.Printf("herald-web: template error: %v", err)
 	}
+}
+
+// publicPageData wraps a public page's own data with the shared analytics view
+// so base_public.html can emit the (optional) tracker snippet. Page templates
+// reach their own payload through .Data; the landing page currently passes nil.
+type publicPageData struct {
+	Analytics analyticsView
+	Data      any
 }
 
 // --- Template data types ---

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -331,7 +331,7 @@ func newTestFixturesWith(t *testing.T, mutate func(*herald.EngineConfig)) *testF
 
 	validator, issueToken := newTestValidatorIssuer(t)
 	jwtToken := issueToken("test-sub-1", "tester@example.com", "Tester")
-	router := NewRouter(engine, validator, "", nil)
+	router := NewRouter(engine, validator, "", nil, AnalyticsConfig{})
 
 	t.Cleanup(func() {
 		engine.Close()
@@ -1045,7 +1045,7 @@ func TestHandleCallback_SetsSessionCookie(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	state := "test-state-nonce"
 	verifier := "test-pkce-verifier"
@@ -1082,7 +1082,7 @@ func TestHandleCallback_DefaultRedirect(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state="+state, nil)
@@ -1105,7 +1105,7 @@ func TestHandleCallback_InvalidState(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state=WRONG", nil)
 	req.AddCookie(&http.Cookie{Name: oidclient.CookieState, Value: "correct-state"})
@@ -1123,7 +1123,7 @@ func TestHandleCallback_MissingVerifier(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=test-code&state="+state, nil)
@@ -1145,7 +1145,7 @@ func TestHandleCallback_TokenExchangeError(t *testing.T) {
 	validator := newTestValidatorWithOIDC(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid_grant", http.StatusUnauthorized)
 	})
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	state := "test-state"
 	req := httptest.NewRequest("GET", "/auth/callback?code=bad-code&state="+state, nil)
@@ -1164,7 +1164,7 @@ func TestHandleCallback_UpstreamAuthError(t *testing.T) {
 	tf := newTestFixtures(t)
 
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	// Webauth redirects with ?error=access_denied when the user denies.
 	req := httptest.NewRequest("GET", "/auth/callback?error=access_denied&error_description=User+denied+access", nil)
@@ -1603,7 +1603,7 @@ func newAdminFixtures(t *testing.T) *testFixtures {
 	validator, issueToken := newTestValidatorIssuer(t)
 	jwtToken := issueToken("test-sub-1", "tester@example.com", "Tester")
 	// Grant admin by listing the test user's email in adminUsers.
-	router := NewRouter(engine, validator, "", []string{"tester@example.com"})
+	router := NewRouter(engine, validator, "", []string{"tester@example.com"}, AnalyticsConfig{})
 
 	t.Cleanup(func() {
 		engine.Close()

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -143,17 +143,42 @@ func (h *handlers) requireAuth(next http.Handler) http.Handler {
 	})
 }
 
+// contentSecurityPolicy builds the CSP header value. With an empty
+// analyticsOrigin (the default, and every authenticated response) it returns the
+// strict baseline: nothing loads from off-origin. When a landing page is served
+// with analytics enabled, the single configured Umami origin (scheme://host, not
+// a full URL) is whitelisted in script-src (to load the tracker) and connect-src
+// (so the tracker may POST events there) -- and nowhere else. The empty-origin
+// output is kept byte-for-byte stable because tests and operators pin it.
+func contentSecurityPolicy(analyticsOrigin string) string {
+	parts := []string{
+		"default-src 'self'",
+		"img-src 'self' data:",
+		"style-src 'self' 'unsafe-inline'",
+	}
+	if analyticsOrigin != "" {
+		parts = append(parts,
+			"script-src 'self' 'unsafe-inline' "+analyticsOrigin,
+			"connect-src 'self' "+analyticsOrigin)
+	} else {
+		parts = append(parts, "script-src 'self' 'unsafe-inline'")
+	}
+	parts = append(parts, "object-src 'none'", "frame-ancestors 'none'", "base-uri 'self'")
+	return strings.Join(parts, "; ")
+}
+
 // SecurityHeaders sets conservative security response headers on every
-// response. The CSP currently permits inline scripts/styles because some
-// templates use them; tightening script-src with nonces is a follow-up.
+// response. The CSP permits inline scripts/styles because some templates use
+// them; tightening script-src with nonces is a follow-up. Individual handlers
+// may override Content-Security-Policy before writing (the public landing page
+// does, to whitelist an optional analytics origin); this sets the strict default.
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		h.Set("Content-Security-Policy",
-			"default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'")
+		h.Set("Content-Security-Policy", contentSecurityPolicy(""))
 		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		next.ServeHTTP(w, r)
 	})

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -16,7 +16,7 @@ import (
 func TestRequireAuth_ReusesExistingFlow(t *testing.T) {
 	tf := newTestFixtures(t)
 	validator := newTestValidatorWithOIDC(t, nil)
-	router := NewRouter(tf.engine, validator, "", nil)
+	router := NewRouter(tf.engine, validator, "", nil, AnalyticsConfig{})
 
 	// First unauthenticated request to an auth-wrapped route starts a flow.
 	// ("/" is now the public landing page; use a protected route to drive

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -33,7 +33,7 @@ var embedded embed.FS
 // Fixture id convention: each seeded entity is the first row in a fresh DB, so
 // its id is 1; destructive writes target a dedicated second row (id 2) so they
 // don't delete what the read probes need. See TestSmokeRoutesAuthenticated.
-func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string) *smoke.Mux {
+func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole string, adminUsers []string, analytics AnalyticsConfig) *smoke.Mux {
 	mux := smoke.NewMux()
 
 	// Liveness probe — no auth, no DB. Used by the PR-preview pipeline to wait
@@ -72,6 +72,7 @@ func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 		sessions:   sessions,
 		adminRole:  adminRole,
 		adminUsers: adminUsers,
+		analytics:  newAnalyticsView(analytics),
 	}
 	auth := h.requireAuth
 

--- a/internal/web/smoke_manifest_test.go
+++ b/internal/web/smoke_manifest_test.go
@@ -22,7 +22,7 @@ const smokeManifestPath = "smoke-manifest.json"
 // specs at registration time and never touches the engine/validator, so a nil
 // engine is sufficient to enumerate the surface without a database.
 func TestSmokeManifestUpToDate(t *testing.T) {
-	got, err := NewRouter(nil, nil, "", nil).Registry().Manifest().MarshalJSON()
+	got, err := NewRouter(nil, nil, "", nil, AnalyticsConfig{}).Registry().Manifest().MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/web/smoke_run_test.go
+++ b/internal/web/smoke_run_test.go
@@ -151,7 +151,7 @@ func TestSmokeRoutesAuthenticated(t *testing.T) {
 	validator, token := newTestValidator(t)
 	// adminRole "admin" with no role claim falls back to the adminUsers email
 	// list, granting the smoke user admin so /admin/* returns 200.
-	mux := NewRouter(engine, validator, "admin", []string{"tester@example.com"})
+	mux := NewRouter(engine, validator, "admin", []string{"tester@example.com"}, AnalyticsConfig{})
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)

--- a/internal/web/templates/base_public.html
+++ b/internal/web/templates/base_public.html
@@ -14,6 +14,7 @@
             if (t) document.documentElement.setAttribute('data-theme', t);
         })();
     </script>
+    {{with .Analytics}}{{if .Enabled}}<script defer src="{{.Src}}" data-website-id="{{.WebsiteID}}"></script>{{end}}{{end}}
 </head>
 <body class="public">
     <header class="public-nav">


### PR DESCRIPTION
## What

Adds opt-in, privacy-respecting web analytics on the **public landing page only**. Off by default -- no tracking, no config, no CSP change unless a self-hoster explicitly enables it against their own Umami instance.

## Design

- New `[web.analytics]` config (`umami_src` + `website_id`); both required to enable.
- `contentSecurityPolicy(origin)` builder: empty origin returns the **byte-identical** strict policy; an origin widens only `script-src` and `connect-src`, and only on public-page responses.
- The authenticated reader is never instrumented -- the tracker snippet lives solely in `base_public.html`, and its CSP is unchanged whether or not analytics is set.
- A malformed `umami_src` disables analytics with a logged warning; it never fails boot or emits a broken tag.

## Why landing-only / client-side

The goal is counting human discovery of the landing page. A browser-run script filters bots that dominate request logs, and living only in the public template scopes it to exactly the measured page -- no request-path filtering to misconfigure. The private reader stays fully locked down.

## Tests

- `TestContentSecurityPolicy` -- strict string pinned; widened form whitelists the origin in exactly two directives and nowhere else.
- `TestNewAnalyticsView` -- table: empty/missing/invalid/non-http(s) all disable; valid http(s) yields the right origin.
- `TestLandingAnalytics_{Enabled,Disabled,InvalidSrcDisabled}` -- end-to-end through `SecurityHeaders` + router.
- Existing `TestSecurityHeaders` (pinned strict CSP) unchanged.

Docs: `docs/analytics.md` -- self-hoster guide + security model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)