### PR TITLE
ci: pin infodancer/workflows to @v0

### DIFF
--- a/.github/workflows/pr-preview-sweep.yml
+++ b/.github/workflows/pr-preview-sweep.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   sweep:
-    uses: infodancer/workflows/.github/workflows/pr-preview-sweep.yml@v0.2.7
+    uses: infodancer/workflows/.github/workflows/pr-preview-sweep.yml@v0
     with:
       slug: herald
       image: ghcr.io/matthewjhunter/herald


### PR DESCRIPTION
Float on the major pointer instead of an exact patch, so shared-workflow fixes (like the v0.2.8 lint fix that drops the remote config-schema fetch) land without a per-repo pin bump. That is what the workflow's auto-version release and `@v0` pointer are for.

Verified the pin is the only change.