### PR TITLE
ai: cap security screen output budget at 512 tokens

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -191,6 +191,14 @@ type modelsResponse struct {
 // distinguish non-retryable auth/permission failures from transient errors.
 // A built-in circuit breaker blocks all calls after repeated 4xx failures.
 func (c *openAIClient) generate(ctx context.Context, model, prompt string, temperature float64) (string, error) {
+	return c.generateWithBudget(ctx, model, prompt, temperature, chatMaxTokens)
+}
+
+// generateWithBudget is generate with an explicit output-token cap. Most stages
+// use the default chatMaxTokens (via generate); the security screen passes a much
+// smaller budget because its verdict is a tiny JSON object and a large output
+// request needlessly crowds a backend's context window (see securityMaxTokens).
+func (c *openAIClient) generateWithBudget(ctx context.Context, model, prompt string, temperature float64, maxTokens int) (string, error) {
 	if c.isOpen() {
 		c.mu.Lock()
 		status := c.lastStatus
@@ -216,7 +224,7 @@ func (c *openAIClient) generate(ctx context.Context, model, prompt string, tempe
 			{Role: "user", Content: prompt},
 		},
 		Temperature: temperature,
-		MaxTokens:   chatMaxTokens,
+		MaxTokens:   maxTokens,
 		Stream:      false,
 	}
 

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -190,7 +190,7 @@ func (p *AIProcessor) screenSpan(ctx context.Context, model string, temperature 
 	callCtx, cancel := p.withCallTimeout(ctx)
 	defer cancel()
 
-	responseText, err := p.client.generate(callCtx, model, promptText, temperature)
+	responseText, err := p.client.generateWithBudget(callCtx, model, promptText, temperature, securityMaxTokens)
 	if err != nil {
 		return screen.Finding{}, fmt.Errorf("ollama security check failed: %w", err)
 	}
@@ -328,6 +328,16 @@ const (
 	maxScreenChunkLen  = 10000
 	screenChunkOverlap = 1000
 )
+
+// securityMaxTokens caps the output budget for a single security screen. The
+// verdict is a small JSON object (threat, category, short evidence/reason --
+// typically well under 100 tokens), and unlike a reasoning model's chat turn it
+// carries no long thinking pass: Gemma emits the JSON directly. Requesting the
+// full chatMaxTokens here is wasteful and, on a small-context backend, pushes
+// prompt + chunk + reserved output past the window (HTTP 500 "Context size has
+// been exceeded"). 512 is generous for the verdict while leaving ample context
+// headroom on every backend.
+const securityMaxTokens = 512
 
 // chunkText splits s into windows of at most size runes that overlap by overlap
 // runes. It returns s unchanged in a single-element slice when it already fits,

--- a/internal/ai/security_test.go
+++ b/internal/ai/security_test.go
@@ -231,6 +231,34 @@ func TestSecurityCheck_ChunkErrorFailsClosed(t *testing.T) {
 	}
 }
 
+// The security verdict is a tiny JSON object; herald must not ask the backend
+// for the full 2048-token budget. An oversized output request needlessly crowds
+// a backend's context window (a small-context GPU intermittently 500s "Context
+// size has been exceeded") and lets a model run away. The security path caps
+// output at securityMaxTokens.
+func TestSecurityCheck_UsesSmallOutputBudget(t *testing.T) {
+	var gotMaxTokens int
+	reply := `{"threat":0,"category":"none","evidence":"","reason":"clean"}`
+	p := fakeModelServerFunc(t, nil, func(reqBody string) string {
+		var req struct {
+			MaxTokens int `json:"max_tokens"`
+		}
+		_ = json.Unmarshal([]byte(reqBody), &req)
+		gotMaxTokens = req.MaxTokens
+		return reply
+	})
+
+	if _, err := p.SecurityCheck(context.Background(), "Recipe", "Combine flour and water."); err != nil {
+		t.Fatalf("SecurityCheck: %v", err)
+	}
+	if gotMaxTokens != securityMaxTokens {
+		t.Errorf("security request max_tokens = %d, want %d (the verdict is tiny; do not request the full chat budget)", gotMaxTokens, securityMaxTokens)
+	}
+	if securityMaxTokens >= chatMaxTokens {
+		t.Errorf("securityMaxTokens (%d) should be well below chatMaxTokens (%d)", securityMaxTokens, chatMaxTokens)
+	}
+}
+
 func TestChunkText(t *testing.T) {
 	// Fits in one window -> returned unchanged, no copy needed.
 	if got := chunkText("short", 100, 10); len(got) != 1 || got[0] != "short" {


### PR DESCRIPTION
## Problem

Every chat call requests `chatMaxTokens` (2048) output. For the **security screen** that is both wasteful and harmful:

- The verdict is a tiny JSON object (threat, category, short evidence/reason -- well under 100 tokens), and Gemma-4-E4B emits it **directly**, with no long reasoning pass (verified against the live backends).
- Reserving 2048 output tokens crowds a backend's context window. On a small-context GPU (rainbow's 3080 was at ctx 8192), prompt + a full 10k-char chunk + the 2048 reservation tips past the window and returns HTTP 500 `Context size has been exceeded` even for tiny articles. herald classifies that as backend-unavailable and retries the claim indefinitely, dragging screening throughput.

## Fix

Give the security path its own **512**-token output budget via a new `generateWithBudget`. `generate` stays a thin wrapper at `chatMaxTokens`, so curation / summarization / clustering are unchanged. 512 is generous for the verdict and leaves ample context headroom on every backend.

## Why not smaller / why safe

The `chatMaxTokens` comment warns that too-tight a cap makes *reasoning* models spend the whole budget thinking and return empty content (mislabeled as malformed JSON). That risk is real for Qwen-style models but not the security path: the airlock screen prompt asks for direct JSON and Gemma complies (`{"threat":0}` with no thinking trace). 512 leaves generous room for the JSON. `screenSpan` already treats an empty reply as a retryable error, so a rare empty response is safe.

## Tests

`TestSecurityCheck_UsesSmallOutputBudget` captures the outgoing request and asserts `max_tokens == securityMaxTokens` and that it is well below `chatMaxTokens`. Existing security/chunking tests unchanged and green.

## Context

Third of three fixes for the plan-012 rescore context-overflow stalls: chunking long articles (#240, merged), raising rainbow's lemonade ctx 8192->16384 (homelab), and this output-budget cap. Pairs with #238.