### PR TITLE
gitignore: ignore local config/config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ feedreader
 
 # Config files (may contain sensitive data)
 config/config.yaml
+config/config.toml
 
 # Log files
 *.log


### PR DESCRIPTION
The rendered `config.toml` (produced by ansible from the homelab template, or copied locally for a run) is environment-specific and may hold secrets -- exactly like `config.yaml`, already listed. The tracked `config.docker.toml` and `config.toml.example` stay tracked; only the live `config.toml` is ignored.

Noticed while deploying plan 012 -- `git status` kept surfacing an untracked `config/config.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)