### PR TITLE
daemon: split into fetch/screen/curate loops + claimed screen queue (#233)

### DIFF
--- a/cmd/herald/daemon.go
+++ b/cmd/herald/daemon.go
@@ -13,14 +13,27 @@ import (
 
 func daemonCmd() *cobra.Command {
 	var interval time.Duration
+	var stagesCSV string
 
 	cmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Run fetch+process in a loop with configurable interval",
 		Long: `Continuously fetch feeds and process articles with AI on a timer.
 Designed for running inside a Docker container or as a background service.
-Handles SIGINT/SIGTERM for graceful shutdown (finishes the current cycle).`,
+Handles SIGINT/SIGTERM for graceful shutdown (finishes the current cycle).
+
+--stages selects which of the three independent loops this process runs
+(fetch, screen, curate), comma-separated; the default runs all three, the
+original single-service behavior. Run them as separate services -- each with
+its own image command and interval -- to decouple the slow, LLM-bound screen
+pass from feed fetching and per-user curation (#233). The security screen is
+concurrency-safe across multiple screen loops via a per-article claim/lease.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			stages, err := parseStages(stagesCSV)
+			if err != nil {
+				return err
+			}
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -36,14 +49,14 @@ Handles SIGINT/SIGTERM for graceful shutdown (finishes the current cycle).`,
 				cancel()
 			}()
 
-			log.Printf("herald daemon: starting with interval %s", interval)
+			log.Printf("herald daemon: starting with interval %s, stages %s", interval, stagesCSV)
 
 			cycle := 1
 			for {
 				start := time.Now()
 				log.Printf("herald daemon: cycle %d starting", cycle)
 
-				if err := doFetch(ctx); err != nil {
+				if err := runCycle(ctx, stages); err != nil {
 					if ctx.Err() != nil {
 						log.Println("herald daemon: cycle cancelled, exiting")
 						return nil
@@ -53,12 +66,15 @@ Handles SIGINT/SIGTERM for graceful shutdown (finishes the current cycle).`,
 					log.Printf("herald daemon: cycle %d completed in %s", cycle, time.Since(start).Round(time.Millisecond))
 				}
 
-				// Process due newsletters (hourly/daily).
-				if err := processNewsletters(ctx); err != nil {
-					if ctx.Err() != nil {
-						return nil
+				// Due newsletters belong to the curate stage (per-user output); a
+				// fetch- or screen-only loop does not send them.
+				if stages.has(stageCurate) {
+					if err := processNewsletters(ctx); err != nil {
+						if ctx.Err() != nil {
+							return nil
+						}
+						log.Printf("herald daemon: newsletter processing error: %v", err)
 					}
-					log.Printf("herald daemon: newsletter processing error: %v", err)
 				}
 
 				cycle++
@@ -75,6 +91,7 @@ Handles SIGINT/SIGTERM for graceful shutdown (finishes the current cycle).`,
 		},
 	}
 
-	cmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Minute, "duration between fetch cycles (e.g. 5m, 30s, 1h)")
+	cmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Minute, "duration between cycles (e.g. 5m, 30s, 1h)")
+	cmd.Flags().StringVar(&stagesCSV, "stages", "", "comma-separated stages to run: fetch,screen,curate (default all)")
 	return cmd
 }

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -385,7 +385,47 @@ func processCmd() *cobra.Command {
 // doFetch runs the complete fetch+process cycle once. Both the `fetch` command
 // and the `daemon` command call this. It uses the package-level cfg and
 // outputFormat variables.
-func doFetch(ctx context.Context) error {
+// stage identifies one of the daemon's three independent loops (#233). Splitting
+// them lets a slow screen drain (LLM-bound) run at its own cadence without
+// blocking feed fetching (network-bound) or per-user curation.
+type stage string
+
+const (
+	stageFetch  stage = "fetch"
+	stageScreen stage = "screen"
+	stageCurate stage = "curate"
+)
+
+type stageSet map[stage]bool
+
+func (s stageSet) has(st stage) bool { return s[st] }
+
+func allStages() stageSet {
+	return stageSet{stageFetch: true, stageScreen: true, stageCurate: true}
+}
+
+// parseStages parses a comma-separated stage list (e.g. "screen"); empty means
+// all three, preserving the single-service default.
+func parseStages(csv string) (stageSet, error) {
+	if strings.TrimSpace(csv) == "" {
+		return allStages(), nil
+	}
+	set := stageSet{}
+	for _, part := range strings.Split(csv, ",") {
+		switch st := stage(strings.TrimSpace(part)); st {
+		case stageFetch, stageScreen, stageCurate:
+			set[st] = true
+		default:
+			return nil, fmt.Errorf("unknown stage %q (valid: fetch, screen, curate)", part)
+		}
+	}
+	return set, nil
+}
+
+// runCycle runs one pass of the selected stages against a freshly opened store.
+// With all three stages (the default) it is the original fetch+process cycle;
+// the daemon can also run any subset as its own loop.
+func runCycle(ctx context.Context, stages stageSet) error {
 	cycleStart := time.Now()
 	formatter := output.NewFormatter(output.Format(outputFormat))
 
@@ -423,18 +463,112 @@ func doFetch(ctx context.Context) error {
 		}
 	}()
 
-	// Get all feeds due to fetch this cycle. Adaptive scheduling stages
-	// next_fetch_at across feeds, so it's normal for an individual cycle to
-	// have zero due — the AI passes downstream still need to run to drain
-	// pending work from prior cycles, so we don't early-return on this.
-	subscribedFeeds, err := store.GetAllSubscribedFeeds()
-	if err != nil {
-		return fmt.Errorf("failed to get subscribed feeds: %w", err)
+	// FETCH stage: pull every due feed once and enrich the new articles.
+	if stages.has(stageFetch) {
+		fr, err := runFetchStage(ctx, store, formatter)
+		if err != nil {
+			return err
+		}
+		fetchResult = fr
 	}
 
-	// Fetch each feed once (efficient)
+	// The screen and curate stages both need the AI backend; skip building the
+	// processor when this loop runs neither. Each drains pending work from prior
+	// cycles regardless of whether this cycle fetched anything new.
+	if !stages.has(stageScreen) && !stages.has(stageCurate) {
+		if fetchResult != nil {
+			return formatter.OutputFetchResult(fetchResult)
+		}
+		return nil
+	}
+
+	processor, err := ai.NewAIProcessor(cfg.Ollama.BaseURL, cfg.Ollama.SecurityModel, cfg.Ollama.CurationModel, store, cfg)
+	if err != nil {
+		formatter.Warning("failed to create AI processor: %v", err)
+		formatter.Warning("skipping AI processing (Ollama may not be running)")
+		if fetchResult != nil {
+			return formatter.OutputFetchResult(fetchResult)
+		}
+		return nil
+	}
+	aiBackendUp = processor.BackendAvailable()
+
+	groupMatcher, err := newGroupMatcher()
+	if err != nil {
+		formatter.Warning("failed to create group matcher: %v", err)
+		formatter.Warning("skipping embedding backfill and group matching")
+	}
+
+	// SCREEN stage: security screening and summarization are global -- each
+	// article is screened and summarized once, the verdict/summary shared by every
+	// subscriber (#141, #162). Runs before curation so this cycle's freshly
+	// screened articles are available to it. One breaker check, not one per user
+	// (#111). Concurrency-safe against other screen workers via the claim/lease
+	// on the article queue (#233).
+	if stages.has(stageScreen) {
+		securityStage := newPipelineStage(store, processor, groupMatcher, formatter, cfg.DefaultUserID)
+		totalProcessed, err := securityStage.RunSecurity(ctx)
+		if err != nil {
+			formatter.Warning("security pass failed: %v", err)
+		}
+		if _, err := securityStage.RunSummaries(ctx); err != nil {
+			formatter.Warning("summarize pass failed: %v", err)
+		}
+		if fetchResult != nil {
+			fetchResult.ProcessedCount = totalProcessed
+		}
+	}
+
+	// CURATE stage: the per-user pipeline. Each user's curation/grouping is driven
+	// from its own state-driven, newest-first query off the shared article
+	// verdicts, so freshly screened articles are curated ahead of older backlog.
+	if stages.has(stageCurate) {
+		allUserIDs, err := store.GetAllSubscribingUsers()
+		if err != nil {
+			return fmt.Errorf("failed to get subscribing users: %w", err)
+		}
+		if len(allUserIDs) == 0 {
+			formatter.Warning("no users with subscriptions")
+		}
+		for _, userID := range allUserIDs {
+			stage := newPipelineStage(store, processor, groupMatcher, formatter, userID)
+			if err := stage.Run(ctx); err != nil {
+				formatter.Warning("pipeline failed for user %d: %v", userID, err)
+			}
+		}
+	}
+
+	// Fetch-cycle summary + high-interest notification: only when this loop
+	// fetched (a screen/curate-only loop has no fetch tally to report).
+	if fetchResult != nil {
+		highInterestArticles, scores, err := store.GetArticlesByInterestScore(cfg.DefaultUserID, cfg.Thresholds.InterestScore, 10, 0, nil)
+		if err != nil {
+			return fmt.Errorf("failed to get high-interest articles: %w", err)
+		}
+		fetchResult.HighInterest = len(highInterestArticles)
+		if err := formatter.OutputFetchResult(fetchResult); err != nil {
+			return err
+		}
+		if len(highInterestArticles) > 0 {
+			if err := formatter.OutputHighInterestNotification(highInterestArticles, scores); err != nil {
+				formatter.Warning("notification output failed: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// runFetchStage fetches every due feed once and enriches the new articles
+// (full text, outbound links, images, favicons). Returns the cycle's fetch tally.
+func runFetchStage(ctx context.Context, store storage.Store, formatter *output.Formatter) (*output.FetchResult, error) {
+	subscribedFeeds, err := store.GetAllSubscribedFeeds()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subscribed feeds: %w", err)
+	}
+
 	fetcher := feeds.NewFetcher(store)
-	fetchResult = &output.FetchResult{FeedsTotal: len(subscribedFeeds)}
+	fetchResult := &output.FetchResult{FeedsTotal: len(subscribedFeeds)}
 	for _, feed := range subscribedFeeds {
 		feedCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		result, err := fetcher.FetchFeed(feedCtx, feed)
@@ -455,138 +589,50 @@ func doFetch(ctx context.Context) error {
 
 		fetchResult.FeedsDownloaded++
 
-		// Store articles (global, fetched once)
 		stored, err := fetcher.StoreArticles(feed.ID, result.Feed)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: error storing articles from %s: %v\n", feed.URL, err)
 		}
 		fetchResult.NewArticles += len(stored)
 
-		// Persist cache headers for next conditional request
 		if result.ETag != "" || result.LastModified != "" {
 			store.UpdateFeedCacheHeaders(feed.ID, result.ETag, result.LastModified)
 		}
 
-		// Update last fetched timestamp
 		if err := store.UpdateFeedLastFetched(feed.ID); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to update last_fetched for %s: %v\n", feed.URL, err)
 		}
 	}
 
-	// Fetch full text for any articles whose feed content appears truncated.
-	// This runs after all feeds are stored so the AI pipeline gets the best content.
+	// Full text for truncated feed content, run after all feeds are stored so the
+	// AI pipeline gets the best content.
 	if fullTextUpdated, err := fetcher.FetchFullTextForArticles(ctx); err != nil {
 		formatter.Warning("full-text fetch error: %v", err)
 	} else if fullTextUpdated > 0 {
 		fmt.Fprintf(os.Stdout, "Updated full text for %d articles\n", fullTextUpdated)
 	}
 
-	// Index outbound links (from the now-enriched body/summary) for the
-	// "which feed linked to this?" lookup. Runs after full-text so it sees the
-	// best content; backfills existing articles over cycles.
+	// Index outbound links from the enriched body for the "who linked this?"
+	// lookup; backfills existing articles over cycles.
 	if linksExtracted, err := fetcher.ExtractLinksForArticles(ctx); err != nil {
 		formatter.Warning("link extraction error: %v", err)
 	} else if linksExtracted > 0 {
 		fmt.Fprintf(os.Stdout, "Extracted links for %d articles\n", linksExtracted)
 	}
 
-	// Cache images referenced in article content.
 	if imagesStored, err := fetcher.CacheArticleImages(ctx); err != nil {
 		formatter.Warning("image cache error: %v", err)
 	} else if imagesStored > 0 {
 		fmt.Fprintf(os.Stdout, "Cached %d article images\n", imagesStored)
 	}
 
-	// Fetch and cache favicons for any newly-subscribed feeds.
 	if faviconStored, err := fetcher.FetchFaviconsForFeeds(ctx); err != nil {
 		formatter.Warning("favicon fetch error: %v", err)
 	} else if faviconStored > 0 {
 		fmt.Fprintf(os.Stdout, "Cached favicons for %d feeds\n", faviconStored)
 	}
 
-	// Run AI passes every cycle, regardless of whether new articles were fetched
-	// this cycle — pending work from prior cycles (unscored articles, missing
-	// summaries from transient failures) needs to drain.
-	processor, err := ai.NewAIProcessor(cfg.Ollama.BaseURL, cfg.Ollama.SecurityModel, cfg.Ollama.CurationModel, store, cfg)
-	if err != nil {
-		formatter.Warning("failed to create AI processor: %v", err)
-		formatter.Warning("skipping AI processing (Ollama may not be running)")
-		return formatter.OutputFetchResult(fetchResult)
-	}
-	aiBackendUp = processor.BackendAvailable()
-
-	// Get all users who have subscriptions
-	allUserIDs, err := store.GetAllSubscribingUsers()
-	if err != nil {
-		return fmt.Errorf("failed to get subscribing users: %w", err)
-	}
-
-	if len(allUserIDs) == 0 {
-		formatter.Warning("no users with subscriptions")
-		return formatter.OutputFetchResult(fetchResult)
-	}
-
-	groupMatcher, err := newGroupMatcher()
-	if err != nil {
-		formatter.Warning("failed to create group matcher: %v", err)
-		formatter.Warning("skipping embedding backfill and group matching")
-	}
-
-	// Security screening and summarization are global: each article is screened
-	// and summarized once, with the verdict and summary shared by every
-	// subscriber (#141, #162), so run both once per cycle before the per-user
-	// pipelines rather than redoing them per user. One breaker check, not one
-	// per user (#111).
-	securityStage := newPipelineStage(store, processor, groupMatcher, formatter, cfg.DefaultUserID)
-	totalProcessed, err := securityStage.RunSecurity(ctx)
-	if err != nil {
-		formatter.Warning("security pass failed: %v", err)
-	}
-	if _, err := securityStage.RunSummaries(ctx); err != nil {
-		formatter.Warning("summarize pass failed: %v", err)
-	}
-
-	// Run the per-user pipeline for each subscribing user. It drives every stage
-	// from its own state-driven, newest-first query, reading the article-level
-	// security verdict to decide what to curate, so this cycle's freshly
-	// screened articles are processed ahead of older backlog, and anything left
-	// pending from prior cycles drains the same way. Self-skips when the AI
-	// backend is unavailable.
-	for _, userID := range allUserIDs {
-		stage := newPipelineStage(store, processor, groupMatcher, formatter, userID)
-		if err := stage.Run(ctx); err != nil {
-			formatter.Warning("pipeline failed for user %d: %v", userID, err)
-		}
-	}
-
-	fetchResult.ProcessedCount = totalProcessed
-
-	// Get and output high-interest articles
-	// Show high-interest articles for the first subscribing user.
-	var displayUserID int64 = 1
-	if len(allUserIDs) > 0 {
-		displayUserID = allUserIDs[0]
-	}
-	highInterestArticles, scores, err := store.GetArticlesByInterestScore(displayUserID, cfg.Thresholds.InterestScore, 10, 0, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get high-interest articles: %w", err)
-	}
-
-	fetchResult.HighInterest = len(highInterestArticles)
-
-	// Output result summary
-	if err := formatter.OutputFetchResult(fetchResult); err != nil {
-		return err
-	}
-
-	// Output high-interest notifications
-	if len(highInterestArticles) > 0 {
-		if err := formatter.OutputHighInterestNotification(highInterestArticles, scores); err != nil {
-			formatter.Warning("notification output failed: %v", err)
-		}
-	}
-
-	return nil
+	return fetchResult, nil
 }
 
 // processNewsletters creates a temporary Engine and processes due newsletters.
@@ -621,7 +667,7 @@ func fetchCmd() *cobra.Command {
 		Use:   "fetch",
 		Short: "Fetch all feeds and process articles with AI",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doFetch(context.Background())
+			return runCycle(context.Background(), allStages())
 		},
 	}
 }

--- a/cmd/herald/main_test.go
+++ b/cmd/herald/main_test.go
@@ -211,3 +211,40 @@ func TestPersistentPreRun_HonorsSkipAnnotation(t *testing.T) {
 		}
 	})
 }
+
+func TestParseStages(t *testing.T) {
+	all := allStages()
+	// Empty means all three (single-service default).
+	got, err := parseStages("")
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	for st := range all {
+		if !got.has(st) {
+			t.Errorf("empty should enable %q", st)
+		}
+	}
+
+	// A subset enables only the named stages.
+	got, err = parseStages("screen")
+	if err != nil {
+		t.Fatalf("screen: %v", err)
+	}
+	if !got.has(stageScreen) || got.has(stageFetch) || got.has(stageCurate) {
+		t.Errorf(`"screen" should enable only screen, got %v`, got)
+	}
+
+	// Comma-separated, whitespace-tolerant.
+	got, err = parseStages("fetch, curate")
+	if err != nil {
+		t.Fatalf("fetch,curate: %v", err)
+	}
+	if !got.has(stageFetch) || !got.has(stageCurate) || got.has(stageScreen) {
+		t.Errorf(`"fetch, curate" should enable fetch+curate only, got %v`, got)
+	}
+
+	// Unknown stage is rejected (fail-closed rather than silently doing nothing).
+	if _, err := parseStages("frobnicate"); err == nil {
+		t.Error("unknown stage should error")
+	}
+}

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -14,6 +14,13 @@ const clusterCohortLimit = 500
 // drainBatch is how many articles each stage pulls per query.
 const drainBatch = 100
 
+// securityClaimLeaseSeconds is how long a claimed-but-not-yet-verdicted article
+// stays off other screeners' queues (#233). It must comfortably exceed the
+// worst-case single-article screen latency (olla round-trip); a crashed worker's
+// claim is reclaimable only after this window, so too short risks a double
+// screen, too long delays recovery. 10 minutes is well clear of a Gemma call.
+const securityClaimLeaseSeconds = 600
+
 // RunSecurity screens every not-yet-screened article exactly once, globally. The
 // security verdict is a property of the content, shared by all subscribers
 // (#141), so this runs once per cycle rather than once per user — and it checks
@@ -28,7 +35,9 @@ func (s *Stage) RunSecurity(ctx context.Context) (int, error) {
 	}
 	processed := 0
 	err := s.drain(
-		func(limit int) ([]storage.Article, error) { return s.Store.GetUnscreenedArticles(limit) },
+		func(limit int) ([]storage.Article, error) {
+			return s.Store.ClaimUnscreenedArticles(limit, securityClaimLeaseSeconds)
+		},
 		func(arts []storage.Article) { processed += len(s.Security(ctx, arts)) },
 	)
 	return processed, err

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -36,6 +36,15 @@ func (s *Stage) RunSecurity(ctx context.Context) (int, error) {
 	processed := 0
 	err := s.drain(
 		func(limit int) ([]storage.Article, error) {
+			// Stop claiming the moment the breaker opens. The claim counts an
+			// attempt per article (#233); if we kept claiming while Security
+			// self-skips an open breaker, a backend outage would burn the retry
+			// budget on unscreened articles and strand the whole queue in a few
+			// cycles. Articles already claimed in the batch that tripped the
+			// breaker are refunded per-article in securityOne (#100).
+			if !s.AI.BackendAvailable() {
+				return nil, nil
+			}
 			return s.Store.ClaimUnscreenedArticles(limit, securityClaimLeaseSeconds)
 		},
 		func(arts []storage.Article) { processed += len(s.Security(ctx, arts)) },

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -49,12 +49,15 @@ func (s *Stage) securityOne(ctx context.Context, article storage.Article) *stora
 	secResult, err := s.AI.SecurityCheck(ctx, article.Title, content)
 	if err != nil {
 		s.Formatter.Warning("security check failed for article %d: %v", article.ID, err)
-		// Only a genuine model-response failure counts against the retry budget;
-		// a backend-unavailable error means we never got a verdict, so re-queue
-		// without incrementing and let a later cycle retry once the backend
-		// recovers (#100).
-		if !errors.Is(err, ai.ErrBackendUnavailable) {
-			s.Store.IncrementArticleSecurityAttempts(article.ID) //nolint:errcheck
+		// The attempt was counted when the article was claimed (#233). A genuine
+		// model-response failure keeps that attempt (bounding retries) and just
+		// releases the claim so it can be retried before the lease expires. A
+		// backend-unavailable error means we never got a verdict, so refund the
+		// attempt too -- an olla outage must not burn the retry budget (#100).
+		if errors.Is(err, ai.ErrBackendUnavailable) {
+			s.Store.RefundSecurityClaim(article.ID) //nolint:errcheck
+		} else {
+			s.Store.ReleaseSecurityClaim(article.ID) //nolint:errcheck
 		}
 		return nil
 	}

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -32,7 +33,11 @@ type fakeAI struct {
 	secCalls, sumCalls, curCalls int
 }
 
-func (f *fakeAI) BackendAvailable() bool { return f.available }
+func (f *fakeAI) BackendAvailable() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.available
+}
 
 func (f *fakeAI) GenerateGroupSummary(_ context.Context, _ int64, topic string, articles []ai.GroupSummaryInput) (*ai.GroupSummaryResult, error) {
 	if f.groupSummaryFn != nil {
@@ -197,6 +202,72 @@ func TestSecurityRetryBudget(t *testing.T) {
 			t.Fatalf("article should drop out after 3 verdict failures, got %v", ids(unscored))
 		}
 	})
+}
+
+// TestSecurityStopsClaimingWhenBreakerTripsMidDrain guards the #233 interaction:
+// the claim counts an attempt per article, so if the drain kept claiming after
+// the breaker opens mid-batch (while Security self-skips), a backend outage would
+// burn the retry budget on unscreened articles and strand the queue. Here the
+// breaker trips on the first call (during batch 1); with the guard, later batches
+// are never claimed, so an oldest (batch-2) article keeps its full 3-attempt
+// budget. Without the guard it would have been claimed once (budget 2).
+func TestSecurityStopsClaimingWhenBreakerTripsMidDrain(t *testing.T) {
+	fake := &fakeAI{available: true}
+	fake.securityFn = func(string, string) (*ai.SecurityResult, error) {
+		fake.mu.Lock()
+		fake.available = false // breaker opens on the first real failure
+		fake.mu.Unlock()
+		return nil, ai.ErrBackendUnavailable
+	}
+	st, store, feedID := newHarness(t, fake)
+
+	// One definitively-oldest article (lands in batch 2), plus a full first batch
+	// of newer ones so the drain must fetch a second batch to reach the old one.
+	old := time.Now().Add(-72 * time.Hour)
+	oldID, err := store.AddArticle(&storage.Article{
+		FeedID: feedID, GUID: "oldest", Title: "oldest",
+		URL: "https://example.com/oldest", Content: strings.Repeat("x", 500), PublishedDate: &old,
+	})
+	if err != nil {
+		t.Fatalf("seed oldest: %v", err)
+	}
+	for i := 0; i < drainBatch+4; i++ {
+		seed(t, store, feedID, fmt.Sprintf("n%d", i), strings.Repeat("x", 500))
+	}
+
+	if _, err := st.RunSecurity(context.Background()); err != nil {
+		t.Fatalf("RunSecurity: %v", err)
+	}
+
+	// Probe the oldest article's remaining claim budget: with an expired lease it
+	// is claimable (3 - attempts) times before the attempts<3 cap excludes it. 3
+	// means no attempt was burned -- the guard stopped the drain before batch 2.
+	if got := remainingClaimBudget(t, store, oldID); got != 3 {
+		t.Fatalf("oldest article claim budget = %d, want 3 (a mid-drain breaker burned the retry budget)", got)
+	}
+}
+
+// remainingClaimBudget counts how many times articleID can still be claimed
+// (lease expired) before the attempts cap excludes it: 3 - current attempts.
+func remainingClaimBudget(t *testing.T, store storage.Store, articleID int64) int {
+	t.Helper()
+	for n := 0; n <= 4; n++ {
+		got, err := store.ClaimUnscreenedArticles(500, 0)
+		if err != nil {
+			t.Fatalf("claim probe: %v", err)
+		}
+		found := false
+		for _, a := range got {
+			if a.ID == articleID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return n
+		}
+	}
+	return 99 // never excluded -- unexpected
 }
 
 func TestSecurityStageSkipsWhenBreakerOpen(t *testing.T) {

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -162,17 +162,20 @@ func TestSecurityStageGatesAndMarks(t *testing.T) {
 }
 
 func TestSecurityRetryBudget(t *testing.T) {
-	// A backend-unavailable error must NOT burn the retry budget (#100): the
-	// article keeps coming back. A genuine verdict failure does, so after three
-	// it drops out of the unscored queue.
+	// The retry budget is spent at claim time now (#233): each RunSecurity cycle
+	// claims the article once, incrementing its attempt. A genuine verdict failure
+	// keeps that attempt (so after three cycles it drops out of the queue); a
+	// backend-unavailable error refunds it (#100), so the article keeps coming
+	// back. These drive RunSecurity (the real claim-based drain), not Security()
+	// directly, since the claim is where the attempt is counted.
 	t.Run("backend unavailable does not increment", func(t *testing.T) {
 		fake := &fakeAI{available: true, securityFn: func(string, string) (*ai.SecurityResult, error) {
 			return nil, ai.ErrBackendUnavailable
 		}}
 		st, store, feedID := newHarness(t, fake)
-		art := seed(t, store, feedID, "x", strings.Repeat("x", 500))
+		seed(t, store, feedID, "x", strings.Repeat("x", 500))
 		for range 4 {
-			st.Security(context.Background(), []storage.Article{art})
+			st.RunSecurity(context.Background()) //nolint:errcheck
 		}
 		unscored, _ := store.GetUnscreenedArticles(10)
 		if len(unscored) != 1 {
@@ -185,9 +188,9 @@ func TestSecurityRetryBudget(t *testing.T) {
 			return nil, errors.New("unparseable verdict")
 		}}
 		st, store, feedID := newHarness(t, fake)
-		art := seed(t, store, feedID, "x", strings.Repeat("x", 500))
+		seed(t, store, feedID, "x", strings.Repeat("x", 500))
 		for range 3 {
-			st.Security(context.Background(), []storage.Article{art})
+			st.RunSecurity(context.Background()) //nolint:errcheck
 		}
 		unscored, _ := store.GetUnscreenedArticles(10)
 		if len(unscored) != 0 {

--- a/internal/storage/claim_test.go
+++ b/internal/storage/claim_test.go
@@ -1,0 +1,203 @@
+package storage
+
+import (
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// seedUnscreened adds n unscreened articles to a fresh subscribed feed and
+// returns their IDs.
+func seedUnscreened(t *testing.T, store Store, n int) []int64 {
+	t.Helper()
+	feedID, _ := store.AddFeed("https://example.com/feed", "Feed", "")
+	if err := store.SubscribeUserToFeed(1, feedID); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	now := time.Now()
+	ids := make([]int64, n)
+	for i := range ids {
+		id, err := store.AddArticle(&Article{
+			FeedID: feedID, GUID: string(rune('a' + i)), Title: "t",
+			URL: "https://example.com/" + string(rune('a'+i)), PublishedDate: &now,
+		})
+		if err != nil {
+			t.Fatalf("add: %v", err)
+		}
+		ids[i] = id
+	}
+	return ids
+}
+
+func idSet(arts []Article) map[int64]bool {
+	m := make(map[int64]bool, len(arts))
+	for _, a := range arts {
+		m[a.ID] = true
+	}
+	return m
+}
+
+// TestClaimUnscreenedArticles_HoldsAndReclaims verifies the claim keeps a row off
+// other workers' queues until the lease expires, and that an expired lease makes
+// it claimable again -- bounded by the attempts cap (#233).
+func TestClaimUnscreenedArticles_HoldsAndReclaims(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		ids := seedUnscreened(t, store, 3)
+
+		// A live-lease claim holds its rows: successive claims return the rest,
+		// never a row already held.
+		first, err := store.ClaimUnscreenedArticles(2, 600)
+		if err != nil {
+			t.Fatalf("claim 1: %v", err)
+		}
+		if len(first) != 2 {
+			t.Fatalf("claim 1 returned %d, want 2", len(first))
+		}
+		second, err := store.ClaimUnscreenedArticles(2, 600)
+		if err != nil {
+			t.Fatalf("claim 2: %v", err)
+		}
+		if len(second) != 1 {
+			t.Fatalf("claim 2 returned %d, want 1 (two still held)", len(second))
+		}
+		for id := range idSet(second) {
+			if idSet(first)[id] {
+				t.Errorf("article %d claimed twice under a live lease", id)
+			}
+		}
+		if got := len(first) + len(second); got != len(ids) {
+			t.Fatalf("claimed %d distinct, want %d", got, len(ids))
+		}
+		// Nothing left to claim while all leases are live.
+		if again, _ := store.ClaimUnscreenedArticles(10, 600); len(again) != 0 {
+			t.Fatalf("claim under live leases returned %d, want 0", len(again))
+		}
+
+		// A zero-second lease treats every claim as expired -> reclaimable, but
+		// each reclaim spends an attempt, so after the cap (3) the row is gone.
+		// The rows already have 1 attempt from above; two more reclaims exhaust it.
+		for round := 0; round < 2; round++ {
+			got, err := store.ClaimUnscreenedArticles(10, 0)
+			if err != nil {
+				t.Fatalf("reclaim round %d: %v", round, err)
+			}
+			if len(got) != len(ids) {
+				t.Fatalf("reclaim round %d returned %d, want %d", round, len(got), len(ids))
+			}
+		}
+		if got, _ := store.ClaimUnscreenedArticles(10, 0); len(got) != 0 {
+			t.Fatalf("claim after attempts exhausted returned %d, want 0", len(got))
+		}
+	})
+}
+
+// TestRefundSecurityClaim_RestoresAttempt verifies a refund returns the budget so
+// a backend outage does not permanently retire an article.
+func TestRefundSecurityClaim_RestoresAttempt(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		id := seedUnscreened(t, store, 1)[0]
+		// Exhaust the budget: three reclaims with an expired lease.
+		for i := 0; i < 3; i++ {
+			store.ClaimUnscreenedArticles(10, 0) //nolint:errcheck
+		}
+		if got, _ := store.ClaimUnscreenedArticles(10, 0); len(got) != 0 {
+			t.Fatalf("precondition: expected exhausted, got %d claimable", len(got))
+		}
+		if err := store.RefundSecurityClaim(id); err != nil {
+			t.Fatalf("refund: %v", err)
+		}
+		got, err := store.ClaimUnscreenedArticles(10, 0)
+		if err != nil {
+			t.Fatalf("claim after refund: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != id {
+			t.Fatalf("after refund expected article %d claimable, got %v", id, idSet(got))
+		}
+	})
+}
+
+// TestReleaseSecurityClaim_ImmediateRetry verifies releasing a claim makes the
+// row claimable again without waiting for the lease to expire.
+func TestReleaseSecurityClaim_ImmediateRetry(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		id := seedUnscreened(t, store, 1)[0]
+		if got, _ := store.ClaimUnscreenedArticles(1, 600); len(got) != 1 {
+			t.Fatalf("initial claim returned %d, want 1", len(got))
+		}
+		// Held under a live lease.
+		if got, _ := store.ClaimUnscreenedArticles(1, 600); len(got) != 0 {
+			t.Fatalf("expected held under live lease, got %d", len(got))
+		}
+		if err := store.ReleaseSecurityClaim(id); err != nil {
+			t.Fatalf("release: %v", err)
+		}
+		if got, _ := store.ClaimUnscreenedArticles(1, 600); len(got) != 1 {
+			t.Fatalf("expected reclaimable after release, got %d", len(got))
+		}
+	})
+}
+
+// TestScreenArticleSecurity_LeavesClaimQueue verifies a recorded verdict removes
+// the row from the claim queue (and clears its claim).
+func TestScreenArticleSecurity_LeavesClaimQueue(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		id := seedUnscreened(t, store, 1)[0]
+		if got, _ := store.ClaimUnscreenedArticles(1, 600); len(got) != 1 {
+			t.Fatalf("claim returned %d, want 1", len(got))
+		}
+		if err := store.ScreenArticleSecurity(id, 1, "none", false, false); err != nil {
+			t.Fatalf("screen: %v", err)
+		}
+		if got, _ := store.ClaimUnscreenedArticles(10, 0); len(got) != 0 {
+			t.Fatalf("screened article still claimable: %d", len(got))
+		}
+	})
+}
+
+// TestClaimUnscreenedArticles_ConcurrentDisjoint verifies FOR UPDATE SKIP LOCKED:
+// two workers claiming at once never grab the same article.
+func TestClaimUnscreenedArticles_ConcurrentDisjoint(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		ids := seedUnscreened(t, store, 20)
+
+		var wg sync.WaitGroup
+		results := make([][]Article, 4)
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				got, err := store.ClaimUnscreenedArticles(10, 600)
+				if err != nil {
+					t.Errorf("worker %d claim: %v", w, err)
+					return
+				}
+				results[w] = got
+			}(w)
+		}
+		wg.Wait()
+
+		seen := map[int64]int{}
+		total := 0
+		for _, r := range results {
+			total += len(r)
+			for _, a := range r {
+				seen[a.ID]++
+			}
+		}
+		for id, c := range seen {
+			if c > 1 {
+				t.Errorf("article %d claimed by %d workers concurrently", id, c)
+			}
+		}
+		if total != len(ids) {
+			// All 20 within budget should be claimed exactly once across workers.
+			claimed := make([]int64, 0, len(seen))
+			for id := range seen {
+				claimed = append(claimed, id)
+			}
+			sort.Slice(claimed, func(i, j int) bool { return claimed[i] < claimed[j] })
+			t.Errorf("claimed %d total across workers, want %d (distinct=%d)", total, len(ids), len(seen))
+		}
+	})
+}

--- a/internal/storage/db/article.sql.go
+++ b/internal/storage/db/article.sql.go
@@ -44,6 +44,81 @@ func (q *Queries) AddArticle(ctx context.Context, arg AddArticleParams) (int64, 
 	return id, err
 }
 
+const claimUnscreenedArticles = `-- name: ClaimUnscreenedArticles :many
+UPDATE articles a
+SET screening_claimed_at = NOW(), security_attempts = a.security_attempts + 1
+FROM (
+    SELECT id FROM articles
+    WHERE security_screened_at IS NULL
+      AND security_attempts < 3
+      AND (screening_claimed_at IS NULL
+           OR screening_claimed_at < NOW() - make_interval(secs => $1::double precision))
+    ORDER BY published_date DESC
+    LIMIT $2
+    FOR UPDATE SKIP LOCKED
+) claimed
+WHERE a.id = claimed.id
+RETURNING a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+          a.author, a.published_date, a.fetched_date
+`
+
+type ClaimUnscreenedArticlesParams struct {
+	LeaseSeconds float64
+	Lim          int32
+}
+
+type ClaimUnscreenedArticlesRow struct {
+	ID            int64
+	FeedID        int64
+	Guid          string
+	Title         string
+	Url           string
+	Content       *string
+	Summary       *string
+	Author        *string
+	PublishedDate *time.Time
+	FetchedDate   time.Time
+}
+
+// Atomically claim up to @lim unscreened articles for a screener worker (#233):
+// pick rows not yet screened, within the retry budget, and either unclaimed or
+// whose prior claim lease has expired (@lease_seconds ago). FOR UPDATE SKIP
+// LOCKED means concurrent workers never contend on or double-grab a row. The
+// claim is stamped and the attempt counted here, not on failure, so a poison
+// article that keeps crashing a worker is bounded by security_attempts < 3
+// instead of being reclaimed forever; a clean backend-unavailable result refunds
+// the attempt (RefundSecurityClaim).
+func (q *Queries) ClaimUnscreenedArticles(ctx context.Context, arg ClaimUnscreenedArticlesParams) ([]ClaimUnscreenedArticlesRow, error) {
+	rows, err := q.db.Query(ctx, claimUnscreenedArticles, arg.LeaseSeconds, arg.Lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ClaimUnscreenedArticlesRow{}
+	for rows.Next() {
+		var i ClaimUnscreenedArticlesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.FeedID,
+			&i.Guid,
+			&i.Title,
+			&i.Url,
+			&i.Content,
+			&i.Summary,
+			&i.Author,
+			&i.PublishedDate,
+			&i.FetchedDate,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findDuplicateArticle = `-- name: FindDuplicateArticle :one
 SELECT id FROM articles
 WHERE title = $1 AND published_date = $2
@@ -658,13 +733,40 @@ func (q *Queries) MarkArticleFullTextFetched(ctx context.Context, id int64) erro
 	return err
 }
 
+const refundSecurityClaim = `-- name: RefundSecurityClaim :exec
+UPDATE articles
+SET screening_claimed_at = NULL,
+    security_attempts = GREATEST(security_attempts - 1, 0)
+WHERE id = $1
+`
+
+// Clear the claim AND return the attempt after a backend-unavailable result: we
+// never got a verdict, so an olla outage must not burn the retry budget (#100).
+func (q *Queries) RefundSecurityClaim(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, refundSecurityClaim, id)
+	return err
+}
+
+const releaseSecurityClaim = `-- name: ReleaseSecurityClaim :exec
+UPDATE articles SET screening_claimed_at = NULL WHERE id = $1
+`
+
+// Clear the claim after a genuine (non-backend) screening failure so the row can
+// be retried without waiting for the lease to expire. The attempt was already
+// counted at claim time.
+func (q *Queries) ReleaseSecurityClaim(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, releaseSecurityClaim, id)
+	return err
+}
+
 const screenArticleSecurity = `-- name: ScreenArticleSecurity :exec
 UPDATE articles
 SET security_threat = $1::double precision,
     security_category = $2::text,
     security_verified = $3,
     security_flagged = $4,
-    security_screened_at = NOW()
+    security_screened_at = NOW(),
+    screening_claimed_at = NULL
 WHERE id = $5
 `
 
@@ -708,7 +810,8 @@ func (q *Queries) SetInterestScore(ctx context.Context, arg SetInterestScorePara
 
 const skipArticleSecurity = `-- name: SkipArticleSecurity :exec
 UPDATE articles
-SET security_screened_at = NOW()
+SET security_screened_at = NOW(),
+    screening_claimed_at = NULL
 WHERE id = $1
 `
 

--- a/internal/storage/db/models.go
+++ b/internal/storage/db/models.go
@@ -51,6 +51,7 @@ type Article struct {
 	LinksExtracted     bool
 	SecurityCategory   *string
 	SecurityVerified   *bool
+	ScreeningClaimedAt *time.Time
 }
 
 type ArticleAuthor struct {

--- a/internal/storage/db/queries/article.sql
+++ b/internal/storage/db/queries/article.sql
@@ -51,6 +51,45 @@ WHERE a.security_screened_at IS NULL AND a.security_attempts < 3
 ORDER BY a.published_date DESC
 LIMIT @lim;
 
+-- name: ClaimUnscreenedArticles :many
+-- Atomically claim up to @lim unscreened articles for a screener worker (#233):
+-- pick rows not yet screened, within the retry budget, and either unclaimed or
+-- whose prior claim lease has expired (@lease_seconds ago). FOR UPDATE SKIP
+-- LOCKED means concurrent workers never contend on or double-grab a row. The
+-- claim is stamped and the attempt counted here, not on failure, so a poison
+-- article that keeps crashing a worker is bounded by security_attempts < 3
+-- instead of being reclaimed forever; a clean backend-unavailable result refunds
+-- the attempt (RefundSecurityClaim).
+UPDATE articles a
+SET screening_claimed_at = NOW(), security_attempts = a.security_attempts + 1
+FROM (
+    SELECT id FROM articles
+    WHERE security_screened_at IS NULL
+      AND security_attempts < 3
+      AND (screening_claimed_at IS NULL
+           OR screening_claimed_at < NOW() - make_interval(secs => @lease_seconds::double precision))
+    ORDER BY published_date DESC
+    LIMIT @lim
+    FOR UPDATE SKIP LOCKED
+) claimed
+WHERE a.id = claimed.id
+RETURNING a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+          a.author, a.published_date, a.fetched_date;
+
+-- name: ReleaseSecurityClaim :exec
+-- Clear the claim after a genuine (non-backend) screening failure so the row can
+-- be retried without waiting for the lease to expire. The attempt was already
+-- counted at claim time.
+UPDATE articles SET screening_claimed_at = NULL WHERE id = @id;
+
+-- name: RefundSecurityClaim :exec
+-- Clear the claim AND return the attempt after a backend-unavailable result: we
+-- never got a verdict, so an olla outage must not burn the retry budget (#100).
+UPDATE articles
+SET screening_claimed_at = NULL,
+    security_attempts = GREATEST(security_attempts - 1, 0)
+WHERE id = @id;
+
 -- name: GetUnscoredCurationArticles :many
 SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
        a.author, a.published_date, a.fetched_date
@@ -117,7 +156,8 @@ SET security_threat = @security_threat::double precision,
     security_category = @security_category::text,
     security_verified = @security_verified,
     security_flagged = @security_flagged,
-    security_screened_at = NOW()
+    security_screened_at = NOW(),
+    screening_claimed_at = NULL
 WHERE id = @id;
 
 -- name: SkipArticleSecurity :exec
@@ -125,7 +165,8 @@ WHERE id = @id;
 -- skip reason is herald-authored, not attacker text, but the column that held it
 -- is gone (plan 012); screened_at + NULL threat already encodes the state.
 UPDATE articles
-SET security_screened_at = NOW()
+SET security_screened_at = NOW(),
+    screening_claimed_at = NULL
 WHERE id = @id;
 
 -- name: IncrementArticleSecurityAttempts :exec

--- a/internal/storage/db/queries/read_state.sql
+++ b/internal/storage/db/queries/read_state.sql
@@ -64,7 +64,8 @@ WHERE user_id = @user_id;
 -- name: ResetArticleScores :execrows
 UPDATE articles
 SET security_threat = NULL, security_category = NULL, security_verified = NULL,
-    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0
+    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0,
+    screening_claimed_at = NULL
 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = @user_id);
 
 -- name: ResetArticleScoresBelow :execrows
@@ -72,6 +73,7 @@ WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = @user_id);
 -- score (above the ceiling), where the old safety scale made it a LOW one.
 UPDATE articles
 SET security_threat = NULL, security_category = NULL, security_verified = NULL,
-    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0
+    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0,
+    screening_claimed_at = NULL
 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = @user_id)
   AND security_threat IS NOT NULL AND security_threat > @above_threat::double precision;

--- a/internal/storage/db/read_state.sql.go
+++ b/internal/storage/db/read_state.sql.go
@@ -96,7 +96,8 @@ func (q *Queries) IncrementAIRetries(ctx context.Context, arg IncrementAIRetries
 const resetArticleScores = `-- name: ResetArticleScores :execrows
 UPDATE articles
 SET security_threat = NULL, security_category = NULL, security_verified = NULL,
-    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0
+    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0,
+    screening_claimed_at = NULL
 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = $1)
 `
 
@@ -111,7 +112,8 @@ func (q *Queries) ResetArticleScores(ctx context.Context, userID int64) (int64, 
 const resetArticleScoresBelow = `-- name: ResetArticleScoresBelow :execrows
 UPDATE articles
 SET security_threat = NULL, security_category = NULL, security_verified = NULL,
-    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0
+    security_flagged = FALSE, security_screened_at = NULL, security_attempts = 0,
+    screening_claimed_at = NULL
 WHERE feed_id IN (SELECT feed_id FROM user_feeds WHERE user_id = $1)
   AND security_threat IS NOT NULL AND security_threat > $2::double precision
 `

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 8 {
-		t.Errorf("goose max version = %d, want 8", maxVersion)
+	if maxVersion != 9 {
+		t.Errorf("goose max version = %d, want 9", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0009_screening_claim.sql
+++ b/internal/storage/migrations/0009_screening_claim.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+--
+-- Add a claim/lease column so the security screen can run as N concurrent
+-- drainers (issue #233) -- whether N goroutines in one process or N separate
+-- containers, they contend on the same queue and must not screen the same
+-- article twice. screening_claimed_at is stamped when a worker claims a row and
+-- cleared when the verdict is written; a claim older than the lease is
+-- reclaimable (crash recovery). The claim query increments security_attempts, so
+-- a poison article that repeatedly crashes a worker is eventually excluded by the
+-- existing attempts < 3 cap rather than looping forever.
+
+ALTER TABLE articles ADD COLUMN screening_claimed_at TIMESTAMPTZ;
+
+-- Hot predicate for the claim query: unscreened rows still within the retry
+-- budget, newest first. Narrower than idx_articles_unscreened (which omits the
+-- attempts bound), so the claimant scan stays small as screened rows pile up.
+CREATE INDEX IF NOT EXISTS idx_articles_screen_claimable
+    ON articles (published_date DESC)
+    WHERE security_screened_at IS NULL AND security_attempts < 3;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_articles_screen_claimable;
+ALTER TABLE articles DROP COLUMN screening_claimed_at;

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -890,6 +890,35 @@ func (s *PostgresStore) GetUnscreenedArticles(limit int) ([]Article, error) {
 	return articles, nil
 }
 
+func (s *PostgresStore) ClaimUnscreenedArticles(limit int, leaseSeconds float64) ([]Article, error) {
+	rows, err := s.q.ClaimUnscreenedArticles(context.Background(), db.ClaimUnscreenedArticlesParams{
+		LeaseSeconds: leaseSeconds,
+		Lim:          int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("claim unscreened articles: %w", err)
+	}
+	articles := make([]Article, len(rows))
+	for i, r := range rows {
+		articles[i] = coreArticle(r.ID, r.FeedID, r.Guid, r.Title, r.Url, r.Content, r.Summary, r.Author, r.PublishedDate, r.FetchedDate)
+	}
+	return articles, nil
+}
+
+func (s *PostgresStore) ReleaseSecurityClaim(articleID int64) error {
+	if err := s.q.ReleaseSecurityClaim(context.Background(), articleID); err != nil {
+		return fmt.Errorf("release security claim: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) RefundSecurityClaim(articleID int64) error {
+	if err := s.q.RefundSecurityClaim(context.Background(), articleID); err != nil {
+		return fmt.Errorf("refund security claim: %w", err)
+	}
+	return nil
+}
+
 // GetUnscoredCurationArticles returns articles that passed the security screen
 // but have not yet been interest-scored (interest_score IS NULL). Backfill input
 // for the staged pipeline's curation stage. See the SQLite implementation.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -129,6 +129,18 @@ type Store interface {
 	SkipArticleSecurity(articleID int64, reason string) error
 	IncrementArticleSecurityAttempts(articleID int64) error
 	GetUnscreenedArticles(limit int) ([]Article, error)
+	// ClaimUnscreenedArticles atomically claims up to limit unscreened articles for
+	// a screener worker (#233), skipping rows another worker holds and reclaiming
+	// any whose lease (leaseSeconds) has expired. It counts the attempt; a clean
+	// backend-unavailable result must refund it via RefundSecurityClaim, and a
+	// genuine failure clears the claim via ReleaseSecurityClaim.
+	ClaimUnscreenedArticles(limit int, leaseSeconds float64) ([]Article, error)
+	// ReleaseSecurityClaim clears an article's claim after a genuine screening
+	// failure so it can be retried before the lease expires (attempt already spent).
+	ReleaseSecurityClaim(articleID int64) error
+	// RefundSecurityClaim clears the claim and returns the attempt after a
+	// backend-unavailable result, so an olla outage does not burn the retry budget.
+	RefundSecurityClaim(articleID int64) error
 	// GetScreenedArticleSample returns a random sample of screened articles with
 	// content, for the plan-012 score-comparison harness. Diagnostic; read-only.
 	GetScreenedArticleSample(limit int) ([]ScreenedArticle, error)


### PR DESCRIPTION
Closes #233.

> **Stacked on #230** (`229-drop-read_state-security-cols`) so the migration chain stays contiguous: `0008` (read_state drop) then `0009` (screening claim). Merge #230 first; I'll rebase this onto main and the base will retarget automatically. The diff shown here is #233-only.

## Why

The daemon ran one sequential cycle -- fetch -> screen -> curate -- gated by a single interval. Screening is the LLM-bound bottleneck; fetch is cheap and network-bound. Chaining them means a long screen drain blocks the next fetch entirely. The plan-012 rescore made this concrete: re-screening ~35k articles starves feed fetching for the whole drain.

## The split

`herald daemon --stages fetch|screen|curate` (comma-separated; **default all three**, preserving today's single-service behavior). Run them as separate containers off the same image, each with its own interval, to decouple cadence and failure domains.

- `runCycle` runs the selected stages against a freshly opened store; the fetch body is extracted into `runFetchStage`.
- Curate owns due-newsletter processing, so a fetch/screen-only loop does not send digests.
- Cycle stats are recorded only when the fetch stage runs.

## Concurrency-safe screening (migration 0009)

Screening is now safe for **N screen workers** -- N goroutines in one process or N containers -- via a per-article claim/lease (`screening_claimed_at`):

- `ClaimUnscreenedArticles` atomically claims a batch with `FOR UPDATE SKIP LOCKED`, so concurrent workers never grab the same row, and reclaims rows whose lease (**10 min**, well clear of a Gemma round-trip) has expired -- crash recovery.
- **Attempt counted at claim time**, not on failure, so a poison article that keeps crashing a worker is bounded by the existing `attempts < 3` cap instead of looping forever (the design decision from the issue's open questions).
- A genuine verdict failure **releases** the claim for immediate retry (attempt kept); a backend-unavailable result **refunds** the attempt and clears the claim, so an olla outage never burns the retry budget (#100).
- `ScreenArticleSecurity`/`SkipArticleSecurity` clear the claim on verdict; the rescore reset nulls it too.
- The lease never wraps the LLM call: claim commits in a short txn, olla runs outside any txn, the verdict commits separately.

## Tests

- `claim_test.go`: hold/reclaim + attempts-cap, refund restores budget, release allows immediate retry, verdict removes from the queue, and **concurrent claims are disjoint** (4 goroutines, no double-grab).
- `TestSecurityRetryBudget` rewritten to drive the real claim-based drain.
- `TestParseStages` covers the stage flag (subset, whitespace, unknown -> error).
- Migrate baseline bumped to 9. Full suite green against pgvector:pg18.

## Deployment follow-up (separate homelab change, lands with the new image)

Replace the single `herald-fetcher` service with three services off the same image and config, each `herald daemon --stages <one> --interval <n>`:

- `herald-fetch --stages fetch --interval 30m`
- `herald-screen --stages screen --interval 2m` (tight; drains continuously)
- `herald-curate --stages curate --interval 10m`

Not applied yet -- a `--stages` compose referencing a flag absent from the deployed image would break prod. Left for the deploy that ships this image.

## Open questions settled (from #233)

- **Increment on claim** (poison-pill safety) with a backend-unavailable refund (preserves #100).
- **Lease = 10 min.**
- Interval semantics unchanged (fixed sleep between cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)