### PR TITLE
Revert #241: security output cap starves Gemma's reasoning

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -191,14 +191,6 @@ type modelsResponse struct {
 // distinguish non-retryable auth/permission failures from transient errors.
 // A built-in circuit breaker blocks all calls after repeated 4xx failures.
 func (c *openAIClient) generate(ctx context.Context, model, prompt string, temperature float64) (string, error) {
-	return c.generateWithBudget(ctx, model, prompt, temperature, chatMaxTokens)
-}
-
-// generateWithBudget is generate with an explicit output-token cap. Most stages
-// use the default chatMaxTokens (via generate); the security screen passes a much
-// smaller budget because its verdict is a tiny JSON object and a large output
-// request needlessly crowds a backend's context window (see securityMaxTokens).
-func (c *openAIClient) generateWithBudget(ctx context.Context, model, prompt string, temperature float64, maxTokens int) (string, error) {
 	if c.isOpen() {
 		c.mu.Lock()
 		status := c.lastStatus
@@ -224,7 +216,7 @@ func (c *openAIClient) generateWithBudget(ctx context.Context, model, prompt str
 			{Role: "user", Content: prompt},
 		},
 		Temperature: temperature,
-		MaxTokens:   maxTokens,
+		MaxTokens:   chatMaxTokens,
 		Stream:      false,
 	}
 

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -190,7 +190,7 @@ func (p *AIProcessor) screenSpan(ctx context.Context, model string, temperature 
 	callCtx, cancel := p.withCallTimeout(ctx)
 	defer cancel()
 
-	responseText, err := p.client.generateWithBudget(callCtx, model, promptText, temperature, securityMaxTokens)
+	responseText, err := p.client.generate(callCtx, model, promptText, temperature)
 	if err != nil {
 		return screen.Finding{}, fmt.Errorf("ollama security check failed: %w", err)
 	}
@@ -328,16 +328,6 @@ const (
 	maxScreenChunkLen  = 10000
 	screenChunkOverlap = 1000
 )
-
-// securityMaxTokens caps the output budget for a single security screen. The
-// verdict is a small JSON object (threat, category, short evidence/reason --
-// typically well under 100 tokens), and unlike a reasoning model's chat turn it
-// carries no long thinking pass: Gemma emits the JSON directly. Requesting the
-// full chatMaxTokens here is wasteful and, on a small-context backend, pushes
-// prompt + chunk + reserved output past the window (HTTP 500 "Context size has
-// been exceeded"). 512 is generous for the verdict while leaving ample context
-// headroom on every backend.
-const securityMaxTokens = 512
 
 // chunkText splits s into windows of at most size runes that overlap by overlap
 // runes. It returns s unchanged in a single-element slice when it already fits,

--- a/internal/ai/security_test.go
+++ b/internal/ai/security_test.go
@@ -231,34 +231,6 @@ func TestSecurityCheck_ChunkErrorFailsClosed(t *testing.T) {
 	}
 }
 
-// The security verdict is a tiny JSON object; herald must not ask the backend
-// for the full 2048-token budget. An oversized output request needlessly crowds
-// a backend's context window (a small-context GPU intermittently 500s "Context
-// size has been exceeded") and lets a model run away. The security path caps
-// output at securityMaxTokens.
-func TestSecurityCheck_UsesSmallOutputBudget(t *testing.T) {
-	var gotMaxTokens int
-	reply := `{"threat":0,"category":"none","evidence":"","reason":"clean"}`
-	p := fakeModelServerFunc(t, nil, func(reqBody string) string {
-		var req struct {
-			MaxTokens int `json:"max_tokens"`
-		}
-		_ = json.Unmarshal([]byte(reqBody), &req)
-		gotMaxTokens = req.MaxTokens
-		return reply
-	})
-
-	if _, err := p.SecurityCheck(context.Background(), "Recipe", "Combine flour and water."); err != nil {
-		t.Fatalf("SecurityCheck: %v", err)
-	}
-	if gotMaxTokens != securityMaxTokens {
-		t.Errorf("security request max_tokens = %d, want %d (the verdict is tiny; do not request the full chat budget)", gotMaxTokens, securityMaxTokens)
-	}
-	if securityMaxTokens >= chatMaxTokens {
-		t.Errorf("securityMaxTokens (%d) should be well below chatMaxTokens (%d)", securityMaxTokens, chatMaxTokens)
-	}
-}
-
 func TestChunkText(t *testing.T) {
 	// Fits in one window -> returned unchanged, no copy needed.
 	if got := chunkText("short", 100, 10); len(got) != 1 || got[0] != "short" {


### PR DESCRIPTION
## Revert of #241 (security output budget cap)

#241 capped the security screen's output at 512 tokens on the theory that the verdict is a tiny JSON object. **That was wrong for the real prompt.** On the actual airlock screen prompt (not a trivial "reply with JSON" probe), Gemma-4-E4B emits a reasoning trace before the JSON verdict, so 512 truncates it: content comes back empty or unparseable. Live, this caused ~80% of screens to fail (`no JSON (model reasoning exhausted output budget)` + `unparseable verdict`) -- exactly the failure mode the `chatMaxTokens` comment warns about.

The failures are fail-closed and retryable (no data loss / no fail-open), but screening was effectively stalled.

## Why the cap is also unnecessary

The context-crowding #241 aimed at is already solved by:
- chunking long articles (#240), and
- normalizing the backend fleet contexts (rainbow + martian raised 8192 -> 16384; strix/zero at 32768).

With every backend now >= 16384, the original 2048 output budget fits comfortably (prompt ~1.7k + full chunk ~4k + 2048 << 16384). So the cap buys nothing and only risks starving the model.

Restores `generate` at `chatMaxTokens` for the security path. Post-revert verification: context errors were already 0/3min after the fleet bump; this restores full screening throughput.