### PR TITLE
build: bump Go to 1.26.5 (fixes GO-2026-5856 crypto/tls ECH leak)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewjhunter/herald
 
-go 1.26.4
+go 1.26.5
 
 require (
 	codeberg.org/readeck/go-readability/v2 v2.1.2

--- a/plans/001-cross-user-authorization-fixes.md
+++ b/plans/001-cross-user-authorization-fixes.md
@@ -1,0 +1,358 @@
+# Plan 001: Enforce per-user ownership on filter rules, groups, and newsletter generation
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 62f949e..HEAD -- engine.go engine_summary.go internal/storage/store.go internal/storage/storage.go internal/storage/postgres.go cmd/herald-web/handlers.go cmd/herald-mcp/server.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `62f949e`, 2026-06-12
+
+## Why this matters
+
+Herald is moving to multiuser operation: every web request is authenticated
+(OIDC) and resolved to a user ID, and most handlers scope their queries
+correctly. Four code paths do not, so any authenticated user can act on
+another user's data by guessing small integer IDs:
+
+1. Delete or rescore any user's filter rules.
+2. Mute (hide) any user's article groups.
+3. Read any user's group topic/summary/articles via the group banner path.
+4. Trigger digest generation against any user's newsletter config -- which
+   also advances that newsletter's `last_generated_at` (so the victim's next
+   scheduled digest silently skips articles) and emails the result to the
+   victim's configured recipient.
+
+A fifth, smaller fix rides along: the OPML sync token is compared with `!=`
+instead of a constant-time compare.
+
+## Current state
+
+Files and their roles:
+
+- `engine.go` -- the Engine facade all binaries call; ownership checks live
+  here (see `DisbandGroup` and `DeleteNewsletter` for the existing pattern).
+- `engine_summary.go` -- AI digest (ad-hoc summary + newsletter) generation.
+- `internal/storage/store.go` -- the `Store` interface both backends implement.
+- `internal/storage/storage.go` -- SQLite implementation.
+- `internal/storage/postgres.go` -- Postgres implementation (mirror every
+  SQLite query change here).
+- `cmd/herald-web/handlers.go` -- HTTP handlers; user ID comes from
+  `userFromContext(r.Context()).ID`.
+- `cmd/herald-mcp/server.go` -- MCP server; calls the same Engine methods.
+
+The existing GOOD pattern to copy -- `engine.go:950-961`:
+
+```go
+// DisbandGroup deletes a group; its articles return to their feeds.
+func (e *Engine) DisbandGroup(userID, groupID int64) error {
+	// Verify the group belongs to this user
+	group, err := e.store.GetGroup(groupID)
+	if err != nil {
+		return fmt.Errorf("get group: %w", err)
+	}
+	if group == nil || group.UserID != userID {
+		return fmt.Errorf("group not found or not owned by user")
+	}
+	return e.store.DisbandGroup(groupID)
+}
+```
+
+The four broken paths as they exist today:
+
+`engine.go:942-947` -- MuteGroup has NO ownership check:
+
+```go
+func (e *Engine) MuteGroup(userID, groupID int64) error {
+	if err := e.store.SetGroupMuted(groupID, true); err != nil {
+		return err
+	}
+	return e.store.MarkGroupArticlesRead(userID, groupID, 0)
+}
+```
+
+`engine.go:1714-1722` -- filter rule mutations take no userID:
+
+```go
+// UpdateFilterRule updates the score of an existing filter rule.
+func (e *Engine) UpdateFilterRule(ruleID int64, score int) error {
+	return e.store.UpdateFilterRuleScore(ruleID, score)
+}
+
+// DeleteFilterRule deletes a filter rule by ID.
+func (e *Engine) DeleteFilterRule(ruleID int64) error {
+	return e.store.DeleteFilterRule(ruleID)
+}
+```
+
+Backing queries: `internal/storage/storage.go:2828` and `:2837` (SQLite),
+`internal/storage/postgres.go:1420` and `:1428` (Postgres) -- both are
+`UPDATE/DELETE ... WHERE id = ?` with no `user_id` condition. The interface
+declarations are at `internal/storage/store.go:157` (UpdateFilterRuleScore)
+and nearby (DeleteFilterRule). Web caller: `cmd/herald-web/handlers.go:1791`
+(`h.engine.DeleteFilterRule(ruleID)` inside `handleFilterDelete`). MCP
+caller: `cmd/herald-mcp/server.go:459`
+(`hs.engine.UpdateFilterRule(input.RuleID, input.Score)`).
+
+`engine.go:872-909` -- `GetGroupArticles(groupID int64)` loads any group's
+topic, display name, articles, and summary with no user check. Web caller:
+`cmd/herald-web/handlers.go:675` inside `handleArticleList`:
+
+```go
+if group, err := h.engine.GetGroupArticles(groupID); err == nil && group != nil {
+```
+
+Note: `GetUnreadGroupArticles` (the actual article rows for the group view)
+is already scoped -- its SQL has `ag.user_id = ?`. Only the
+`GetGroupArticles` banner/metadata path leaks.
+
+`engine_summary.go:114-132` -- `BeginAISummary(userID int64, newsletterID
+*int64)` never verifies the newsletter belongs to userID. Neither does
+`FinishAISummary` (`engine_summary.go:138-160`), which calls
+`UpdateNewsletterLastGenerated(*newsletterID)` and emails
+`nl.EmailRecipient`. Web caller: `cmd/herald-web/handlers.go:1037-1057`
+(`handleNewsletterGenerate`) parses `newsletterID` from the URL and passes it
+straight in. Contrast with `handleNewsletterUpdate`
+(`cmd/herald-web/handlers.go:1022-1026`), which does it right:
+
+```go
+nl, err := h.engine.GetNewsletter(id)
+if err != nil || nl.UserID != uid {
+	h.renderError(w, http.StatusNotFound, "Digest not found")
+	return
+}
+```
+
+Token compare -- `cmd/herald-web/handlers.go:1946-1950` (`handleOPMLSync`):
+
+```go
+stored, err := h.engine.GetUserPreference(userID, "opml_sync_token")
+if err != nil || stored == "" || stored != token {
+```
+
+Repo conventions: errors wrapped with `fmt.Errorf("...: %w", err)`; storage
+methods exist in BOTH storage.go and postgres.go and must stay in sync;
+handlers render errors via `h.renderError(w, status, msg)` for HTML routes or
+`http.Error` for fragment/API-ish routes -- match whichever the handler
+already uses.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests | `go test -race -count=1 ./...` | all pass |
+| One package | `go test -race -count=1 ./cmd/herald-web/` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0, no issues |
+| Vuln check | `govulncheck ./...` | no findings |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope** (the only files you should modify):
+
+- `engine.go`
+- `engine_summary.go`
+- `internal/storage/store.go`
+- `internal/storage/storage.go`
+- `internal/storage/postgres.go`
+- `cmd/herald-web/handlers.go`
+- `cmd/herald-mcp/server.go`
+- Test files: `engine_test.go`, `engine_summary_test.go`,
+  `cmd/herald-web/handlers_test.go`, `internal/storage/storage_test.go`,
+  `cmd/herald-mcp/server_test.go` (as needed to keep existing tests passing
+  and add the new ones)
+
+**Out of scope** (do NOT touch):
+
+- `internal/storage/schema.go` / `schema_postgres.go` -- no schema change is
+  needed for any of this.
+- `DisbandGroup`, `DeleteNewsletter`, `handleNewsletterUpdate` -- already
+  correct; leave them alone.
+- `internal/storage/fever.go` and the Fever handlers -- already scoped.
+- The article-summaries architecture (that is plan 002).
+- Smoke test fixtures/route specs in `cmd/herald-web/routes.go` -- the routes
+  themselves do not change.
+
+## Git workflow
+
+- Branch off the current feature branch or main as the operator directs
+  (repo convention: `fix/<slug>` branches, e.g. `fix/cross-user-authz`).
+- Small, logical, separate commits -- one per step below is ideal. Message
+  style from git log: short imperative subject, e.g.
+  `Reject cross-user newsletter generation in BeginAISummary`.
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Newsletter ownership in BeginAISummary
+
+In `engine_summary.go`, at the top of `BeginAISummary` (after the
+`e.summarizer == nil` check), add: when `newsletterID != nil`, load the
+newsletter via `e.store.GetNewsletter(*newsletterID)` and return an error
+unless it exists and `nl.UserID == userID`. Reuse the exact error wording
+from `DeleteNewsletter` (`engine.go:992`): `"newsletter not found or not
+owned by user"`.
+
+In `cmd/herald-web/handlers.go` `handleNewsletterGenerate`, add the same
+ownership pre-check used by `handleNewsletterUpdate` (lines 1022-1026):
+load `h.engine.GetNewsletter(id)`, and on error or `nl.UserID != uid` render
+404 "Digest not found" and return, BEFORE calling `BeginAISummary`. (Engine
+check = defense in depth for non-web callers; handler check = correct HTTP
+status, since the handler currently swallows BeginAISummary errors and
+prints "Generating..." regardless.)
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 2: User-scope filter rule mutations end to end
+
+1. `internal/storage/store.go`: change the interface methods to
+   `UpdateFilterRuleScore(userID, ruleID int64, score int) error` and
+   `DeleteFilterRule(userID, ruleID int64) error`.
+2. `internal/storage/storage.go:2828,2837`: add `AND user_id = ?` to both
+   statements; use the `sql.Result` to detect 0 rows affected and return
+   `fmt.Errorf("filter rule %d not found for user %d", ruleID, userID)` in
+   that case.
+3. `internal/storage/postgres.go:1420,1428`: same change (pgx result
+   `RowsAffected()`).
+4. `engine.go:1715,1720`: thread `userID` through:
+   `UpdateFilterRule(userID, ruleID int64, score int)` and
+   `DeleteFilterRule(userID, ruleID int64)`.
+5. `cmd/herald-web/handlers.go:1791` (`handleFilterDelete`): call
+   `h.engine.DeleteFilterRule(uid, ruleID)`; on error render 404
+   "Rule not found" instead of the current 500.
+6. `cmd/herald-mcp/server.go:459`: pass the already-resolved `userID`
+   (the variable from `hs.resolveUser(...)` in that tool handler) as the
+   first argument.
+
+**Verify**: `go build ./...` -> exit 0;
+`grep -rn "DeleteFilterRule(ruleID)" --include='*.go' .` -> no matches.
+
+### Step 3: Group ownership for MuteGroup and GetGroupArticles
+
+1. `engine.go` `MuteGroup`: before `SetGroupMuted`, add the same
+   load-and-verify block as `DisbandGroup` (lines 950-961). Do not change
+   the storage `SetGroupMuted` signature.
+2. `engine.go` `GetGroupArticles`: change signature to
+   `GetGroupArticles(userID, groupID int64) (*ArticleGroup, error)`. It
+   already loads the group first (`e.store.GetGroup(groupID)`); after that
+   load, return `fmt.Errorf("group not found or not owned by user")` when
+   `group == nil || group.UserID != userID`. (Note: today the function
+   tolerates `group == nil` and returns a partially filled result -- that
+   tolerance goes away; a missing group is now an error.)
+3. Update every caller of `GetGroupArticles`: run
+   `grep -rn "GetGroupArticles(" --include='*.go' .` and update each engine-
+   level call site to pass the user ID. Known: `cmd/herald-web/handlers.go:675`
+   (use `uid`). If an MCP tool calls it, pass that tool's resolved `userID`.
+   Do NOT change the storage-layer method `store.GetGroupArticles(groupID)`
+   -- only the Engine method.
+
+**Verify**: `go build ./...` -> exit 0; `go test -race -count=1 ./...` ->
+existing tests pass (some may need the new argument added -- update them).
+
+### Step 4: Constant-time OPML token compare
+
+In `cmd/herald-web/handlers.go` `handleOPMLSync` (line ~1947), replace
+`stored != token` with a constant-time comparison:
+
+```go
+if err != nil || stored == "" ||
+	subtle.ConstantTimeCompare([]byte(stored), []byte(token)) != 1 {
+```
+
+Add `crypto/subtle` to the imports.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 5: Tests
+
+See "Test plan" below. Write them, run the full suite.
+
+**Verify**: `go test -race -count=1 ./...` -> all pass, including the new
+tests.
+
+### Step 6: Full gate
+
+**Verify**: `task check` -> exit 0 (runs build, tests, lint, govulncheck).
+
+## Test plan
+
+Model web tests on the existing harness in
+`cmd/herald-web/handlers_test.go` (it has a `fakeOIDCProvider` that mints
+JWTs for arbitrary subjects -- issue tokens for two different subs to get
+two distinct auto-provisioned users; see
+`TestHandleArticleView_NotFound` for the request/response shape). Model
+storage tests on `internal/storage/storage_test.go`. Cases:
+
+1. **Filter rule cross-user delete rejected**: user A creates a rule; user B
+   sends `DELETE /filters/{ruleID}` -> 404, and A's rule still exists
+   (verify via `GetFilterRules(A, nil)`). A deleting their own rule -> 200
+   and the rule is gone.
+2. **Filter rule storage scoping** (storage-level, both backends if the
+   Postgres tests have a harness; otherwise SQLite only):
+   `DeleteFilterRule(otherUser, ruleID)` returns an error and the row
+   survives; `UpdateFilterRuleScore(otherUser, ruleID, n)` likewise.
+3. **MuteGroup cross-user rejected** (engine-level): create a group owned by
+   user A (insert via storage), call `engine.MuteGroup(B, groupID)` ->
+   error, and the group's `muted` flag is still false.
+4. **GetGroupArticles cross-user rejected** (engine-level): A's group,
+   `engine.GetGroupArticles(B, groupID)` -> error; `(A, groupID)` -> group
+   returned.
+5. **Newsletter generate cross-user rejected** (web-level): A creates a
+   newsletter; B posts `/newsletters/{id}/generate` -> 404, and A's
+   newsletter `last_generated_at` is unchanged, and no `ai_summaries` row
+   was created for either user. B generating their own -> the "Generating"
+   fragment.
+6. **BeginAISummary ownership** (engine-level, in `engine_summary_test.go`):
+   `BeginAISummary(B, &aNewsletterID)` -> error containing "not owned".
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -rn "func (e \*Engine) DeleteFilterRule(ruleID" engine.go` -> no match (signature now takes userID)
+- [ ] `grep -n "SetGroupMuted" engine.go` shows the call preceded by an ownership check in `MuteGroup`
+- [ ] `grep -n "ConstantTimeCompare" cmd/herald-web/handlers.go` -> 1 match in `handleOPMLSync`
+- [ ] New tests from the test plan exist and pass
+- [ ] `git status` shows no modified files outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The excerpts in "Current state" do not match the live code (drift).
+- `cmd/herald-mcp/` has been deleted from the repo (the operator is
+  considering dropping MCP support) -- if so, skip the MCP edits in step 2,
+  note it in your report, and continue with the rest.
+- Changing `GetGroupArticles` requires touching template files or the smoke
+  route specs -- the response shape should not change; if a template breaks,
+  stop.
+- Any existing test fails for a reason unrelated to your change, twice.
+
+## Maintenance notes
+
+- Reviewer should scrutinize: that BOTH storage backends got the filter-rule
+  WHERE clause, and that the MCP call site passes the resolved speaker's
+  userID, not the server default.
+- Future group/newsletter Engine methods must follow the DisbandGroup
+  load-and-verify pattern; consider a `requireGroupOwner(userID, groupID)`
+  helper if a third group method appears.
+- Deferred (out of this plan): storage-layer defense in depth (adding
+  user_id to `SetGroupMuted`/`DisbandGroup` queries themselves); the
+  open-registration gating finding; the article/image direct-ID visibility
+  policy decision.

--- a/plans/002-shared-article-summaries.md
+++ b/plans/002-shared-article-summaries.md
@@ -1,0 +1,496 @@
+# Plan 002: Share per-article AI summaries across all users (one summary per article)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 62f949e..HEAD -- internal/storage/ internal/pipeline/ internal/ai/ engine.go cmd/herald/main.go cmd/herald-web/handlers.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M-L
+- **Risk**: MED (data migration; both DB backends)
+- **Depends on**: 001 (not technically coupled, but land 001 first so the
+  two changes do not collide in engine/handlers files)
+- **Category**: migration / architecture
+- **Planned at**: commit `62f949e`, 2026-06-12
+
+## Why this matters
+
+Per-article AI summaries are currently generated and stored once per
+(user, article): `article_summaries` has PRIMARY KEY (user_id, article_id)
+and the summarize stage runs inside each user's pipeline. With N subscribers
+to the same feed, every article costs N LLM summarization calls and N stored
+copies that are byte-for-byte identical in practice. The maintainer's
+decision: a summary is a property of the article, exactly like the security
+verdict already migrated in #141. Per-user summarization prompts are
+dropped entirely -- only the admin/global summarization prompt (user_id=0
+in `user_prompts`, then config file, then embedded default) applies.
+
+After this lands: each article is summarized at most once, in the global
+pipeline pass next to security screening, and every subscriber reads the
+same cached summary.
+
+The precedent to imitate throughout is the #141 security-verdict migration
+-- see the migration block in `internal/storage/storage.go` (search for
+"Move the security verdict") and its tests in
+`internal/storage/security_perarticle_test.go`.
+
+## Current state
+
+Schema -- `internal/storage/schema.go:110-120`:
+
+```sql
+CREATE TABLE IF NOT EXISTS article_summaries (
+    user_id INTEGER NOT NULL DEFAULT 1,
+    article_id INTEGER NOT NULL,
+    ai_summary TEXT NOT NULL,
+    skip_reason TEXT,
+    generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, article_id),
+    FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_article_summaries_article ON article_summaries(article_id);
+```
+
+Postgres mirror -- `internal/storage/schema_postgres.go:116-126` (same shape,
+BIGINT/TIMESTAMPTZ).
+
+Semantics of a row (preserve these): `ai_summary <> ''` = real summary;
+`ai_summary = ''` with non-null `skip_reason` = "tried, deterministically
+rejected, do not retry". Absence of a row = "not yet attempted, queue it".
+
+Store interface -- `internal/storage/store.go`:
+
+```go
+GetUnsummarizedScoredArticles(userID int64, securityThreshold float64, limit int) ([]Article, error)   // :127
+UpdateArticleAISummary(userID, articleID int64, aiSummary string) error                                 // :162
+MarkSummarizationSkipped(userID, articleID int64, reason string) error                                  // :163
+GetArticleSummary(userID, articleID int64) (*ArticleSummary, error)                                     // :164
+```
+
+SQLite implementations: `internal/storage/storage.go:1351` (insert),
+`:1371` (skip insert), `:1387` (get), `:2337` (queue query, joins
+`user_feeds` and filters `asumm.user_id = uf.user_id`). The per-user
+unsummarized count feeding the stats pages: `:1429` (feed-stats LEFT JOIN
+with `asumm.user_id = ?`), `:1499-1500` (processing-stats subqueries with
+`WHERE user_id = ?`), and another LEFT JOIN at `:2323`
+(`GetUnreadArticlesForSummary` region). `GetUnsummarizedArticleCount(userID)`
+is called from `engine.go:1349-1358` (`PendingCounts`).
+
+Postgres mirrors: `internal/storage/postgres.go:962` (queue query), `:1447`,
+`:1463`, `:1478` (CRUD), `:1522-1523`, `:1116`, `:1608` (stats/joins).
+
+Pipeline -- the summarize stage runs PER USER today:
+
+- `internal/pipeline/orchestrate.go:46-66` -- `Stage.Run` (per-user) drains
+  `GetUnsummarizedScoredArticles(s.UserID, ...)` into `s.Summarize`, then
+  curation. `RunSecurity` (`:24-37`) is the existing GLOBAL pass, driven by
+  `GetUnscreenedArticles(limit)` -- that is the pattern to copy.
+- `internal/pipeline/stages.go:106-150` -- `summarizeOne` calls
+  `GetArticleSummary(s.UserID, ...)`, `SummarizeArticle(ctx, s.UserID, ...)`,
+  `MarkSummarizationSkipped(s.UserID, ...)`,
+  `UpdateArticleAISummary(s.UserID, ...)`.
+- `internal/pipeline/pipeline.go:19-26` -- the `AI` interface declares
+  `SummarizeArticle(ctx context.Context, userID int64, title, content string,
+  maxSummaryLength int) (string, error)`.
+- `internal/pipeline/clusterstage.go:188` -- group summarization reads
+  `GetArticleSummary(s.UserID, a.ID)`.
+- `cmd/herald/main.go:486-507` -- the daemon cycle: builds `securityStage`
+  with `cfg.DefaultUserID`, calls `securityStage.RunSecurity(ctx)`, then
+  loops `GetAllSubscribingUsers()` running `stage.Run(ctx)` per user.
+
+Prompt resolution -- `internal/ai/summarization.go:12-20`:
+
+```go
+func (p *AIProcessor) SummarizeArticle(ctx context.Context, userID int64, title, content string, maxSummaryLength int) (string, error) {
+	promptTemplate, err := p.promptLoader.GetPrompt(userID, PromptTypeSummarization)
+```
+
+The pattern to copy is `SecurityCheck` in `internal/ai/ollama.go:92-109`,
+which pins the prompt to the global user:
+
+```go
+const globalUser = int64(0)
+promptTemplate, err := p.promptLoader.GetPrompt(globalUser, PromptTypeSecurity)
+```
+
+(`PromptLoader.GetPrompt(0, ...)` reads the admin's user_id=0 row, then the
+config file, then the embedded default -- exactly the desired chain.)
+
+Prompt policy surfaces:
+
+- `engine.go:1361-1368` -- `allowedPromptTypes` map gating
+  `SetPrompt`/`ResetPrompt`/`DefaultPrompt`; currently
+  `{curation, summarization, group_summary, summary}` ("security" is already
+  excluded with a comment).
+- `cmd/herald-web/handlers.go:79-86` -- `promptTypeOrder` +
+  `promptLabels` drive BOTH the user settings page
+  (`loadPromptEntries(uid)`, called from `handleSettingsPrompts`) and the
+  admin page (`loadPromptEntries(0)`, called from `handleAdminPrompts`).
+- `engine.go:1494-1521` (`ListPrompts`) iterates `allowedPromptTypes` -- used
+  by MCP.
+
+Engine read sites for the per-article summary: `engine.go:244`
+(`GetArticleForUser`), `engine.go:1111` (newsletter issue assembly),
+`engine.go:1229` (`GenerateBriefing`).
+
+SQLite-to-Postgres copy tool: `internal/storage/migrate.go:67` registers
+`migrateArticleSummaries`; its query at `:630` selects
+`user_id, article_id, ai_summary` and writes via
+`dst.UpdateArticleAISummary(dstUserID, dstArticleID, summary)` at `:650`.
+
+Migration machinery (SQLite): `NewSQLiteStore` in
+`internal/storage/storage.go` applies a `migrations []string` list with
+errors ignored (duplicate-column tolerance), then runs guarded table
+rebuilds -- see `needsReadStateMigration` (PRAGMA table_info detection) and
+the `read_state_new` rebuild block (~`storage.go:404-430`). That rebuild is
+the exact template for this plan's table rebuild. Postgres applies its own
+small list of `ALTER ... IF NOT EXISTS` migrations (see
+`internal/storage/postgres.go:63`).
+
+Distinct concept, do NOT confuse: the `ai_summaries` table and
+`PromptTypeSummary` ("summary") are the DIGEST feature (multi-article
+newsletters); they stay per-user and are untouched. Only per-article
+summarization (`article_summaries`, `PromptTypeSummarization` =
+"summarization") changes.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests | `go test -race -count=1 ./...` | all pass |
+| One package | `go test -race -count=1 ./internal/storage/` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `internal/storage/schema.go`, `internal/storage/schema_postgres.go`
+- `internal/storage/storage.go`, `internal/storage/postgres.go`,
+  `internal/storage/store.go`, `internal/storage/migrate.go`
+- `internal/pipeline/orchestrate.go`, `internal/pipeline/stages.go`,
+  `internal/pipeline/pipeline.go`, `internal/pipeline/clusterstage.go`
+- `internal/ai/summarization.go`
+- `engine.go` (summary read sites, PendingCounts, prompt-type policy)
+- `cmd/herald/main.go` (wire the global summarize pass)
+- `cmd/herald-web/handlers.go` (prompt-type lists only)
+- Docs that describe per-user summarization prompts (step 8)
+- Test files in the packages above
+
+**Out of scope** (do NOT touch):
+
+- `ai_summaries` table, `engine_summary.go`, digest/newsletter code -- the
+  DIGEST pipeline is a different feature and stays per-user.
+- `PromptTypeCuration`, `PromptTypeGroupSummary`, `PromptTypeNewsletter`,
+  `PromptTypeSummary` -- still per-user-customizable.
+- The security screening path -- already global; only imitate it.
+- `read_state`, interest scoring, clustering ownership -- per-user by design.
+
+## Git workflow
+
+- Branch: `feat/shared-article-summaries` (or as the operator directs).
+- Small commits per step; subject style from git log, e.g.
+  `Move article summaries from per-user to per-article (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Schema for fresh databases
+
+In `internal/storage/schema.go`, change `article_summaries` to:
+
+```sql
+CREATE TABLE IF NOT EXISTS article_summaries (
+    article_id INTEGER PRIMARY KEY,
+    ai_summary TEXT NOT NULL,
+    skip_reason TEXT,
+    generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+```
+
+Drop the now-redundant `idx_article_summaries_article` index line (the PK
+covers it). Mirror in `internal/storage/schema_postgres.go` (BIGINT
+PRIMARY KEY, TIMESTAMPTZ).
+
+**Verify**: `go build ./...` -> exit 0 (schema is a string constant; build
+still passes).
+
+### Step 2: Guarded table rebuild for existing SQLite databases
+
+In `internal/storage/storage.go`, after the `needsReadStateMigration` block
+in `NewSQLiteStore`, add a `needsArticleSummariesMigration(db)` check that
+returns true when `PRAGMA table_info(article_summaries)` lists a `user_id`
+column (copy the shape of `needsReadStateMigration`,
+`storage.go:438-460`, inverting the condition: user_id PRESENT means
+migrate). When true, run one Exec:
+
+```sql
+CREATE TABLE article_summaries_new (
+    article_id INTEGER PRIMARY KEY,
+    ai_summary TEXT NOT NULL,
+    skip_reason TEXT,
+    generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (article_id) REFERENCES articles(id) ON DELETE CASCADE
+);
+INSERT INTO article_summaries_new (article_id, ai_summary, skip_reason, generated_at)
+SELECT article_id, ai_summary, skip_reason, generated_at
+FROM (
+    SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY article_id
+        ORDER BY (ai_summary = '') ASC, user_id ASC
+    ) AS rn
+    FROM article_summaries
+) WHERE rn = 1;
+DROP TABLE article_summaries;
+ALTER TABLE article_summaries_new RENAME TO article_summaries;
+```
+
+The ORDER BY makes the pick deterministic and prefers a real summary over a
+skip marker, then the lowest user_id -- the same tiebreak philosophy as the
+#141 backfill ("lowest user_id ... deterministic"). modernc.org/sqlite
+supports window functions.
+
+For Postgres, add a guarded migration alongside the existing list applied in
+`NewPostgresStore` (`internal/storage/postgres.go:63` region): detect the
+old shape via
+`SELECT 1 FROM information_schema.columns WHERE table_name = 'article_summaries' AND column_name = 'user_id'`
+in Go, and when present run the equivalent rebuild (same SELECT; Postgres
+window-function syntax is identical).
+
+**Verify**: `go test -race -count=1 ./internal/storage/` -> pass (the new
+migration test from step 9 lands here; at this point existing tests must
+still pass).
+
+### Step 3: Storage API to per-article
+
+Change signatures in `internal/storage/store.go` and BOTH implementations
+(`storage.go`, `postgres.go`):
+
+- `UpdateArticleAISummary(articleID int64, aiSummary string) error` --
+  insert keyed by article_id only, `ON CONFLICT(article_id) DO UPDATE`.
+- `MarkSummarizationSkipped(articleID int64, reason string) error` -- same.
+- `GetArticleSummary(articleID int64) (*ArticleSummary, error)` -- drop the
+  user_id column from SELECT and the `ArticleSummary` struct's `UserID`
+  field if one exists (check the struct; remove the field and fix scans).
+- `GetUnsummarizedScoredArticles(securityThreshold float64, limit int)
+  ([]Article, error)` -- make it global, mirroring `GetUnscreenedArticles`:
+  drop the `user_feeds` join and `uf.user_id = ?` filter; keep
+  `a.security_score >= ?` and `asumm.article_id IS NULL`:
+
+  ```sql
+  SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+         a.author, a.published_date, a.fetched_date
+  FROM articles a
+  LEFT JOIN article_summaries asumm ON asumm.article_id = a.id
+  WHERE a.security_score >= ? AND asumm.article_id IS NULL
+  ORDER BY a.published_date DESC
+  LIMIT ?
+  ```
+
+- `GetUnsummarizedArticleCount` -- make it global (no userID); update the
+  `engine.go:1349` `PendingCounts` call. The processing-status page already
+  notes some funnel numbers are global.
+- Stats queries: at `storage.go:1429`, `:1499-1500`, `:2323` (and Postgres
+  mirrors `:1116`, `:1522-1523`, `:1608`) remove the
+  `asumm.user_id = ?` / `WHERE user_id = ?` conditions on article_summaries
+  and drop the corresponding bound args. Counts become "articles without a
+  shared summary", which is the correct new meaning.
+
+**Verify**: `go build ./...` -> FAILS with compile errors at every caller --
+that is the worklist for steps 4-6. List the errors; they must all be in
+files named in this plan's scope.
+
+### Step 4: Pipeline -- summarize globally, once per article
+
+1. `internal/pipeline/pipeline.go`: change the `AI` interface method to
+   `SummarizeArticle(ctx context.Context, title, content string,
+   maxSummaryLength int) (string, error)` (drop userID).
+2. `internal/ai/summarization.go`: drop the `userID` parameter; resolve
+   prompt and temperature with the global user exactly like `SecurityCheck`
+   does (`const globalUser = int64(0)` is declared inside `SecurityCheck`
+   in `ollama.go` -- declare the same local constant or hoist a package
+   const; match existing style).
+3. `internal/pipeline/stages.go` `summarizeOne`: replace the four
+   `s.UserID`-scoped store calls with the new per-article signatures. Update
+   the stage doc comment: summaries are global per #162, like security.
+4. `internal/pipeline/orchestrate.go`:
+   - Remove the summarize drain from `Stage.Run` (the per-user pipeline now
+     starts at curation).
+   - Add `RunSummaries(ctx) (int, error)` next to `RunSecurity`, draining
+     `GetUnsummarizedScoredArticles(s.Cfg.Thresholds.SecurityScore, limit)`
+     through `s.Summarize` -- copy `RunSecurity`'s shape and counters.
+5. `internal/pipeline/clusterstage.go:188`: `GetArticleSummary(a.ID)`.
+6. `cmd/herald/main.go` (~line 490): after
+   `securityStage.RunSecurity(ctx)`, call
+   `securityStage.RunSummaries(ctx)` with the same warning-on-error
+   handling. The comment block above the security pass (lines 486-489)
+   should now say security AND summarization are global.
+
+**Verify**: `go build ./...` -> remaining errors only in engine.go /
+handlers / migrate.go (next steps), or exit 0 if you did steps 4-6 together.
+
+### Step 5: Engine read sites and prompt policy
+
+1. `engine.go:244`, `:1111`, `:1229`: call `GetArticleSummary(articleID)`
+   (drop the userID argument; the surrounding userID stays for the other
+   per-user logic).
+2. `engine.go:1361-1368`: remove `"summarization"` from
+   `allowedPromptTypes` and extend the comment: summarization is global-only
+   as of #162 -- the admin sets it via the admin UI, which bypasses this
+   map. THEN check what the admin path needs: `handleAdminPromptSave`
+   (`cmd/herald-web/handlers.go:1658-1685`) calls
+   `e.SetPrompt(0, promptType, ...)` which consults `allowedPromptTypes`.
+   So instead of removing it from the map, change the guard in `SetPrompt`,
+   `ResetPrompt`, and `DefaultPrompt` to:
+
+   ```go
+   if !allowedPromptTypes[promptType] {
+       return fmt.Errorf("unknown or restricted prompt type: %q", promptType)
+   }
+   if promptType == "summarization" && userID != 0 {
+       return fmt.Errorf("summarization prompt is global; set it as admin")
+   }
+   ```
+
+   (`DefaultPrompt` has no userID -- leave it permissive.) `ListPrompts`
+   (`engine.go:1494`) takes a userID; make it skip "summarization" when
+   `userID != 0`.
+3. `cmd/herald-web/handlers.go:79`: split the list --
+   `userPromptTypeOrder = [curation, group_summary, newsletter]` and
+   `adminPromptTypeOrder = [curation, summarization, group_summary,
+   newsletter]`. Give `loadPromptEntries` the list as a parameter (or a
+   bool); `handleSettingsPrompts` uses the user list, `handleAdminPrompts`
+   the admin list. Keep `promptLabels` unchanged.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 6: SQLite-to-Postgres copy tool
+
+`internal/storage/migrate.go`: update `migrateArticleSummaries` -- the
+source query at `:630` becomes per-article. If the SOURCE database may still
+have the old per-user shape, the source store will already have been opened
+through `NewSQLiteStore` (which rebuilds it -- confirm this is true by
+reading how migrate.go opens the source; if it opens a raw `*sql.DB`
+instead, apply the same ROW_NUMBER dedup in the source query). Write via the
+new `UpdateArticleAISummary(dstArticleID, summary)`; drop the userMap usage
+for this table.
+
+**Verify**: `go build ./...` -> exit 0;
+`go test -race -count=1 ./internal/storage/` -> pass.
+
+### Step 7: Update existing tests
+
+Fix compile errors in test files mechanically (signature changes). Expect
+work at least in: `internal/pipeline/stages_test.go` (`TestSummarizeStage`
+and its fake AI's `SummarizeArticle`), `internal/storage/storage_test.go`,
+`cmd/herald-web/handlers_test.go` (prompt settings page assertions),
+`cmd/herald-mcp/server_test.go` (set-prompt tool: setting "summarization"
+as a non-admin user must now error -- update the expectation).
+
+**Verify**: `go test -race -count=1 ./...` -> all pass.
+
+### Step 8: Docs
+
+`grep -rn "summarization" docs/ USAGE.md README.md QUICKSTART.md` and update
+any statement that says users can customize the summarization prompt or
+that summaries are per-user. Keep edits minimal and factual.
+
+**Verify**: re-run the grep; remaining hits describe the global/admin
+prompt only.
+
+### Step 9: New tests
+
+See "Test plan". Write and run.
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Model the migration tests on `internal/storage/security_perarticle_test.go`
+(`TestSecurityBackfillFromReadState` builds an old-schema DB with raw SQL,
+then opens the store and asserts the migrated shape;
+`TestSecurityVerdictSharedAcrossUsers` asserts cross-user sharing). New
+cases:
+
+1. **Migration picks the right row**: old-schema `article_summaries` with,
+   for one article: user 2 -> real summary, user 1 -> skip marker
+   (`ai_summary = ''`, skip_reason set). After `NewSQLiteStore`, exactly one
+   row per article and the REAL summary won (user 2's text), proving the
+   "(ai_summary = '') ASC" sort outranks the lower user_id.
+2. **Migration is idempotent**: open the store twice on the same file; second
+   open succeeds and row counts are unchanged.
+3. **Summary shared across users**: two users subscribed to one feed; write
+   a summary for an article; `GetArticleSummary(articleID)` returns it and
+   `GetUnsummarizedScoredArticles` no longer returns that article (it would
+   have, per-user, before).
+4. **Pipeline summarizes once** (`internal/pipeline/stages_test.go` /
+   orchestrate test): with a fake AI that counts calls, two subscribing
+   users plus `RunSummaries` -> exactly one `SummarizeArticle` call per
+   article; the per-user `Run` makes none.
+5. **Prompt policy**: `SetPrompt(realUserID, "summarization", ...)` ->
+   error; `SetPrompt(0, "summarization", ...)` -> success;
+   `ListPrompts(realUserID)` omits "summarization"; `ListPrompts(0)`
+   includes it.
+6. **Skip markers shared**: `MarkSummarizationSkipped(articleID, reason)`
+   keeps the article out of `GetUnsummarizedScoredArticles` (no per-user
+   retry).
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -rn "asumm.user_id\|article_summaries WHERE user_id" --include='*.go' internal/` -> no matches
+- [ ] `grep -n "user_id" internal/storage/schema.go` shows NO user_id in the article_summaries block
+- [ ] `grep -rn "SummarizeArticle(ctx, s.UserID" internal/pipeline/` -> no matches
+- [ ] `Stage.Run` in orchestrate.go contains no summarize drain; `RunSummaries` exists and is called from `cmd/herald/main.go`
+- [ ] Migration tests (old-schema fixture) pass; opening the store twice is idempotent
+- [ ] `git status` shows no modified files outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The `article_summaries` schema or any excerpt above does not match the
+  live code (drift -- especially if plan 001 landed with unexpected overlap).
+- `ROW_NUMBER() OVER` fails under modernc.org/sqlite in tests (window
+  function support gap) -- report; a GROUP BY fallback needs design sign-off.
+- You find a code path where two users genuinely receive DIFFERENT
+  summarization output for the same article today other than via the
+  per-user prompt (e.g. per-user model overrides changing output) -- the
+  "summaries are identical in practice" premise would be wrong; report what
+  you found.
+- migrate.go opens the source DB without going through `NewSQLiteStore` AND
+  the dedup-in-query fallback in step 6 starts exceeding a few lines of
+  change -- report instead of redesigning the tool.
+- Removing the summarize drain from `Stage.Run` breaks an ordering
+  assumption in `clusterRecent` or curation (tests reveal articles reaching
+  curation without summaries where a stage required them).
+
+## Maintenance notes
+
+- Reviewer should scrutinize: the migration's pick-one semantics (real
+  summary preferred over skip marker), Postgres parity of every query
+  change, and that the DIGEST tables (`ai_summaries`, newsletters) were not
+  touched.
+- The `generated_at` of the surviving row is the original generation time of
+  whichever copy won -- acceptable; do not refresh it.
+- If per-user summary STYLE is ever wanted again, do not re-add user_id
+  here; layer it as a per-user rendering of the shared summary or revisit
+  option (c) from the audit (prompt-fingerprint keying).
+- Follow-up deferred: `GetUnsummarizedScoredArticles` could use a partial
+  index like `idx_articles_unscreened` if the queue scan shows up in
+  profiles; not needed at current scale.

--- a/plans/003-subscription-gate-article-access.md
+++ b/plans/003-subscription-gate-article-access.md
@@ -1,0 +1,269 @@
+# Plan 003: Gate direct article and image access by feed subscription
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 62f949e..HEAD -- engine.go internal/storage/store.go internal/storage/storage.go internal/storage/postgres.go cmd/herald-web/handlers.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition. EXCEPTION: if plans 001/002 landed
+> first, their changes to these files are expected -- verify only that the
+> specific excerpts below still match.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: 001 (soft -- same files; land 001 first to avoid collisions)
+- **Category**: security
+- **Planned at**: commit `62f949e`, 2026-06-12
+
+## Why this matters
+
+Articles and their cached images are globally readable by any authenticated
+user who knows (or enumerates) a small integer ID, regardless of feed
+subscription. Herald fetches capability-URL feeds today (Patreon member RSS,
+premium podcast feeds, GitHub token feeds) -- they are plain URLs -- so one
+user's private feed content is currently readable by every user on the
+instance. The decided policy: an article is visible to a user only if they
+are subscribed to its feed. All LIST surfaces (unread, search, starred,
+groups, Fever) already enforce exactly this via `user_feeds` joins; this
+plan makes the three direct-ID paths match.
+
+## Current state
+
+The list surfaces already scope by subscription -- e.g.
+`GetStarredArticles` (`internal/storage/storage.go`, search for the
+function) does `JOIN user_feeds uf ... WHERE uf.user_id = ?`. The holes are
+the direct-ID paths:
+
+`engine.go:237-248` -- loads any article with no subscription check:
+
+```go
+// GetArticleForUser returns a single article enriched with its AI summary for the given user.
+func (e *Engine) GetArticleForUser(userID, articleID int64) (*Article, error) {
+	a, err := e.store.GetArticle(articleID)
+	if err != nil {
+		return nil, err
+	}
+	result := articleFromInternal(*a)
+	if summary, err := e.store.GetArticleSummary(userID, articleID); err == nil && summary != nil {
+		result.AISummary = summary.AISummary
+	}
+	return &result, nil
+}
+```
+
+(If plan 002 landed first, the `GetArticleSummary` call takes only
+`articleID` -- that is fine, the function shape is otherwise the same.)
+
+`cmd/herald-web/handlers.go:1294-1309` -- `handleArticleImage` serves any
+cached image by ID with no ownership chain:
+
+```go
+func (h *handlers) handleArticleImage(w http.ResponseWriter, r *http.Request) {
+	imageID, err := strconv.ParseInt(r.PathValue("imageID"), 10, 64)
+	...
+	img, err := h.engine.GetArticleImage(imageID)
+```
+
+The storage type already carries what we need --
+`internal/storage/storage.go:2935-2944`: `ArticleImage` has an `ArticleID`
+field, and `GetArticleImage` scans it.
+
+`engine.go:1605-1607` -- starring is ungated (and a starred row on an
+unsubscribed article is invisible anyway, since `GetStarredArticles`
+requires the subscription join -- gating the write keeps state clean and
+closes any future "starred grants access" loophole):
+
+```go
+func (e *Engine) StarArticle(userID, articleID int64, starred bool) error {
+	return e.store.UpdateStarred(userID, articleID, starred)
+}
+```
+
+Engine consumers of `GetArticleForUser`: `cmd/herald-web/handlers.go`
+(`handleArticleView`, which renders 404 "Article not found" on error) and
+`cmd/herald-mcp/server.go:142` (get-article tool). Both get the new
+behavior for free; the MCP tool returning an error for unsubscribed
+articles is desired.
+
+Deliberately NOT gated (document, don't change):
+
+- `MarkArticleRead`/`MarkArticlesRead` -- writes only to the caller's own
+  read_state; rows for unsubscribed articles are invisible everywhere.
+  Gating would add a query per Fever mark with no security benefit.
+- `GET /feeds/{feedID}/favicon` -- a site icon is not content.
+- `GetArticle` (no-user variant) -- daemon/pipeline internal use.
+
+Conventions: storage methods live in BOTH `internal/storage/storage.go` and
+`internal/storage/postgres.go` plus the `Store` interface in
+`internal/storage/store.go`. Errors wrap with `fmt.Errorf("...: %w", err)`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `internal/storage/store.go`, `internal/storage/storage.go`,
+  `internal/storage/postgres.go` (one new method)
+- `engine.go` (`GetArticleForUser`, `StarArticle`, new
+  `GetArticleImageForUser`)
+- `cmd/herald-web/handlers.go` (`handleArticleImage` only)
+- Test files: `cmd/herald-web/handlers_test.go`, `engine_test.go` or
+  `internal/storage/storage_test.go` as fits
+
+**Out of scope** (do NOT touch):
+
+- Every list query (`GetUnreadArticlesForUser`, `SearchArticlesFTS`,
+  `GetStarredArticles`, Fever queries) -- already scoped.
+- `MarkArticleRead`, favicon and feed-metadata handlers -- see "deliberately
+  not gated".
+- `cmd/herald-mcp/server.go` -- behavior changes via the engine; no code
+  change needed there.
+
+## Git workflow
+
+- Branch: `fix/subscription-gate-articles` (or as the operator directs).
+- Small commits; subject style e.g.
+  `Gate direct article and image access by subscription (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Storage -- UserSubscribedToArticleFeed
+
+Add to the `Store` interface and both backends:
+
+```go
+// UserSubscribedToArticleFeed reports whether the user is subscribed to the
+// feed that owns the article. Unknown article IDs return false, nil.
+UserSubscribedToArticleFeed(userID, articleID int64) (bool, error)
+```
+
+SQLite/Postgres implementation (identical SQL):
+
+```sql
+SELECT EXISTS(
+    SELECT 1 FROM articles a
+    JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = ?
+    WHERE a.id = ?
+)
+```
+
+Scan into a bool (SQLite returns 0/1 -- `Scan(&subscribed)` into a `bool`
+works with modernc.org/sqlite; match how other EXISTS-style helpers in the
+file scan, if any).
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 2: Engine -- gate the three paths
+
+1. `GetArticleForUser`: before loading the article, call
+   `e.store.UserSubscribedToArticleFeed(userID, articleID)`; on false (or
+   error) return `fmt.Errorf("article %d not found for user %d", articleID,
+   userID)`. The web handler already maps any error to 404.
+2. `StarArticle`: same check; on false return
+   `fmt.Errorf("article %d not found for user %d", articleID, userID)`.
+3. New method `GetArticleImageForUser(userID, imageID int64)
+   (*storage.ArticleImage, error)`: load via `e.store.GetArticleImage`
+   (keep its nil-on-missing contract), then check
+   `UserSubscribedToArticleFeed(userID, img.ArticleID)`; return `nil, nil`
+   on no access (indistinguishable from missing -- the handler 404s).
+   Keep the existing `GetArticleImage` method for any internal callers; run
+   `grep -rn "GetArticleImage(" --include='*.go' .` -- if the web handler is
+   its only engine-level caller, you may remove the engine wrapper
+   `GetArticleImage` after switching the handler (do not remove the storage
+   method).
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 3: Web handler
+
+`handleArticleImage`: resolve `uid := userFromContext(r.Context()).ID` and
+call `h.engine.GetArticleImageForUser(uid, imageID)`; keep the existing
+nil/error -> `http.NotFound` handling and the cache headers. Note the
+response carries `Cache-Control: public, max-age=2592000` -- images the
+user CAN see remain cacheable; that is fine because the 404-vs-200 decision
+happens per request before any body is written.
+
+**Verify**: `go build ./...` -> exit 0; `go test -race -count=1
+./cmd/herald-web/` -> existing tests pass (the smoke fixture user is
+subscribed to feed 1, whose article 1/image 1 the probes use -- they should
+keep passing; if a smoke probe fails, check whether the fixture's user owns
+the probed resource before changing anything, then STOP if it does not).
+
+### Step 4: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Model on the two-user pattern in `cmd/herald-web/handlers_test.go` (the
+`fakeOIDCProvider` harness mints tokens for arbitrary subs; plan 001 added
+cross-user examples if it landed first). Cases:
+
+1. **Article view gated**: user A subscribed to feed F with article X; user
+   B (not subscribed) requests `GET /articles/X` -> 404; user A -> 200.
+2. **Image gated**: image I belongs to article X; B requests
+   `GET /images/I` -> 404; A -> 200 with the image MIME type.
+3. **Star gated** (engine or web level): B posts
+   `POST /articles/X/star` -> error/500-or-404 path, and B has no starred
+   row for X; A starring X succeeds.
+4. **Unknown IDs**: `GET /articles/999999` and `GET /images/999999` -> 404
+   for everyone (no panic, no 500).
+5. **Storage helper**: `UserSubscribedToArticleFeed` true for subscriber,
+   false for non-subscriber, false for nonexistent article.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -n "UserSubscribedToArticleFeed" internal/storage/store.go internal/storage/storage.go internal/storage/postgres.go` -> 1 match per file (plus call sites)
+- [ ] `grep -n "GetArticleImageForUser" cmd/herald-web/handlers.go` -> the image handler uses the user-scoped method
+- [ ] New tests from the test plan exist and pass
+- [ ] `git status` shows no modified files outside the in-scope list
+- [ ] `plans/README.md` status row updated (unless the reviewer maintains it)
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The excerpts in "Current state" do not match the live code beyond the
+  expected plan-001/002 deltas described in the drift-check exception.
+- The smoke harness (`TestSmokeRoutesAuthenticated`) fails because its
+  fixture user does not own the probed article/image -- fixing the fixture
+  is a judgment call about test infrastructure; report instead.
+- Gating `StarArticle` breaks a Fever client flow in tests (Fever mark
+  "saved" goes through `StarArticle`) -- if a test shows Fever clients
+  legitimately star articles the user cannot access, report; the policy may
+  need a Fever exception.
+
+## Maintenance notes
+
+- Reviewer should scrutinize: that the EXISTS query uses the article's feed
+  (not a parameter feed ID), and Postgres parity.
+- Any future direct-ID endpoint over article-derived data (e.g. a future
+  per-article API) must call `UserSubscribedToArticleFeed` -- this helper is
+  the single point of policy.
+- If feed-level sharing/visibility flags are ever added (public vs private
+  feeds), this helper is where the policy extends.
+- Deliberately not gated (recorded above): mark-read writes, favicons, the
+  daemon's no-user article accessors.

--- a/plans/004-egress-ssrf-hardening.md
+++ b/plans/004-egress-ssrf-hardening.md
@@ -1,0 +1,363 @@
+# Plan 004: Block SSRF on every outbound fetch with one hardened HTTP client
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 73ca920..HEAD -- internal/feeds/ engine.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P0 -- RELEASE-BLOCKING for public deployment
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `73ca920`, 2026-06-12
+
+## Why this matters
+
+Herald is becoming a public service: anyone can sign up and subscribe to
+feeds, and feed *content* (article links, image `src` URLs) is authored by
+whoever runs any feed Herald fetches -- attacker-controllable even by
+non-users. Today every outbound HTTP fetch uses a bare `http.Client{}` with
+no restriction on the destination address. A user subscribing to
+`http://127.0.0.1:6379/` or `http://169.254.169.254/latest/meta-data/`, or a
+feed author embedding `<img src="http://192.168.x.x/...">`, makes Herald issue
+requests from inside the homelab to internal services and cloud-metadata
+endpoints (classic SSRF). The default client also follows redirects, so a
+public URL can 302 to an internal one, and there is no response-size cap on
+feed bodies (a multi-GB response is read fully into memory). This plan routes
+every outbound fetch through one shared, hardened client that blocks
+private/loopback/link-local destinations at dial time (which also defeats DNS
+rebinding and redirect-to-internal), restricts schemes to http/https, caps
+response size, and sets a timeout.
+
+## Current state
+
+All feed fetching lives in `internal/feeds/`. There is one `Fetcher` struct
+with a shared client, plus a few functions that build their own client when
+passed `nil`.
+
+- `internal/feeds/fetcher.go:70-79` -- `NewFetcher` builds the shared client
+  with no hardening:
+
+```go
+func NewFetcher(store storage.Store) *Fetcher {
+	parser := gofeed.NewParser()
+	parser.UserAgent = FeedUserAgent
+	return &Fetcher{
+		parser: parser,
+		client: &http.Client{},
+		store:  store,
+	}
+}
+```
+
+- The `Fetcher.client` (field on the struct, `internal/feeds/fetcher.go:47`)
+  is reused by feed fetch (`fetcher.go:106` `f.client.Do(req)`), discovery
+  (`discovery.go:74`), full-text (`fulltext.go:97,117` pass `f.client`), and
+  images (`images.go:172,190` pass `f.client`), and favicons
+  (`favicon.go:44` passes `f.client`).
+- Two helpers build a fallback client when the passed client is `nil`:
+  - `internal/feeds/fulltext.go:316-318`:
+    `httpClient = &http.Client{Timeout: 20 * time.Second}`
+  - `internal/feeds/images.go:108-110`: `httpClient = &http.Client{}`
+- Response-size caps are present in some paths and absent in others:
+  - PRESENT: `discovery.go:84` (4 MB), `images.go:128` (64 KB),
+    `images.go:267` (`maxImageBytes+1`), `favicon.go:111` (512 KB),
+    `favicon.go:176` (`maxFaviconBytes`).
+  - ABSENT: `fetcher.go:120` -- `body, err := io.ReadAll(resp.Body)` reads the
+    entire feed body with no cap; `fulltext.go` passes `resp.Body` to the
+    readability parser with no `io.LimitReader`.
+- `internal/feeds/fetcher.go:155-200` -- `importOPMLBytes` adds every
+  `outline.XMLURL` from an uploaded OPML file straight to the feeds table via
+  `f.store.AddFeed(outline.XMLURL, ...)` with no URL validation; those URLs
+  are fetched on the next cycle.
+- `engine.go:643` -- `feedURLCandidates(input string) []string` is where a
+  user-supplied subscribe URL is turned into candidate URLs (adds
+  `https://`/`http://` when no scheme). This is the natural place to reject
+  non-http(s) schemes before a fetch is attempted.
+
+Conventions: `internal/feeds` is a self-contained package; errors wrap with
+`fmt.Errorf("...: %w", err)`. Tests live beside the code
+(`fetcher_test.go`, `images_test.go`, etc.) and use `httptest.Server`. No
+external test network access -- everything is served by local `httptest`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests (package) | `go test -race -count=1 ./internal/feeds/` | all pass |
+| Tests (all) | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `internal/feeds/safedial.go` (CREATE) -- the hardened dialer/client + a URL
+  scheme/host guard helper.
+- `internal/feeds/safedial_test.go` (CREATE) -- unit tests for the guard.
+- `internal/feeds/fetcher.go` -- use the hardened client in `NewFetcher`; add
+  a response-size cap in `FetchFeed`; validate URLs in `importOPMLBytes`.
+- `internal/feeds/fulltext.go`, `internal/feeds/images.go` -- replace the
+  `nil`-fallback `http.Client{}` constructions with the hardened client; add a
+  size cap to the full-text read.
+- `engine.go` -- reject non-http(s) schemes in `feedURLCandidates` (or its
+  caller `SubscribeFeed`).
+- Test files in `internal/feeds/` as needed.
+
+**Out of scope** (do NOT touch):
+- `internal/ai/` clients (Ollama / cloud summary). Those talk to an
+  operator-configured backend, not user/feed-supplied URLs; a separate plan
+  may add a config-time check. Do not add SSRF dialing there.
+- The existing size caps that are already present (discovery, images,
+  favicons) -- leave their limits as-is; only ADD caps where absent.
+- Any change to feed PARSING (gofeed) or HTML sanitization.
+- Proxy support / `HTTP_PROXY` handling.
+
+## Git workflow
+
+- Branch: `advisor/004-egress-ssrf-hardening` (or as the operator directs).
+- Small commits; subject style e.g.
+  `Route feed fetches through an SSRF-guarded HTTP client (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Create the hardened dialer and client
+
+Create `internal/feeds/safedial.go`. It must export a constructor that returns
+an `*http.Client` whose transport rejects connections to non-public IPs **at
+dial time** (so DNS rebinding and redirect-to-internal are both caught, since
+every dial -- including redirect targets -- is checked after DNS resolution).
+
+Target shape:
+
+```go
+package feeds
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// isDisallowedIP reports whether an IP must not be dialed: loopback,
+// link-local (incl. 169.254.0.0/16 and fe80::/10), private (RFC1918 /
+// fc00::/7 ULA), unspecified, and multicast. Public unicast addresses pass.
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
+		ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// safeControl is a net.Dialer Control hook: it runs after DNS resolution,
+// once per resolved address, with the concrete IP:port about to be dialed.
+// Returning an error aborts that dial.
+func safeControl(network, address string, c syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("safedial: bad address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("safedial: non-IP dial target %q", host)
+	}
+	if isDisallowedIP(ip) {
+		return fmt.Errorf("safedial: refusing to dial non-public address %s", ip)
+	}
+	return nil
+}
+
+// newSafeClient returns an http.Client that refuses non-public destinations
+// (checked at dial time, so redirects and DNS rebinding are covered), allows
+// only http/https, and applies the given overall timeout.
+func newSafeClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{Timeout: 10 * time.Second, Control: safeControl}
+	transport := &http.Transport{
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("safedial: stopped after 10 redirects")
+			}
+			if s := req.URL.Scheme; s != "http" && s != "https" {
+				return fmt.Errorf("safedial: refusing redirect to scheme %q", s)
+			}
+			return nil
+		},
+	}
+}
+```
+
+Add the `syscall` import. Note: `net.Dialer.Control` runs after DNS resolution
+with the literal IP, so it is the correct rebinding-safe hook -- do NOT
+validate by parsing the URL string alone.
+
+Also add a scheme guard used before a fetch is even attempted:
+
+```go
+// allowedFetchScheme reports whether a URL scheme may be fetched.
+func allowedFetchScheme(scheme string) bool {
+	return scheme == "http" || scheme == "https"
+}
+```
+
+**Verify**: `go build ./internal/feeds/` -> exit 0.
+
+### Step 2: Use the hardened client everywhere in the fetcher
+
+1. In `NewFetcher` (`fetcher.go:70-79`), replace `client: &http.Client{}` with
+   `client: newSafeClient(30 * time.Second)`.
+2. In `fulltext.go:316-318`, replace the `nil`-fallback
+   `&http.Client{Timeout: 20 * time.Second}` with
+   `newSafeClient(20 * time.Second)`.
+3. In `images.go:108-110`, replace the `nil`-fallback `&http.Client{}` with
+   `newSafeClient(30 * time.Second)`.
+
+**Verify**: `go build ./...` -> exit 0; then
+`grep -rn 'http.Client{' internal/feeds/` -> returns ONLY matches inside
+`safedial.go` (no other `http.Client{}` literal remains in the package).
+
+### Step 3: Add the missing response-size caps
+
+1. In `FetchFeed` (`fetcher.go:120`), replace
+   `body, err := io.ReadAll(resp.Body)` with a capped read:
+
+```go
+const maxFeedBytes = 10 << 20 // 10 MB: generous for RSS/Atom; bounds memory.
+body, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedBytes))
+```
+
+2. In `fulltext.go`, the readability parse reads `resp.Body` unbounded
+   (around `fetchReadableContent`, `fulltext.go:304-340`). Wrap the body in an
+   `io.LimitReader` before handing it to the parser:
+
+```go
+const maxArticleBytes = 10 << 20 // 10 MB cap for full-text extraction.
+// ... pass io.LimitReader(resp.Body, maxArticleBytes) to the readability call.
+```
+
+Read the function first and adapt to its exact variable names; keep the
+existing `defer resp.Body.Close()` and error handling.
+
+**Verify**: `go build ./...` -> exit 0;
+`grep -n 'io.ReadAll(resp.Body)' internal/feeds/fetcher.go` -> no matches
+(the feed read is now wrapped in `io.LimitReader`).
+
+### Step 4: Validate URLs at the subscribe and OPML-import boundaries
+
+1. In `engine.go`, reject non-http(s) schemes before fetching. The cleanest
+   point is `feedURLCandidates` (`engine.go:643`): after building each
+   candidate, parse it with `url.Parse` and drop any whose scheme is not
+   http/https (use the package-local check from feeds if exported, or inline
+   the same `scheme == "http" || scheme == "https"` test -- do NOT import an
+   internal symbol that creates a cycle; engine already imports
+   `internal/feeds`, so `feeds.AllowedFetchScheme` is fine if you export it).
+   A `file://`, `gopher://`, or `ftp://` candidate must never become a fetch.
+2. In `importOPMLBytes` (`fetcher.go:155-200`), before
+   `f.store.AddFeed(outline.XMLURL, ...)`, parse `outline.XMLURL` and skip
+   (log a warning, `continue`) any entry whose scheme is not http/https. Do
+   NOT fail the whole import for one bad entry -- match the existing
+   warn-and-continue style at `fetcher.go:189`.
+
+Note: the dial-time guard in Step 1 already blocks private *addresses* even if
+a bad URL slips through; this step rejects bad *schemes* early and keeps junk
+out of the feeds table.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 5: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Add `internal/feeds/safedial_test.go`:
+
+1. **`isDisallowedIP` table test**: assert true for `127.0.0.1`, `::1`,
+   `169.254.169.254`, `10.0.0.1`, `192.168.1.1`, `172.16.0.1`, `fc00::1`,
+   `0.0.0.0`; assert false for `8.8.8.8`, `1.1.1.1`, a public IPv6.
+2. **`allowedFetchScheme`**: true for http/https; false for `file`, `ftp`,
+   `gopher`, ``.
+3. **Dial refusal (integration)**: build a client with `newSafeClient`, then
+   `client.Get("http://127.0.0.1:<port>/")` against a local `httptest.Server`
+   and assert the request FAILS with an error mentioning "non-public" (the
+   dial control rejects loopback). This proves the guard fires even for a
+   real listener. (httptest binds to loopback, which is exactly what must be
+   refused -- so a failure here is the success condition.)
+4. **Size cap**: add a feeds-package test that serves an oversized body from
+   an `httptest.Server` *bound to a public-looking path via the existing test
+   pattern*; if the existing feed tests already hit `httptest` loopback URLs
+   and would now be blocked by the dial guard, see the STOP condition below.
+
+Model new tests on the existing `internal/feeds/fetcher_test.go` /
+`images_test.go` structure (they use `httptest.NewServer`).
+
+Verification: `go test -race -count=1 ./internal/feeds/` -> all pass,
+including the new `safedial_test.go` cases.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -rn 'http.Client{' internal/feeds/` -> matches only in `safedial.go`
+- [ ] `grep -n 'io.ReadAll(resp.Body)' internal/feeds/fetcher.go` -> no matches
+- [ ] `internal/feeds/safedial.go` and `safedial_test.go` exist; new tests pass
+- [ ] `git status` shows no modified files outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The existing `internal/feeds` tests use `httptest.NewServer` (which binds to
+  127.0.0.1) and now FAIL because the dial guard refuses loopback. This is the
+  expected tension between "block loopback in prod" and "tests hit loopback."
+  Do NOT weaken the guard globally. Report it; the intended resolution is a
+  test-only injection seam (e.g. an unexported `dialControl` field or a
+  package var the tests can swap to a permissive control), so production stays
+  locked down while tests can target loopback. Pick the seam, note it, and
+  proceed only if it keeps the production default strict.
+- `feedURLCandidates` turns out NOT to be the only path that constructs
+  subscribe URLs (grep `feedURLCandidates` callers) -- if another path bypasses
+  it, report rather than guessing where to add the scheme check.
+- Adding `MaxConnsPerHost` or per-host limits seems necessary -- that is a
+  separate concern (a malicious-but-public slow host); note it as a follow-up,
+  do not expand this plan's scope.
+
+## Maintenance notes
+
+- The dial-time `Control` hook is the single source of SSRF policy. Any NEW
+  outbound fetch added to Herald (feeds or elsewhere that handles
+  user/feed-supplied URLs) must use `newSafeClient`, not `http.Client{}`. Call
+  that out in review.
+- Reviewer should scrutinize: that the guard is at DIAL time (not URL-string
+  parsing), that redirects are re-checked (they are, because each redirect
+  hop dials again through the same Control hook), and that the test seam (if
+  added per the STOP condition) cannot be triggered in production.
+- Deferred: per-host connection/rate limits against slow *public* hosts; a
+  config-time validation of the Ollama/cloud `base_url` (operator-supplied, so
+  low risk). Both recorded in `plans/README.md`.

--- a/plans/005-per-user-resource-quotas.md
+++ b/plans/005-per-user-resource-quotas.md
@@ -1,0 +1,288 @@
+# Plan 005: Cap per-user feeds, filter rules, and newsletters
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 73ca920..HEAD -- engine.go internal/storage/config.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (independent of 004)
+- **Category**: security (abuse / resource exhaustion)
+- **Planned at**: commit `73ca920`, 2026-06-12
+
+## Why this matters
+
+Herald is going public with free self-signup. Three per-user resources have
+no creation limit today: feed subscriptions, filter rules, and newsletters. A
+single account can subscribe to tens of thousands of feeds -- and because the
+fetch loop is shared (the daemon fetches the *union* of all users'
+subscriptions), one abusive account inflates fetch-cycle time and AI work for
+everyone, not just itself. Unbounded filter rules also slow that user's
+scoring queries. This plan adds configurable per-user caps enforced at
+creation time, returning a clear error when a limit is reached. The caps are
+generous (a normal user never hits them) and exist only to stop abuse.
+
+## Current state
+
+The three creation methods on `Engine` perform no count check:
+
+- `engine.go:658` -- `SubscribeFeed(userID int64, rawURL, title string) error`
+  fetches and stores; no check on how many feeds the user already has.
+- `engine.go:1713` -- `AddFilterRule(userID int64, rule FilterRule) (int64, error)`:
+
+```go
+func (e *Engine) AddFilterRule(userID int64, rule FilterRule) (int64, error) {
+	if !allowedFilterAxes[rule.Axis] {
+		return 0, fmt.Errorf("invalid filter axis: %q (must be author, category, or tag)", rule.Axis)
+	}
+	if rule.Value == "" {
+		return 0, fmt.Errorf("filter rule value cannot be empty")
+	}
+	// ... builds storage.FilterRule and calls e.store.AddFilterRule(sr)
+}
+```
+
+- `engine.go:981` -- `CreateNewsletter(userID int64, name, schedule, emailRecipient, promptTemplate string, config storage.NewsletterConfig) (int64, error)`:
+
+```go
+func (e *Engine) CreateNewsletter(userID int64, name, schedule, emailRecipient, promptTemplate string, config storage.NewsletterConfig) (int64, error) {
+	if config.MaxArticles == 0 {
+		config.MaxArticles = 20
+	}
+	return e.store.CreateNewsletter(&storage.Newsletter{ ... })
+}
+```
+
+Existing per-user getters that return the current set (use these to count --
+do NOT add new Store methods):
+
+- `engine.go:570` -- `GetUserFeeds(userID int64) ([]Feed, error)`
+- `engine.go:1731` -- `GetFilterRules(userID int64, feedID *int64) ([]FilterRule, error)`
+  (pass `nil` for feedID to get all the user's rules)
+- `engine.go:1019` -- `GetUserNewsletters(userID int64) ([]storage.Newsletter, error)`
+
+Config lives in `internal/storage/config.go`. The `Config` struct
+(`config.go:5`) has sections like `Ollama`, `Thresholds`, etc., and
+`DefaultConfig()` (`config.go:103`) sets defaults. There is no `Limits`
+section yet. Engine reads config via `e.cfg` / its stored `*storage.Config`
+(grep `e.cfg` or how `Engine` holds config to confirm the field name before
+referencing it).
+
+Conventions: engine methods return wrapped errors with
+`fmt.Errorf(...)`; web handlers map an error from these methods to a 400-ish
+response already (the filter/subscribe handlers render the error string). A
+returned error is sufficient -- no new HTTP plumbing needed.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests (engine) | `go test -race -count=1 .` | all pass |
+| Tests (all) | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `internal/storage/config.go` -- add a `Limits` struct + defaults.
+- `engine.go` -- count-and-reject in `SubscribeFeed`, `AddFilterRule`,
+  `CreateNewsletter`.
+- `engine_test.go` (or the existing engine test file) -- quota tests.
+
+**Out of scope** (do NOT touch):
+- Article groups -- they are created by the clustering pipeline, not by users,
+  so there is no user-facing create path to cap. Do not add a group quota.
+- Storage layer / `Store` interface -- reuse the existing getters; add no new
+  methods or queries.
+- Read-state / interest-score rows -- those are bounded by article count, not
+  user action.
+- Admin stats pagination -- tracked separately (see Maintenance notes); not in
+  this plan.
+
+## Git workflow
+
+- Branch: `advisor/005-per-user-resource-quotas`.
+- Small commits; subject e.g. `Cap per-user feed subscriptions (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Add a Limits config section with generous defaults
+
+In `internal/storage/config.go`, add to the `Config` struct (place it after
+`Thresholds`):
+
+```go
+	Limits struct {
+		MaxFeedsPerUser       int `yaml:"max_feeds_per_user"`
+		MaxFilterRulesPerUser int `yaml:"max_filter_rules_per_user"`
+		MaxNewslettersPerUser int `yaml:"max_newsletters_per_user"`
+	} `yaml:"limits"`
+```
+
+In `DefaultConfig()` (`config.go:103`), set defaults:
+
+```go
+	cfg.Limits.MaxFeedsPerUser = 1000
+	cfg.Limits.MaxFilterRulesPerUser = 1000
+	cfg.Limits.MaxNewslettersPerUser = 50
+```
+
+Semantics: a limit `<= 0` means "unbounded" (so an operator can disable a cap
+by setting 0). Enforce that semantics in Step 2.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 2: Enforce the caps at creation time
+
+First confirm how `Engine` accesses config: grep `engine.go` for the config
+field (likely `e.cfg` of type `*storage.Config`). Use that field; if the
+engine does not already hold the config, STOP (see STOP conditions) -- do not
+add a new field without confirming the wiring.
+
+Add a small helper near the other engine helpers:
+
+```go
+// overQuota returns a non-nil error if have >= limit, treating limit <= 0 as
+// unbounded. resource is used in the message ("feeds", "filter rules", ...).
+func overQuota(resource string, have, limit int) error {
+	if limit > 0 && have >= limit {
+		return fmt.Errorf("%s limit reached (%d); delete some before adding more", resource, limit)
+	}
+	return nil
+}
+```
+
+1. `SubscribeFeed` (`engine.go:658`): at the very top, before the fetch,
+
+```go
+	existing, err := e.GetUserFeeds(userID)
+	if err != nil {
+		return fmt.Errorf("check feed quota: %w", err)
+	}
+	if err := overQuota("feed", len(existing), e.cfg.Limits.MaxFeedsPerUser); err != nil {
+		return err
+	}
+```
+
+(Counting before the network fetch also avoids wasting a fetch when the user
+is already at the cap.)
+
+2. `AddFilterRule` (`engine.go:1713`): after the existing axis/value
+   validation, before building `sr`:
+
+```go
+	existing, err := e.GetFilterRules(userID, nil)
+	if err != nil {
+		return 0, fmt.Errorf("check filter rule quota: %w", err)
+	}
+	if err := overQuota("filter rule", len(existing), e.cfg.Limits.MaxFilterRulesPerUser); err != nil {
+		return 0, err
+	}
+```
+
+3. `CreateNewsletter` (`engine.go:981`): at the top,
+
+```go
+	existing, err := e.GetUserNewsletters(userID)
+	if err != nil {
+		return 0, fmt.Errorf("check newsletter quota: %w", err)
+	}
+	if err := overQuota("newsletter", len(existing), e.cfg.Limits.MaxNewslettersPerUser); err != nil {
+		return 0, err
+	}
+```
+
+Adapt the exact config field path to whatever Step 2's grep confirmed.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 3: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Add to the engine test file (find it: `ls engine_test.go` or
+`grep -rln "func TestSubscribeFeed\|NewEngine(" *_test.go`). Model on the
+existing engine tests' setup (they construct an `Engine` against an in-memory
+or temp SQLite store).
+
+Cases:
+1. **Feed quota**: construct an engine whose config sets
+   `Limits.MaxFeedsPerUser = 2`; subscribe two feeds (use a local
+   `httptest.Server` serving a minimal valid RSS doc, matching how existing
+   subscribe tests work); assert the third `SubscribeFeed` returns an error
+   containing "limit reached" and that `GetUserFeeds` still returns 2.
+2. **Filter-rule quota**: set `MaxFilterRulesPerUser = 1`; first `AddFilterRule`
+   succeeds, second returns the limit error.
+3. **Newsletter quota**: set `MaxNewslettersPerUser = 1`; first succeeds,
+   second returns the limit error.
+4. **Unbounded**: set a limit to `0`; assert creation past the would-be cap
+   succeeds (limit 0 = unbounded).
+
+If the existing subscribe tests don't already have an `httptest` RSS fixture
+to copy, reuse the one in `internal/feeds` tests as a structural reference.
+
+Verification: `go test -race -count=1 .` -> all pass including the new quota
+tests.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -n "Limits" internal/storage/config.go` -> struct + 3 defaults
+- [ ] `grep -n "limit reached" engine.go` -> the `overQuota` helper
+- [ ] New quota tests exist and pass (feed, filter, newsletter, unbounded)
+- [ ] `git status` shows no files modified outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `Engine` does not already hold a `*storage.Config` (or equivalent) you can
+  read the limits from. Adding config wiring through the constructor is a
+  larger change -- report how the engine currently gets thresholds/config and
+  let the reviewer choose the seam, rather than inventing one.
+- A creation path is reachable that does NOT go through these three engine
+  methods (e.g. a bulk OPML import that subscribes many feeds at once --
+  `grep -n "SubscribeUserToFeed" .`). If OPML import bypasses the feed cap,
+  report it: the policy decision (cap OPML imports too, or exempt them) is the
+  operator's, not yours.
+- The web handlers turn these engine errors into a 500 rather than a 4xx
+  (check the subscribe/filter/newsletter handlers map the error to a
+  client-facing message). If they 500, note it -- a quota rejection should be
+  a 400/409, and that may belong in plan 007's error-handling work.
+
+## Maintenance notes
+
+- Defaults are deliberately generous; tune in config, not code. `limit <= 0`
+  disables a cap.
+- A future per-user article-group cap is intentionally omitted (groups are
+  pipeline-created). If user-created groups are ever added, add a cap then.
+- Deferred to a separate concern (NOT this plan): paginating the admin stats
+  page (`GetDBStats` / `handleAdminStats`) so a large feed union doesn't render
+  unbounded. It is admin-only and self-inflicted; record it in the index as a
+  small follow-up.
+- Reviewer should scrutinize: the count-before-create has a benign TOCTOU
+  (two concurrent creates could both pass at the boundary). That is acceptable
+  for an abuse cap -- it bounds order-of-magnitude growth, not exact counts. Do
+  not add locking.

--- a/plans/006-global-llm-concurrency-ceiling.md
+++ b/plans/006-global-llm-concurrency-ceiling.md
@@ -1,0 +1,321 @@
+# Plan 006: Bound concurrent LLM calls with a process-global ceiling
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 73ca920..HEAD -- internal/ai/ internal/storage/config.go`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: security (abuse / resource exhaustion)
+- **Planned at**: commit `73ca920`, 2026-06-12
+
+## Why this matters
+
+Herald drives one shared Ollama backend. Two independent sources issue LLM
+calls: the `herald` daemon's processing pipeline (security screening,
+summarization, per-user curation) and the `herald-web` process's on-demand
+digest/summary generation (triggered by a user hitting "generate"). Today the
+only concurrency control is a *per-stage, per-invocation* semaphore
+(`Ollama.MaxParallel`, floored at 1) inside the daemon pipeline. Nothing bounds
+the TOTAL number of concurrent requests a single process sends to Ollama: in
+`herald-web`, every concurrent user who triggers generation fires an LLM call
+with no shared ceiling. On a public instance, a burst of activity can flood the
+single Ollama backend, driving latency up for everyone and risking OOM/crash of
+the inference server -- a denial of service for all users. This plan adds one
+process-global ceiling at the single point every Ollama chat call passes
+through, so concurrency is bounded regardless of how many stages or web
+requests are active.
+
+Note: `herald` and `herald-web` are separate processes, so this ceiling is
+per-process (each process gets its own bound). That is the correct and
+sufficient fix for the in-process flood; coordinating a single cross-process
+limit is an Ollama-side concern (`OLLAMA_NUM_PARALLEL` / its request queue),
+recorded in Maintenance notes.
+
+## Current state
+
+Every Ollama chat completion in Herald funnels through one method:
+
+- `internal/ai/client.go:184` --
+  `func (c *openAIClient) generate(ctx context.Context, model, prompt string, temperature float64) (string, error)`.
+  `SecurityCheck` (`ollama.go:117`), curation, and summarization all call
+  `p.client.generate(...)`. This is the single chokepoint.
+
+- `internal/ai/client.go:68-91` -- the client struct and its constructor:
+
+```go
+type openAIClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+
+	breakerCooldown time.Duration
+
+	mu             sync.Mutex
+	consecutive4xx int
+	circuitOpen    bool
+	openedAt       time.Time
+	lastStatus     int
+}
+
+func newOpenAIClient(baseURL, apiKey string) *openAIClient {
+	return &openAIClient{
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		apiKey:          apiKey,
+		httpClient:      &http.Client{},
+		breakerCooldown: defaultBreakerCooldown,
+	}
+}
+```
+
+- `internal/ai/ollama.go:51-76` -- `NewAIProcessor` builds the client and
+  already type-asserts the config:
+
+```go
+func NewAIProcessor(baseURL, securityModel, curationModel string, store any, config any) (*AIProcessor, error) {
+	...
+	if cfg, ok := config.(*storage.Config); ok && cfg != nil {
+		if cfg.Ollama.APIKey != "" { apiKey = cfg.Ollama.APIKey }
+		if cfg.Ollama.Timeout > 0 { callTimeout = cfg.Ollama.Timeout }
+	}
+	...
+	return &AIProcessor{
+		client:        newOpenAIClient(baseURL, apiKey),
+		...
+	}, nil
+}
+```
+
+- `internal/storage/config.go:12-19` -- the Ollama config block has
+  `MaxParallel int` (the per-stage bound) but no global ceiling field.
+
+- The per-stage semaphore is `internal/pipeline/pipeline.go:53-57`
+  (`maxParallel()` -> `max(s.Cfg.Ollama.MaxParallel, 1)`). Leave it in place;
+  it stays useful as an ordering/batch bound. This plan adds a SEPARATE,
+  lower-layer global gate.
+
+- The cloud-summary path (`internal/ai/cloud.go`, `generateStream`) is a
+  DIFFERENT client to a different backend (the AI Summary feature). It is out
+  of scope -- it is already single-flighted per user and is not the
+  Ollama-saturation concern.
+
+Conventions: `internal/ai` uses `sync.Mutex` and standard library
+concurrency primitives (see the breaker fields above). Match that style; no
+new dependencies.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests (ai) | `go test -race -count=1 ./internal/ai/` | all pass |
+| Tests (all) | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `internal/storage/config.go` -- add `Ollama.MaxConcurrent` + default.
+- `internal/ai/client.go` -- add a semaphore field to `openAIClient`, acquire
+  it inside `generate`, thread the size through `newOpenAIClient`.
+- `internal/ai/ollama.go` -- read `cfg.Ollama.MaxConcurrent` and pass it to
+  `newOpenAIClient`.
+- `internal/ai/client_test.go` (or the existing ai test file) -- a
+  concurrency test.
+
+**Out of scope** (do NOT touch):
+- `internal/pipeline/` -- the per-stage `MaxParallel` semaphore stays as-is.
+- `internal/ai/cloud.go` -- separate backend, separate plan if ever needed.
+- The circuit breaker logic -- do not change its behavior; the semaphore sits
+  alongside it.
+
+## Git workflow
+
+- Branch: `advisor/006-global-llm-concurrency-ceiling`.
+- Small commits; subject e.g.
+  `Bound concurrent Ollama calls with a process-global semaphore (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Add the config field
+
+In `internal/storage/config.go`, add `MaxConcurrent int` to the `Ollama`
+block (alongside `MaxParallel`):
+
+```go
+		MaxParallel   int           `yaml:"max_parallel"`
+		MaxConcurrent int           `yaml:"max_concurrent"`
+```
+
+In `DefaultConfig()`, set a sane default:
+
+```go
+	cfg.Ollama.MaxConcurrent = 8
+```
+
+Semantics: `<= 0` means unbounded (no gate). Document this in a comment.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 2: Add the semaphore to the client
+
+In `internal/ai/client.go`:
+
+1. Add a field to `openAIClient`:
+
+```go
+	// sem bounds the number of in-flight generate() calls in this process.
+	// nil when unbounded (MaxConcurrent <= 0). A buffered channel is the
+	// idiomatic counting semaphore.
+	sem chan struct{}
+```
+
+2. Change the constructor signature and body:
+
+```go
+func newOpenAIClient(baseURL, apiKey string, maxConcurrent int) *openAIClient {
+	c := &openAIClient{
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		apiKey:          apiKey,
+		httpClient:      &http.Client{},
+		breakerCooldown: defaultBreakerCooldown,
+	}
+	if maxConcurrent > 0 {
+		c.sem = make(chan struct{}, maxConcurrent)
+	}
+	return c
+}
+```
+
+3. In `generate` (`client.go:184`), AFTER the `if c.isOpen()` breaker check
+   and BEFORE building/sending the request, acquire the semaphore in a
+   context-aware way so a cancelled call doesn't block forever:
+
+```go
+	if c.sem != nil {
+		select {
+		case c.sem <- struct{}{}:
+			defer func() { <-c.sem }()
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+```
+
+Place this so the token is held only for the duration of the actual HTTP call
+(it is fine for it to span request build + `Do` + body read; the `defer`
+releases on every return path).
+
+**Verify**: `go build ./...` -> FAILS at the `newOpenAIClient` call site in
+`ollama.go` (signature changed) -- that is expected; fix it in Step 3.
+
+### Step 3: Thread the limit from config
+
+In `internal/ai/ollama.go` `NewAIProcessor` (line 51-76):
+
+1. Add a local read inside the existing `if cfg, ok := config.(*storage.Config)`
+   block:
+
+```go
+		maxConcurrent = cfg.Ollama.MaxConcurrent
+```
+
+   (declare `maxConcurrent := 0` before the block so it defaults to unbounded
+   if no config is provided -- but note the daemon/web always pass a real
+   config, so the configured default of 8 applies in practice).
+
+2. Update the constructor call:
+
+```go
+		client: newOpenAIClient(baseURL, apiKey, maxConcurrent),
+```
+
+Then `grep -rn "newOpenAIClient(" internal/ai/` and fix any OTHER call sites
+(e.g. test helpers) to pass a concurrency argument -- pass `0` (unbounded) in
+tests that don't care.
+
+**Verify**: `go build ./...` -> exit 0;
+`go test -race -count=1 ./internal/ai/` -> existing tests pass.
+
+### Step 4: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Add a test (model it on the existing `internal/ai` client tests, which use an
+`httptest.Server` standing in for Ollama -- find them via
+`grep -rln "httptest" internal/ai/`):
+
+1. **Ceiling enforced**: build a client with `newOpenAIClient(url, "", 2)`
+   pointed at an `httptest.Server` whose handler blocks on a channel until
+   released, then signals how many handlers are concurrently in flight. Launch
+   5 concurrent `generate` goroutines; assert the server never sees more than
+   2 simultaneous in-flight requests. (Use an `atomic.Int32` incremented on
+   handler entry / decremented on exit, with a recorded max.)
+2. **Unbounded when 0**: `newOpenAIClient(url, "", 0)` -> `c.sem == nil`; a
+   `generate` call still works (smoke).
+3. **Context cancellation while waiting**: fill the semaphore (size 1) with one
+   blocked call, then call `generate` with an already-cancelled context;
+   assert it returns `context.Canceled`/`ctx.Err()` promptly rather than
+   blocking.
+
+Verification: `go test -race -count=1 ./internal/ai/` -> all pass including the
+new concurrency test. The `-race` flag is important here.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0 (including `-race`)
+- [ ] `grep -n "MaxConcurrent" internal/storage/config.go` -> field + default
+- [ ] `grep -n "c.sem" internal/ai/client.go` -> acquire/release in `generate`
+- [ ] New concurrency test exists and passes under `-race`
+- [ ] `git status` shows no files modified outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `generate` is NOT the only path issuing Ollama chat requests -- run
+  `grep -rn "/v1/chat/completions\|c.httpClient.Do" internal/ai/`. If there is a
+  second request path that bypasses `generate`, the ceiling would be
+  incomplete; report it rather than gating only one path.
+- Acquiring the semaphore around the call appears to deadlock with the circuit
+  breaker or the per-stage pipeline semaphore (e.g. a test hangs). Do not
+  remove the breaker or the pipeline semaphore to "fix" it -- report the
+  interaction.
+- The default of 8 conflicts with an existing `MaxParallel` expectation in a
+  test (some tests may assume serial calls). Report; the fix is to pass `0`
+  (unbounded) in those tests, not to drop the feature.
+
+## Maintenance notes
+
+- This ceiling is per-process. To bound TOTAL load across the daemon AND
+  herald-web hitting one Ollama, set `OLLAMA_NUM_PARALLEL` and rely on Ollama's
+  request queue, or front Ollama with a gateway. Documented here so a future
+  maintainer doesn't expect a single in-process number to cap both binaries.
+- The semaphore deliberately wraps the whole HTTP call including body read, so
+  a slow Ollama response holds a slot -- that is the point (it reflects real
+  backend pressure). Reviewer should confirm the `defer` release is on all
+  return paths and that ctx-cancellation can't leak a token.
+- If a future feature adds another LLM backend call path, it must either route
+  through `generate` or acquire the same semaphore.

--- a/plans/007-web-input-validation-and-headers.md
+++ b/plans/007-web-input-validation-and-headers.md
@@ -1,0 +1,349 @@
+# Plan 007: Web input limits, security headers, and error hygiene
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 73ca920..HEAD -- cmd/herald-web/`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S-M
+- **Risk**: LOW
+- **Depends on**: none (complements 004; 004 enforces fetch-scheme at the
+  engine layer, this adds the web-layer length/limit checks)
+- **Category**: security
+- **Planned at**: commit `73ca920`, 2026-06-12
+
+## Why this matters
+
+On a public instance, every authenticated request comes from a potentially
+hostile user. Three web-layer gaps matter: (1) pagination `limit` has no upper
+bound, so `?limit=2000000000` pushes a huge LIMIT into the database; (2)
+user-supplied text fields (prompt templates, filter values, feed URL/title)
+have no length cap, so a few large POSTs can bloat storage; (3) handlers return
+raw internal errors to clients (`fmt.Sprintf("Failed to subscribe: %v", err)`),
+leaking fetcher/DNS/parser internals -- which doubles as SSRF reconnaissance
+(the error tells the attacker which hosts the server could and couldn't reach).
+Separately, the app sends no security response headers, so a Content-Security-
+Policy that would backstop any future XSS (feed content is rendered to many
+users) is absent. This plan closes all four with small, self-contained web-
+layer changes.
+
+## Current state
+
+- `cmd/herald-web/handlers.go:406-416` -- `parseIntParam` has no upper bound:
+
+```go
+func parseIntParam(r *http.Request, name string, defaultVal int) int {
+	s := r.URL.Query().Get(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 0 {
+		return defaultVal
+	}
+	return v
+}
+```
+
+- `cmd/herald-web/handlers.go:1188-1204` -- `handleFeedSubscribe` accepts the
+  URL with only a trim/empty check and leaks the error + returns 500 for what
+  is usually a user error:
+
+```go
+	url := strings.TrimSpace(r.FormValue("url"))
+	title := strings.TrimSpace(r.FormValue("title"))
+	if url == "" {
+		h.renderError(w, http.StatusBadRequest, "Feed URL is required")
+		return
+	}
+	if err := h.engine.SubscribeFeed(uid, url, title); err != nil {
+		h.renderError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to subscribe: %v", err))
+		return
+	}
+```
+
+- `cmd/herald-web/handlers.go:1457-1461` -- `handleUserPromptSave` checks only
+  for empty, no length cap:
+
+```go
+	tmpl := strings.TrimSpace(r.FormValue("template"))
+	if tmpl == "" {
+		h.renderError(w, http.StatusBadRequest, "Prompt template cannot be empty")
+		return
+	}
+```
+
+- Parallel handlers with the same `%v`-leak / missing-cap pattern (read each
+  before editing): `handleFeedDiscover` (~`handlers.go:1140`), `handleOPMLImport`
+  (~`1367`), `handleFilterAdd` (`1770`), `handleAdminPromptSave` (`1680`). Find
+  them all with:
+  `grep -n 'renderError(w, http.StatusInternalServerError, fmt.Sprintf' cmd/herald-web/handlers.go`
+
+- `cmd/herald-web/main.go:127-135` -- the server handler chain has no
+  security-header middleware:
+
+```go
+	mux := newRouter(engine, validator, cfg.Admin.Role, cfg.Admin.Users)
+	srv := &http.Server{
+		Addr:         listenAddr,
+		Handler:      logging(recovery(mux)),
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+```
+
+  `logging` and `recovery` are existing middlewares (find them:
+  `grep -rn 'func logging\|func recovery' cmd/herald-web/`). Add a
+  `securityHeaders` middleware in the same style and the same file.
+
+Conventions: handlers render errors via `h.renderError(w, status, msg)`;
+middlewares are `func(http.Handler) http.Handler`. Logging uses the stdlib
+`log` package. Tests live in `cmd/herald-web/*_test.go` and use the
+`fakeOIDCProvider` harness + `httptest`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests (web) | `go test -race -count=1 ./cmd/herald-web/` | all pass |
+| Tests (all) | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `cmd/herald-web/handlers.go` -- `parseIntParam` cap; length caps + generic
+  error responses in the listed handlers.
+- `cmd/herald-web/middleware.go` (or wherever `logging`/`recovery` live) -- a
+  `securityHeaders` middleware.
+- `cmd/herald-web/main.go` -- wire the middleware into the chain.
+- `cmd/herald-web/*_test.go` -- tests for the cap, the headers, and the
+  generic error.
+
+**Out of scope** (do NOT touch):
+- The fetch-scheme / SSRF blocking -- that is plan 004's job at the engine /
+  feeds layer. Here, only add a URL *length* cap and convert the error
+  response; do NOT add IP/scheme dialing logic.
+- The OIDC callback handler and session-cookie flags -- owned by
+  `infodancer/oidclient`; do not reimplement.
+- Any change to template rendering or the bluemonday sanitizer (rendering was
+  audited as safe; CSP here is defense-in-depth, not a fix for a known XSS).
+- The smoke route manifest -- unless a test tells you the manifest is stale
+  (then follow the manifest-update task in the Taskfile, do not hand-edit).
+
+## Git workflow
+
+- Branch: `advisor/007-web-input-validation-and-headers`.
+- Small commits, one per concern: limit cap; length caps + error hygiene;
+  security headers. Subject e.g.
+  `Cap pagination limit and stop leaking fetch errors (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Cap the pagination limit
+
+Add a max-clamp to `parseIntParam`. Add a `maxVal` parameter (0 = no cap) and
+clamp:
+
+```go
+func parseIntParam(r *http.Request, name string, defaultVal, maxVal int) int {
+	s := r.URL.Query().Get(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 0 {
+		return defaultVal
+	}
+	if maxVal > 0 && v > maxVal {
+		return maxVal
+	}
+	return v
+}
+```
+
+Then update every call site (`grep -n 'parseIntParam(' cmd/herald-web/`). For
+`limit` params pass a cap (define `const maxPageLimit = 500` near the function
+and pass it); for `offset` pass a large but finite cap (e.g. `const maxOffset =
+1000000`) so a giant offset can't force a deep scan. Keep existing default
+values unchanged.
+
+**Verify**: `go build ./...` -> exit 0;
+`grep -n 'parseIntParam(' cmd/herald-web/` -> every call passes 4 args.
+
+### Step 2: Length caps on user text fields
+
+Define caps near the top of the handlers file:
+
+```go
+const (
+	maxFeedURLLen      = 2048
+	maxTitleLen        = 512
+	maxPromptLen       = 20000
+	maxFilterValueLen  = 512
+)
+```
+
+Apply them with a `renderError(w, http.StatusBadRequest, ...)` when exceeded:
+
+1. `handleFeedSubscribe`: after the empty check, reject `len(url) > maxFeedURLLen`
+   and `len(title) > maxTitleLen`.
+2. `handleUserPromptSave` and `handleAdminPromptSave`: after the empty check,
+   reject `len(tmpl) > maxPromptLen`.
+3. `handleFilterAdd`: reject the filter value field when
+   `len(value) > maxFilterValueLen` (read the handler to find the form field
+   name).
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 3: Stop leaking internal errors to clients
+
+For each handler matched by
+`grep -n 'renderError(w, http.StatusInternalServerError, fmt.Sprintf' cmd/herald-web/handlers.go`
+that interpolates `%v` of an error from a user-driven action (subscribe,
+discover, OPML import, filter add, prompt save), change to:
+
+```go
+	if err := h.engine.SubscribeFeed(uid, url, title); err != nil {
+		log.Printf("herald-web: subscribe failed for user %d: %v", uid, err)
+		h.renderError(w, http.StatusBadRequest, "Could not subscribe to that feed. Check the URL and try again.")
+		return
+	}
+```
+
+Pattern: log the detailed error server-side (with `log`), return a generic,
+user-actionable message to the client, and use `http.StatusBadRequest` (not
+500) for input-driven failures. Keep genuinely-internal failures (DB write
+errors unrelated to user input) as 500 with a generic message -- still no `%v`
+to the client.
+
+Add `"log"` to the imports if not already present.
+
+**Verify**: `go build ./...` -> exit 0;
+`grep -n 'renderError(w, .*fmt.Sprintf("[^"]*%v", err' cmd/herald-web/handlers.go`
+-> no matches for the converted handlers (no error value reaches the client).
+
+### Step 4: Security-headers middleware
+
+In the file that defines `logging`/`recovery`, add:
+
+```go
+// securityHeaders sets conservative security response headers on every
+// response. The CSP is a backstop for the (sanitized) feed HTML rendered in
+// the app; tune it if inline scripts/styles are ever required.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'; base-uri 'self'")
+		// HSTS: only meaningful over TLS; herald-web sits behind a TLS
+		// terminating proxy in production.
+		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+Wire it in `main.go`:
+
+```go
+		Handler: securityHeaders(logging(recovery(mux))),
+```
+
+IMPORTANT: the CSP must not break the existing UI. herald-web uses htmx and
+server-rendered templates. Check the templates for inline `<script>` blocks
+and inline event handlers (`grep -rn '<script\|onclick\|onsubmit' cmd/herald-web/templates/`).
+The `script-src 'self'` above forbids inline scripts; `style-src` allows inline
+styles (`'unsafe-inline'`) because templates commonly use `style=` attributes.
+If there ARE inline scripts that the app needs, see the STOP condition -- do not
+silently broaden CSP to `'unsafe-inline'` for scripts without flagging it.
+
+**Verify**: `go build ./...` -> exit 0; load the app in the existing web tests
+(they exercise routes) and confirm they still pass.
+
+### Step 5: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+In `cmd/herald-web/*_test.go` (model on the existing handler tests with the
+`fakeOIDCProvider` harness):
+
+1. **Limit cap**: request a list route with `?limit=99999999`; assert the
+   handler does not error and (if observable) the effective limit is clamped.
+   At minimum assert a 200 and no panic. A unit test of `parseIntParam` with
+   `maxVal` is the cleanest: table cases (empty->default, valid->itself,
+   negative->default, over-max->max).
+2. **Length cap**: POST a prompt template longer than `maxPromptLen`; assert
+   400 and that the prompt was not saved.
+3. **Generic error**: POST a subscribe with a URL the fetcher will reject
+   (point it at an unreachable local test URL); assert the response status is
+   400 and the body does NOT contain the raw error substring (e.g. "dial" /
+   "lookup" / "connection refused").
+4. **Security headers**: any authenticated 200 response carries
+   `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a
+   `Content-Security-Policy` header.
+
+Verification: `go test -race -count=1 ./cmd/herald-web/` -> all pass.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `parseIntParam` takes a `maxVal` and all call sites pass it
+- [ ] `grep -n 'fmt.Sprintf("Failed to subscribe: %v"' cmd/herald-web/handlers.go` -> no matches
+- [ ] `securityHeaders` middleware exists and is wired in `main.go`
+- [ ] New tests (limit cap, length cap, generic error, headers) pass
+- [ ] `git status` shows no files modified outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The templates contain inline `<script>` blocks or inline event-handler
+  attributes (`onclick=` etc.) that the UI depends on -- the strict
+  `script-src 'self'` CSP will break them. Report the list; the operator
+  decides between refactoring to external JS, adding a nonce, or relaxing CSP.
+  Do NOT ship a CSP that breaks the app, and do NOT weaken it to
+  `script-src 'unsafe-inline'` without flagging.
+- The smoke-route manifest test fails because a probe now gets a 400 (e.g. a
+  prompt-save probe sending an over-length or now-rejected value). Report;
+  the manifest may need a regenerate via the Taskfile task, which is a
+  deliberate, reviewed change.
+- A handler's error you're converting turns out to carry information the USER
+  legitimately needs (e.g. a validation message). Keep user-actionable
+  validation messages; only suppress internal/system error detail.
+
+## Maintenance notes
+
+- The CSP is intentionally strict (`script-src 'self'`, `frame-ancestors
+  'none'`). Any future feature adding client-side JS must serve it from a
+  same-origin file or add a nonce -- not inline.
+- Reviewer should scrutinize: that no converted handler still passes an `error`
+  value into a client-facing string, and that input-driven failures return 4xx
+  not 5xx.
+- Deferred: a global request rate-limit / per-IP throttle (belongs at the
+  reverse proxy or a dedicated middleware) is NOT in this plan.

--- a/plans/009-admin-user-deletion.md
+++ b/plans/009-admin-user-deletion.md
@@ -1,0 +1,330 @@
+# Plan 009: Let an admin delete a user and all their data
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report -- do not improvise. When done, update the status row for this plan
+> in `plans/README.md` -- unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 73ca920..HEAD -- internal/storage/ engine.go cmd/herald-web/`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: tech-debt / direction (account lifecycle)
+- **Planned at**: commit `73ca920`, 2026-06-12
+
+## Why this matters
+
+Herald is becoming a public service with open self-signup, but there is no way
+to delete a user. An admin needs to remove an account (abuse, request, cleanup)
+and have all of that user's data go with it. Today no `DeleteUser` exists, and
+the schema only partially supports cascade: some per-user tables have a
+`FOREIGN KEY ... REFERENCES users(id) ON DELETE CASCADE`, but several legacy
+tables (`read_state`, `user_preferences`, `user_feeds`, `feed_tags`,
+`user_prompts`, `filter_rules`, `article_groups`) have only a `user_id INTEGER
+DEFAULT 1` column with no user FK -- so deleting a user row would orphan their
+rows in those tables. This plan adds a transactional `DeleteUser` that removes
+the user-scoped rows explicitly (in FK-safe order) and an admin-only endpoint
+to invoke it. It deliberately does NOT alter the schema (no risky table-rebuild
+migration to add the missing FKs); explicit deletes are simpler, work
+identically on both backends, and are easy to test.
+
+## Current state
+
+- SQLite enforces foreign keys: `internal/storage/storage.go:214` sets
+  `&_pragma=foreign_keys(on)` on the connection. So existing
+  `ON DELETE CASCADE` FKs fire, and deleting a parent row cascades to children
+  (see `DisbandGroup`, `storage.go:1955`, which deletes only `article_groups`
+  and relies on cascade to clear `article_group_members` / `group_summaries`).
+
+- From `internal/storage/schema.go`, the per-user tables split into two groups:
+
+  **No `users` FK -- must be deleted explicitly** (column is
+  `user_id INTEGER NOT NULL DEFAULT 1` or similar, FK only to feeds/articles):
+  - `read_state` (schema.go:63)
+  - `user_preferences` (schema.go:81)
+  - `user_feeds` (schema.go:89)
+  - `feed_tags` (schema.go:99)
+  - `user_prompts` (schema.go:153)
+  - `filter_rules` (schema.go:181)
+  - `article_groups` (schema.go:118) -- deleting these cascades to
+    `article_group_members` and `group_summaries` (both FK to
+    `article_groups ON DELETE CASCADE`, schema.go:137,150)
+
+  **Has `users` FK `ON DELETE CASCADE` -- removed automatically when the user
+  row is deleted**:
+  - `fever_credentials` (schema.go:199)
+  - `newsletters` (schema.go:254) -- cascades to `newsletter_issues`
+    (schema.go:267)
+  - `ai_summaries` (schema.go:288)
+
+- `internal/storage/store.go` -- the `Store` interface; user methods live here
+  (e.g. `ListUsers`, `DeleteUserPrompt`). There is no `DeleteUser`.
+- `engine.go:1661` -- `ListUsers() ([]User, error)` exists; the `User` type is
+  defined at `internal/storage/storage.go:629` (read it for field names:
+  ID, Name, OIDCSub, Email, CreatedAt).
+- `cmd/herald-web/handlers.go:59` -- `requireAdmin` middleware:
+
+```go
+func (h *handlers) requireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !h.isAdminCtx(r.Context()) {
+			h.renderError(w, http.StatusForbidden, "Admin access required")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+- `cmd/herald-web/routes.go:143-149` -- admin routes are registered as
+  `mux.Handle("GET /admin/stats", auth(adminAuth(http.HandlerFunc(h.handleAdminStats))))`
+  etc., where `adminAuth := h.requireAdmin` and `auth` is the session
+  middleware. Follow this exact pattern for the new routes.
+- `cfg.DefaultUserID` (config.go:6, default 1) is the fallback user; user_id 0
+  is the sentinel for global/admin prompts (see #162 work). Neither may be
+  deleted.
+
+Conventions: storage methods exist in BOTH `internal/storage/storage.go`
+(SQLite, `s.db`) and `internal/storage/postgres.go` (Postgres, `s.pool` /
+pgx). Both expose a `*sql.DB`-style handle for transactions -- check how
+existing multi-statement methods begin a transaction in each backend before
+writing (grep `Begin` in each file; if SQLite uses `s.db.Begin()` and Postgres
+uses `s.pool.Begin(ctx)`, match each). Errors wrap with
+`fmt.Errorf("...: %w", err)`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `go build ./...` | exit 0 |
+| Tests (storage) | `go test -race -count=1 ./internal/storage/` | all pass |
+| Tests (all) | `go test -race -count=1 ./...` | all pass |
+| Lint | `golangci-lint run ./...` | exit 0 |
+| Everything | `task check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `internal/storage/store.go` -- add `DeleteUser(userID int64) error` to the
+  interface.
+- `internal/storage/storage.go` -- SQLite `DeleteUser` (transactional).
+- `internal/storage/postgres.go` -- Postgres `DeleteUser` (transactional).
+- `engine.go` -- `DeleteUser(userID int64) error` with guard rails.
+- `cmd/herald-web/handlers.go` -- `handleAdminUsers` (list) and
+  `handleAdminUserDelete`.
+- `cmd/herald-web/routes.go` -- register the two admin routes.
+- `cmd/herald-web/templates/` -- a minimal admin users list template.
+- Test files in `internal/storage/` and `cmd/herald-web/`.
+
+**Out of scope** (do NOT touch):
+- Schema changes / migrations to add the missing `users` FKs. Explicit deletes
+  are the chosen approach; a future plan may add FKs, but a 7-table rebuild
+  migration is not worth the risk here.
+- Data EXPORT (GDPR-style download) -- deferred; this plan is deletion only.
+- Self-service account deletion by the user themselves -- admin-only for now.
+- The `RegisterUser`/`ResolveUser` engine methods (currently unused) -- leave
+  them.
+
+## Git workflow
+
+- Branch: `advisor/009-admin-user-deletion`.
+- Small commits: storage layer; engine + guards; web endpoint + template.
+  Subject e.g. `Add transactional DeleteUser across per-user tables (#162)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Add `DeleteUser` to the Store interface and both backends
+
+Add to `store.go` (near the other user methods):
+
+```go
+	// DeleteUser removes a user and all rows they own, atomically.
+	DeleteUser(userID int64) error
+```
+
+SQLite (`storage.go`) -- transactional; delete the no-FK tables explicitly,
+then the user row (cascade clears fever_credentials, newsletters+issues,
+ai_summaries):
+
+```go
+func (s *SQLiteStore) DeleteUser(userID int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("delete user: begin: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+	stmts := []string{
+		"DELETE FROM read_state WHERE user_id = ?",
+		"DELETE FROM user_preferences WHERE user_id = ?",
+		"DELETE FROM user_feeds WHERE user_id = ?",
+		"DELETE FROM feed_tags WHERE user_id = ?",
+		"DELETE FROM user_prompts WHERE user_id = ?",
+		"DELETE FROM filter_rules WHERE user_id = ?",
+		"DELETE FROM article_groups WHERE user_id = ?", // cascades members + summaries
+		"DELETE FROM users WHERE id = ?",               // cascades fever/newsletters/ai_summaries
+	}
+	for _, q := range stmts {
+		if _, err := tx.Exec(q, userID); err != nil {
+			return fmt.Errorf("delete user (%q): %w", q, err)
+		}
+	}
+	return tx.Commit()
+}
+```
+
+Postgres (`postgres.go`) -- same statements, pgx transaction and `$1`
+placeholders. Match the existing Postgres transaction style in that file
+(`s.pool.Begin(ctx)` / `tx.Exec(ctx, ...)` / `tx.Commit(ctx)`; use
+`context.Background()` if the method has no ctx param, matching sibling
+methods). Verify Postgres also has `foreign_keys`-equivalent behavior: in
+Postgres, FK constraints with `ON DELETE CASCADE` are always enforced, so the
+cascade for fever/newsletters/ai_summaries works the same.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 2: Engine `DeleteUser` with guard rails
+
+In `engine.go`, add:
+
+```go
+// DeleteUser removes a user and everything they own. It refuses to delete the
+// global sentinel (user 0, which owns shared/admin prompts) and the configured
+// default user, since those underpin shared state.
+func (e *Engine) DeleteUser(userID int64) error {
+	if userID == 0 || userID == e.cfg.DefaultUserID {
+		return fmt.Errorf("refusing to delete reserved user %d", userID)
+	}
+	return e.store.DeleteUser(userID)
+}
+```
+
+Use whatever field the engine holds config in (confirm via grep, as in other
+plans). If the engine doesn't hold `DefaultUserID`, guard at least `userID == 0`
+and report (STOP) so the reviewer can decide how to protect the default user.
+
+**Verify**: `go build ./...` -> exit 0.
+
+### Step 3: Admin endpoints + minimal list UI
+
+1. `handleAdminUsers` (GET): call `h.engine.ListUsers()` and render a minimal
+   template listing each user's ID, name, email, and created date, with a
+   delete control (a form/htmx button issuing `DELETE /admin/users/{id}`).
+   Model the handler + template on an existing admin page like
+   `handleAdminStats` and its template.
+2. `handleAdminUserDelete` (DELETE): parse `{userID}` with
+   `strconv.ParseInt(r.PathValue("userID"), 10, 64)`; call
+   `h.engine.DeleteUser(id)`; on the engine's guard error return
+   `http.StatusBadRequest` with the message; on success either redirect
+   (`HX-Redirect: /admin/users`) or re-render the list. Do NOT leak raw errors
+   (return a generic message on unexpected failure, log the detail).
+3. In `routes.go`, register both under the admin chain, matching the existing
+   pattern:
+
+```go
+	mux.Handle("GET /admin/users", auth(adminAuth(http.HandlerFunc(h.handleAdminUsers))))
+	mux.Handle("DELETE /admin/users/{userID}", auth(adminAuth(http.HandlerFunc(h.handleAdminUserDelete))), smoke.Example("userID", "1"))
+```
+
+   NOTE on the smoke example: `userID=1` is the default user, which the engine
+   guard REFUSES to delete -- so the smoke probe gets a 400, not a deletion.
+   That is the desired safe behavior for an automated probe. Confirm the smoke
+   harness treats the documented status correctly; if it expects 2xx, set the
+   probe's expected status or pick a non-destructive example per the smoke
+   manifest conventions (see the Taskfile smoke-manifest task). If unsure,
+   STOP and report rather than letting a probe delete a real user.
+
+**Verify**: `go build ./...` -> exit 0;
+`go test -race -count=1 ./cmd/herald-web/` -> existing tests pass.
+
+### Step 4: Tests
+
+See "Test plan".
+
+**Verify**: `task check` -> exit 0.
+
+## Test plan
+
+Storage test (`internal/storage/storage_test.go`, and the Postgres test block
+if one exists -- mirror the existing dual-backend test pattern):
+
+1. **Full deletion**: create a user (id != 1), then create at least one row
+   "owned" by them in EVERY in-scope table: `read_state`, `user_preferences`,
+   `user_feeds`, `feed_tags`, `user_prompts`, `filter_rules`, `article_groups`
+   (+ a member row to prove cascade), `fever_credentials`, `newsletters`
+   (+ an issue to prove cascade), `ai_summaries`. Call `DeleteUser`. Assert:
+   the user row is gone AND every one of those tables has zero rows for that
+   user_id (query each). This is the regression guard against a forgotten
+   table.
+2. **Cascade proof**: assert `article_group_members`/`group_summaries` for the
+   deleted user's groups are gone, and `newsletter_issues` for the deleted
+   user's newsletters are gone.
+3. **Other users untouched**: create a second user with rows; after deleting
+   the first, assert the second user's rows all remain.
+
+Engine test:
+4. **Guard**: `DeleteUser(0)` and `DeleteUser(cfg.DefaultUserID)` return an
+   error and delete nothing.
+
+Web test (model on existing admin handler tests):
+5. **Admin-only**: a non-admin `DELETE /admin/users/2` gets 403; an admin
+   deleting a non-reserved user succeeds and the user is gone.
+
+Verification: `go test -race -count=1 ./...` -> all pass including the new
+tests.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `task check` exits 0
+- [ ] `grep -n "DeleteUser" internal/storage/store.go internal/storage/storage.go internal/storage/postgres.go engine.go` -> defined in all four
+- [ ] Storage test creates rows in every in-scope per-user table and asserts all gone after `DeleteUser`
+- [ ] Engine guard test (user 0 and default user refused) passes
+- [ ] Admin-only web test (403 for non-admin) passes
+- [ ] `git status` shows no files modified outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The set of per-user tables in the live schema differs from the list in
+  "Current state" (a table was added/removed since this plan) -- run
+  `grep -n "user_id" internal/storage/schema.go` and compare. A missing table
+  in `DeleteUser` means orphaned data; get the list right before shipping.
+- The Postgres backend uses a transaction idiom you can't confirm by reading a
+  sibling method -- report rather than guessing the pgx transaction API.
+- The smoke manifest test fails on the new `DELETE /admin/users/{userID}` route
+  in a way that would delete a real user during smoke runs -- STOP; a probe
+  must never perform a destructive delete of a non-reserved account.
+- The engine does not expose `DefaultUserID` -- report; guarding only user 0
+  may be insufficient.
+
+## Maintenance notes
+
+- **Critical**: `DeleteUser` enumerates per-user tables explicitly. Any NEW
+  per-user table MUST be added to `DeleteUser` (and to test #1), OR given a
+  `FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`. The
+  storage test #1 is the safety net -- it will fail if a new table holds the
+  user's rows after deletion only if the test is updated to seed that table,
+  so keep the test's table list in sync with the schema.
+- A future hardening is to add the missing `users` FKs via a table-rebuild
+  migration (the #141 pattern), which would let `DeleteUser` collapse to a
+  single `DELETE FROM users`. Deferred deliberately -- not worth the migration
+  risk now.
+- Deferred and NOT in this plan: user-initiated self-deletion, and data export
+  (GDPR-style). Record as future work if the public service needs them.
+- Reviewer should scrutinize: the table list is complete vs. the schema, the
+  delete runs in a transaction (no partial deletion on error), and the reserved
+  -user guard cannot be bypassed via the web route.

--- a/plans/010-airlock-fence-swap.md
+++ b/plans/010-airlock-fence-swap.md
@@ -1,0 +1,116 @@
+# Plan 010: Replace the hand-rolled prompt fence with airlock/wrap
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. If
+> anything in "STOP conditions" occurs, stop and report -- do not improvise.
+> When done, update the status row in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 8272ea2..HEAD -- internal/ai/`
+> If `fence.go` or the prompt templates changed since this plan was written,
+> compare the "Current state" excerpts against live code before proceeding.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (011 is independent; either can land first)
+- **Category**: refactor / security hygiene
+- **Planned at**: commit `8272ea2`, 2026-07-11
+
+## Why this matters
+
+Herald already invented the right idea. `internal/ai/fence.go` wraps untrusted
+feed text in `<untrusted-{nonce}>` tags with a 128-bit random nonce, tells the
+model to treat the contents as data and never as instructions, and strips any
+fence-tag sequence out of the untrusted text before interpolating it. That is
+structural marking of untrusted content, and it is the technique the airlock
+project was extracted to generalize.
+
+Right now it lives in one package of one app, hand-rolled. airlock exists to be
+the reusable, tested version of it. Swapping Herald onto `airlock/wrap` means
+Herald stops maintaining its own copy, and any hardening airlock gains flows back
+here.
+
+There is one concrete hardening on offer today. `neutralizeFence` matches its
+tag regex against the **raw** text:
+
+```go
+// internal/ai/fence.go
+func neutralizeFence(s string) string {
+	return fenceTagRe.ReplaceAllString(s, "[tag removed]")
+}
+```
+
+A tag sequence spelled with a zero-width space or a homoglyph would not match
+that regex and would survive into the prompt. airlock's `wrap` neutralizes on
+normalized text (`airlock/normalize`), which folds exactly those evasions away.
+
+**This is defense in depth, not a live hole.** The real guarantee is the random
+nonce: an attacker who cannot predict a 128-bit value cannot close the fence, no
+matter how they spell the tag. `neutralizeFence` is the belt behind that
+suspenders. Do not report or describe this swap as fixing a vulnerability.
+
+## Current state
+
+- `internal/ai/fence.go` -- `newFenceNonce()` (16 bytes `crypto/rand`, hex),
+  `neutralizeFence()`, `fencedArticleData()`.
+- Callers: `internal/ai/security.go`, `curation.go`, `summarization.go`
+  (single-article path via `fencedArticleData`, plus group-summary and
+  newsletter paths that build their own map with `Nonce` + `neutralizeFence`).
+- Prompt templates in `internal/ai/prompts/*.txt` interpolate
+  `<untrusted-{{.Nonce}}>` ... `</untrusted-{{.Nonce}}>`.
+
+## Steps
+
+1. **Add the dependency.** `go get github.com/matthewjhunter/airlock@latest`.
+   airlock is Apache-2.0, floor go 1.22, one transitive dep
+   (`golang.org/x/text`). Confirm `task vulncheck` stays clean.
+
+2. **Read airlock's `wrap` API before writing any code.** Confirm it exposes
+   nonce generation, neutralization, and the wrapped-envelope rendering that
+   Herald needs. If `wrap` does not yet expose an equivalent of
+   `fencedArticleData` (nonce + neutralized title + neutralized content as
+   template data), STOP: the gap belongs upstream in airlock, not in a Herald
+   shim.
+
+3. **Reimplement `fence.go` as a thin adapter over `airlock/wrap`.** Keep the
+   existing internal function names and signatures (`newFenceNonce`,
+   `neutralizeFence`, `fencedArticleData`) so no caller changes. The point of
+   this step is that the diff is confined to one file.
+
+4. **Do not change the prompt templates.** The `<untrusted-{{.Nonce}}>` shape
+   stays exactly as-is. If airlock's `wrap` wants a different delimiter shape,
+   that is a bigger change and a separate plan -- the security prompt was tuned
+   recently (`fix/security-prompt-false-positives`, PR #219) and its wording is
+   load-bearing for the false-positive rate.
+
+5. **Add a regression test for the evasion the swap actually buys.** Assert that
+   a fence tag spelled with a zero-width space or a Cyrillic homoglyph is
+   neutralized, where the old raw-regex version would have let it through. This
+   is the only behavioral difference; if it does not hold, the swap bought
+   nothing and step 3 is wrong.
+
+6. `task check` (build, `go test -race -count=1 ./...`, lint, vulncheck).
+
+## Verification
+
+- All existing `internal/ai` tests pass unchanged. The swap is behavior-preserving
+  except for the normalization hardening in step 5.
+- The new evasion test fails against the old `neutralizeFence` and passes against
+  the airlock-backed one. Demonstrate both.
+- Generate one security prompt for a known article and diff the rendered prompt
+  text against the pre-swap output. It should be identical apart from the nonce.
+
+## STOP conditions
+
+- `airlock/wrap` does not cover Herald's use (see step 2). The fix goes upstream.
+- The rendered prompt changes in any way other than the nonce value. The prompt is
+  freshly tuned; silently altering it re-opens the false-positive work in PR #219.
+- `go.sum` picks up any transitive dependency beyond `golang.org/x/text`.
+
+## Out of scope
+
+- The security score polarity change. That is plan 011, and it is independent:
+  this plan touches how untrusted text is fenced, not how verdicts are scored.

--- a/plans/011-security-threat-scale.md
+++ b/plans/011-security-threat-scale.md
@@ -1,0 +1,173 @@
+# Plan 011: Flip the security score to a threat scale, and stop storing model prose
+
+> **Executor instructions**: Follow this plan step by step. Honor the STOP
+> conditions. When done, update the status row in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat 8272ea2..HEAD -- internal/ai/prompts/ internal/storage/ engine.go types.go`
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED (silent inversion is the failure mode -- see STOP conditions)
+- **Depends on**: none (010 is independent)
+- **Category**: correctness / API coherence
+- **Planned at**: commit `8272ea2`, 2026-07-11
+- **DEFERRED by the operator**: do this after 010. Bundle it with the next full
+  rescore -- see "Migration" below, which is why this is cheaper than it looks.
+
+## Why this matters
+
+Herald's security score currently runs **backwards**: `0-10` where **10 means
+completely safe** and 0 means confirmed malicious (`internal/ai/prompts/security.txt`).
+Thresholds read `>= 7.0 pass`, `4.0-7.0 borderline`, `< 4.0 fail`.
+
+That polarity cannot compose. A safety score has to start at a ceiling and
+*subtract* for each piece of bad evidence, which means every new signal needs a
+negative weight and a bounded starting point. A threat score starts at zero and
+*adds*, which is how evidence actually accumulates: no evidence, no score.
+
+**Safe is 0. Anything non-zero is not safe.** That is the only convention under
+which additive scoring works without negative numbers, and it is the convention
+airlock uses (`airlock/detect`: `Score()` returns 0-100, 0 = nothing fired,
+higher = more hostile). Herald and airlock are about to share a fence (plan 010);
+they should not disagree about which end of the scale is dangerous.
+
+The concrete hazard of leaving it: anyone wiring airlock's score into Herald's
+`security_score` writes the natural-looking line
+
+```go
+securityScore = float64(result.Score()) / 10   // WRONG -- inverts safety
+```
+
+and a maximally hostile article (airlock 100) lands on Herald's 10.0 = "completely
+safe" and **passes**. Silent, catastrophic, and a single line of plausible code.
+
+## Part 2: drop `security_reason` entirely
+
+`security_reason` holds a sentence the model wrote about attacker-authored text. It is
+**write-only**: persisted to `articles.security_reason` and
+`read_state.security_reason`, and never SELECTed, never rendered, never logged. Grep
+confirms zero readers.
+
+So today it is pure liability with no upside -- and it is the kind of liability that
+turns into a hole the first time someone adds a "why was this flagged?" panel and
+renders it, or pipes it into an LLM-summarized ops dashboard.
+
+The reason it must not simply be *kept and used* is the one that governs this whole
+design: **a database column, a log line, an error string, and a dashboard are all
+unfenced channels.** Herald wraps article text in a nonce fence precisely so a model
+never receives it as instruction. Copying the model's quote of that text -- or its prose
+about it -- into a column that some future tool renders or summarizes hands the article a
+second delivery path, to a human or to another model, with no fence in sight. Fencing the
+article and then filing its payload in the database is not a defense.
+
+**Drop the columns.** Store instead what `airlock/screen.Finding` carries, which contains
+no attacker bytes at all:
+
+| Column | Type | Note |
+|---|---|---|
+| `security_threat` | `DOUBLE PRECISION` | 0 = clean, higher = worse (the flip above) |
+| `security_category` | `TEXT` | closed vocabulary, never free text |
+| `security_verified` | `BOOLEAN` | the model's citation was found in the article |
+
+The evidence is **re-derived, not stored**. Herald still has the article. When a human
+wants to know why something was flagged, call `screen.Verdict.Locate` against the current
+content at display time and highlight the span inside the article body -- which herald
+already sanitizes, escapes, and treats as untrusted. If the article changed and the span
+no longer matches, say so, rather than showing a stale quote.
+
+`security_flagged` (a bool) is fine and stays; it carries no payload.
+
+For prompt tuning, `screen.Verdict.DebugString()` exposes the quote deliberately. Gate it
+behind a debug setting, log it nowhere an agent or an LLM will read it, and do not persist
+it.
+
+### Steps for part 2
+
+1. Migration: `ALTER TABLE articles DROP COLUMN security_reason;` and the same on
+   `read_state`. Safe -- there are no readers.
+2. Add `security_category` and `security_verified`; rename `security_score` ->
+   `security_threat` (the rename also fail-closes the polarity change: old code selecting
+   `security_score` stops compiling rather than silently reading a flipped number).
+3. Delete `SecurityReason` from `internal/storage/db/models.go`, the sqlc queries, and
+   `postgres.go`; regenerate sqlc.
+4. Reject a verdict whose evidence does not appear in the article
+   (`screen.Verdict.Finding`) -- a fabricated citation is a void finding, not a weak one.
+
+## Target design
+
+`security_score` becomes a **threat score**: `0.0` = no threat detected, `10.0` =
+confirmed malicious. Thresholds invert to preserve today's classifications exactly:
+
+| Band | Old (safety) | New (threat) |
+|---|---|---|
+| pass | `>= 7.0` | `<= 3.0` |
+| borderline (passes, flagged for audit) | `[4.0, 7.0)` | `(3.0, 6.0]` |
+| fail (excluded from pipeline) | `< 4.0` | `> 6.0` |
+
+airlock then maps in with no polarity flip at all: `threat = airlock.Score() / 10`.
+
+## Migration: rescore, do not convert
+
+Do **not** write a migration that rewrites stored values (`10 - security_score`).
+It is exactly the kind of transform that silently inverts safety if it double-runs
+or half-applies, and it is unnecessary:
+
+**The prompt change forces a full rescore regardless.** Flipping the scale in
+`security.txt` changes what the model is asked for, so every existing verdict is
+produced under different instructions and is not comparable. Bundle this plan with
+the next rescore.
+
+So the migration is: **null out `security_score` / `security_reason` /
+`security_screened_at` on `articles` and `read_state`, and let the pipeline
+re-screen.** A null score is already the "not yet screened" state the pipeline
+understands, and it fails closed -- an unscored article is not treated as safe.
+
+## Steps
+
+1. Rewrite the scoring rule in `internal/ai/prompts/security.txt` to the threat
+   scale: no concrete technical threat -> `0-2`; reserve `> 6` for a named,
+   concrete threat present in the text. Keep every other word of that prompt.
+   It was tuned in PR #219 to fix false positives, and the "do NOT flag" list is
+   what does that work.
+2. Flip the comparisons. Known sites (re-grep, do not trust this list):
+   - `engine.go:54-58` defaults `SecurityThreshold = 7.0`, `SecurityMediumThreshold = 4.0`
+   - `types.go:11-13`, `types.go:104` (`MinSecurityScore`)
+   - `internal/storage/db/queries/article.sql:34,42,61,74` (`>= @security_threshold`)
+   - `internal/storage/db/queries/stats.sql:7-8` (**hardcoded `>= 7`**)
+   - `internal/storage/postgres.go:2580-2582` (`MinSecurityScore`)
+   - `FeedScoreStats` banding, `types.go:198-228`
+   - regenerate sqlc after touching `*.sql`
+3. **Rename the config keys.** `thresholds.security_score` ->
+   `thresholds.max_security_threat`; `min_security_score` -> `max_security_threat`.
+   Reusing the old key names is the single most dangerous option available: an
+   existing `security_score = 7.0` reinterpreted on the threat scale means "fail
+   only above 7 threat", i.e. almost everything passes. **Refuse to start** if the
+   old key is present, with an error naming the new key. Fail closed and loud.
+4. Update `config/config.toml`, `config/config.docker.toml`, and the docs
+   (`README.md`, `USAGE.md`, `docs/architecture.md`, `docs/prompts.md`) -- all of
+   which currently state the 10-is-safe convention.
+5. Null the stored scores (see Migration) and rescore.
+
+## Verification
+
+- **The invariant**: for a corpus of already-screened articles, re-screened under
+  the new prompt, the pass/borderline/fail *classification* should land in
+  materially the same place. This is a representation change, not a policy change.
+  A large swing means the prompt rewrite in step 1 changed model behavior -- that
+  is the risk, and it is why step 1 keeps everything but the scoring rule.
+- Feed a known-malicious article and a known-benign one through end to end; assert
+  the malicious one now scores HIGH and is excluded, and the benign one scores LOW
+  and passes. Under the old scale those assertions are exactly reversed, so a test
+  that passes both before and after has not actually been flipped.
+- `task check`.
+
+## STOP conditions
+
+- Any code path still compares `security_score >= threshold` for a *pass*. That is
+  the inverted-safety bug, and it fails open.
+- An old-style config key is accepted rather than rejected.
+- Post-rescore pass rate swings by more than ~10 points against the pre-change
+  baseline. Stop and diff the prompt -- the scale flip should not move the verdict.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,108 @@
+# Implementation Plans
+
+Two audits, in order below.
+
+- **001-003** -- multiuser-readiness audit (2026-06-12, planned at `62f949e`).
+  All merged via PR #167 (`feature/162` -> main) and shipped.
+- **004-009** -- public-service hardening audit (2026-06-12, planned at
+  `73ca920`), re-evaluating the codebase for open public signup. SSRF (004)
+  is release-blocking for public deployment.
+
+Each executor: read the plan fully before starting, honor its STOP
+conditions, and update your row when done.
+
+## Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|------|-------|----------|--------|------------|--------|
+| 001 | Enforce per-user ownership on filter rules, groups, and newsletter generation | P1 | S | -- | DONE (merged in PR #167) |
+| 002 | Share per-article AI summaries across all users | P1 | M-L | 001 (soft) | DONE (merged in PR #167) |
+| 003 | Gate direct article and image access by feed subscription | P2 | S | 001 (soft) | DONE (merged in PR #167) |
+| 004 | Block SSRF on every outbound fetch with one hardened HTTP client | P0 (release-blocking) | M | -- | DONE (worktree `advisor/004-egress-ssrf-hardening`, commit ce87b62, reviewed+approved; awaiting operator merge) |
+| 005 | Cap per-user feeds, filter rules, and newsletters | P1 | S | -- | DONE (merged into feature/162, commits e4a00b1+50350f6; OPML-import bypass closed in commit 16055e2 -- web import now capped, local CLI import exempt) |
+| 006 | Bound concurrent LLM calls with a process-global ceiling | P1 | M | -- | DONE (merged into feature/162, commit 931ee79) |
+| 007 | Web input limits, security headers, and error hygiene | P2 | S-M | -- (complements 004) | DONE (merged into feature/162, commits d2d1a8f..3460163; CSP ships with 'unsafe-inline' for script/style -- nonce tightening deferred) |
+| 009 | Let an admin delete a user and all their data | P2 | M | -- | DONE (merged into feature/162, commits 934031b..e5f3c6b; Postgres path verified live 2026-06-13 -- TestDeleteUser/postgres + TestDeleteUserIdempotent/postgres pass against ephemeral PG 17) |
+
+Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) |
+REJECTED (with one-line rationale)
+
+## Not yet planned (operator deferred)
+
+- **008 -- AI cost / entitlements (paywall)**: per-user curation LLM work
+  scales users x articles. Deferred by the operator: AI runs on free local
+  hardware (cost is electricity + load only), generous free AI may entice
+  signups, and the design needs a joint session (what to meter, free vs paid
+  tiers, enforcement point). Not a plan until that design happens. Evidence:
+  per-user curation in `internal/pipeline/stages.go`; daemon per-user loop
+  `cmd/herald/main.go:506-511`.
+
+## Dependency notes
+
+- 002 depends on 001 only to avoid merge collisions in `engine.go` and
+  `cmd/herald-web/handlers.go`; there is no functional coupling.
+
+## Audit findings not yet planned (pending operator decisions)
+
+- **Registration gating** (audit #7): first OIDC login auto-provisions an
+  account (`engine.go` `GetOrProvisionOIDCUser`). RESOLVED 2026-06-13: Herald
+  is intended to be a public service (open signup, osg/sf pattern), so
+  auto-provisioning is the intended behavior, not a hole. No gate needed.
+- **MCP trust model** (audit #10): MCP `Speaker` parameter is unauthenticated
+  impersonation. RESOLVED 2026-06-13: `herald-mcp` removed entirely (PR #168).
+- **User lifecycle** (audit #8, #11): no DeleteUser; several per-user tables
+  lack FKs to users(id); legacy `DEFAULT 1` on user_id columns. NOW PLANNED as
+  009 (admin user deletion via explicit transactional deletes).
+- **CLI multiuser cleanup** (audit #9): `herald list` uses the unscoped
+  `GetUnreadArticles(limit)` whose read_state join misbehaves with multiple
+  users; cycle notifications show only the first subscribing user. Not
+  planned yet.
+
+## Findings considered and rejected
+
+- Storage-layer IDOR claims for `DeleteNewsletter`, `GetNewsletter`-via-web,
+  and `DisbandGroup`: the Engine layer enforces ownership
+  (`engine.go:950-961`, `engine.go:986-996`,
+  `cmd/herald-web/handlers.go:1022-1026`). Defense-in-depth at the storage
+  layer was judged not worth the signature churn right now.
+- `GetUnreadArticles(limit)` (storage) flagged as a leak: it is a
+  daemon/CLI-scope query by design; the only real problem is the CLI using
+  it as if user-scoped (tracked above as CLI cleanup).
+- Per-user prompts poisoning the shared security verdict: not possible --
+  security prompts resolve from user 0 only (`internal/ai/ollama.go:93`)
+  and "security" is excluded from settable prompt types
+  (`engine.go:1361-1368`).
+- read_state lazy-row design (missing row = unread): sound as long as reads
+  use LEFT JOIN, which they all do today; documented risk only.
+- CSRF on state-changing routes: session cookie is SameSite=Lax (oidclient)
+  and all mutations are POST/DELETE/PATCH; acceptable.
+- SQLite write contention under many users: theoretical at household scale;
+  the Postgres backend already exists as the escape hatch. Confirmed moot for
+  public scale -- production runs Postgres.
+- Global cap on concurrent per-user LLM digest generation: SUPERSEDED -- now
+  planned as 006 (a process-global ceiling), since public scale makes Ollama
+  saturation a real DoS rather than a theoretical one.
+
+### Public-service hardening pass (2026-06-12, planned at `73ca920`)
+
+- **Stored XSS in rendered feed content**: confirmed SAFE, not a finding.
+  `html/template` auto-escapes; feed HTML is sanitized with
+  `bluemonday.UGCPolicy()` at render time (`cmd/herald-web/sanitize.go`,
+  `handlers.go:800/824`, `summary.go:95`, `fever.go:281`); `template.HTML` is
+  used only on already-sanitized content. CSP added as defense-in-depth in 007.
+- **OAuth error-parameter "XSS"** (`handlers.go:459`,
+  `"Authentication error: "+errParam`): NOT XSS -- `http.Error` emits
+  `text/plain` + `nosniff`, so browsers won't render it; and PR #159 already
+  deletes this handler on main (replaced by `oidclient.CallbackHandler`, which
+  doesn't reflect the error). Rejected.
+- **OPML / feed XML XXE & billion-laughs**: Go `encoding/xml` does not resolve
+  external entities (no XXE), and OPML upload is size-capped; entity-expansion
+  risk is bounded once 004's response-size caps land. Not worth a separate
+  decoder-hardening plan.
+- **AI `base_url` SSRF (Ollama/cloud)**: the LLM `base_url` is operator config,
+  not user/feed-supplied, so it is not user-reachable SSRF. A startup
+  validation is a minor nicety, not a plan; 004 deliberately excludes the
+  `internal/ai` clients.
+- **Per-host limits against slow PUBLIC hosts** (connection pool / rate limit):
+  real but lower-leverage than the private-range block; noted as a follow-up in
+  004's maintenance notes, not planned now.


### PR DESCRIPTION
Bumps the Go directive `1.26.4` -> `1.26.5`, closing the one **called** standard-library vulnerability `govulncheck` reports.

## Vulnerability

**GO-2026-5856** -- Encrypted Client Hello privacy leak in `crypto/tls`, fixed in go1.26.5. It reaches real paths: the TLS server handshake in `serveCmd` and outbound HTTPS feed fetches in the feeds fetcher, so both sides of the handshake are in scope.

## Verification (under go1.26.5)

- `go build ./...` -- OK
- `go vet ./...` -- clean
- `go test ./...` -- green
- `govulncheck ./...` -- **No vulnerabilities found** (also clears the one uncalled import-level finding)

Toolchain bump only; no code change.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)