### PR TITLE
fix(pipeline): refund claimed batch when security breaker opens

### DIFF
--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -24,6 +24,15 @@ import (
 func (s *Stage) Security(ctx context.Context, in []storage.Article) []storage.Article {
 	if !s.AI.BackendAvailable() {
 		s.Formatter.Warning("pipeline: skipping security stage — AI backend unavailable (breaker open)")
+		// The drain already claimed this batch (attempt +1, claim stamped) while
+		// the breaker looked closed; it can open in the window before we run. Refund
+		// every claim rather than dropping the batch: we never screened these, so a
+		// backend outage must not burn their retry budget (#100). Without this, an
+		// olla restart parks whole batches at security_attempts>=3 with claims still
+		// held, stranding the queue until an operator resets them.
+		for _, a := range in {
+			s.Store.RefundSecurityClaim(a.ID) //nolint:errcheck
+		}
 		return nil
 	}
 	return s.mapArticles(ctx, in, s.securityOne)

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -288,6 +288,40 @@ func TestSecurityStageSkipsWhenBreakerOpen(t *testing.T) {
 	}
 }
 
+func TestSecurityStageRefundsClaimWhenBreakerOpensAfterClaim(t *testing.T) {
+	// Reproduce the batch-drop leak: the drain claims a batch (attempt +1, claim
+	// stamped) while the backend looks available, then the breaker opens before
+	// the security stage runs. The stage must refund every already-claimed article
+	// instead of silently dropping the batch. Without the refund, an olla restart
+	// burns the retry budget on in-flight articles and parks them at attempts>=3
+	// with their claims still held -- the 2026-07-15 rescore stall, where a single
+	// restart window left ~7.9k articles stranded.
+	fake := &fakeAI{available: false}
+	st, store, feedID := newHarness(t, fake)
+	art := seed(t, store, feedID, "x", strings.Repeat("x", 500))
+
+	// Stand in for the drain's claim, which happened before the breaker opened.
+	claimed, err := store.ClaimUnscreenedArticles(500, securityClaimLeaseSeconds)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed article, got %d", len(claimed))
+	}
+
+	// Breaker is open: the stage must skip the backend but give the claim back.
+	if passed := st.Security(context.Background(), claimed); len(passed) != 0 {
+		t.Fatalf("expected no articles to advance with breaker open, got %v", ids(passed))
+	}
+	if fake.secCalls != 0 {
+		t.Fatalf("expected zero security calls with breaker open, got %d", fake.secCalls)
+	}
+	// Fully refunded: the retry budget is intact (3), so the article is not parked.
+	if got := remainingClaimBudget(t, store, art.ID); got != 3 {
+		t.Fatalf("claim budget after breaker-open skip = %d, want 3 (batch drop burned the retry budget)", got)
+	}
+}
+
 func TestArticleContentSanitizes(t *testing.T) {
 	a := storage.Article{
 		Content:       `<p>Breaking news body.</p><script>steal()</script>`,


### PR DESCRIPTION
## The bug

`RunSecurity`'s drain claims a batch of unscreened articles **up front** -- `ClaimUnscreenedArticles` stamps a claim and increments `security_attempts` on every row -- and only then hands the batch to the `Security` stage. The drain checks the breaker before claiming, but the breaker can open in the window between the claim and the stage running (an olla restart, a probe failure). When it does, `Security`'s early return dropped the whole batch on the floor:

```go
func (s *Stage) Security(ctx context.Context, in []storage.Article) []storage.Article {
	if !s.AI.BackendAvailable() {
		s.Formatter.Warning("... breaker open")
		return nil   // <-- `in` was already claimed (+1 attempt, claim stamped); never refunded
	}
	return s.mapArticles(ctx, in, s.securityOne)
}
```

The per-article error path in `securityOne` correctly refunds on `ErrBackendUnavailable` (#100), but a batch that never reaches `securityOne` never gets refunded. The claimed rows keep the burned attempt and the held claim; across an outage the drain re-claims the same rows each cycle, climbing to `security_attempts >= 3`, and they park permanently -- screenable content stranded off the queue until an operator resets it.

## Observed impact

On 2026-07-15 the every-3h olla restart cron triggered this three times. Restart windows at **05:00 / 08:00 / 11:00 UTC** parked **~12.6k articles** (7.9k in the 08:00 window alone), halting the security rescore. 99% of the logged failures were `connection refused` (olla down), and the parked rows were left with claims still held -- the signature of a claim that was incremented but never refunded/released. 76% of the parked articles were under 5k chars (single-chunk, trivially screenable), confirming these were false-exhausted, not genuine failures.

## The fix

Refund every already-claimed article in the breaker-open path, matching the per-article `ErrBackendUnavailable` refund in `securityOne`. A backend outage must never burn the retry budget for content we never actually screened.

## Test

`TestSecurityStageRefundsClaimWhenBreakerOpensAfterClaim` claims a batch, opens the breaker, runs the stage, and asserts the retry budget is intact (3). It fails against the unfixed code (budget = 2, one attempt burned) and passes with the fix. Full suite green against a pgvector Postgres.

## Follow-ups (not in this PR)

- A related, lower-impact leak: `mapArticles` (`pipeline.go`) `break`s on `ctx.Err()` mid-batch, stranding the un-dispatched tail of a claimed batch on daemon shutdown. Rare (only on cancel) and self-heals after the lease, but worth an issue.
- Deploy this, then reset the already-parked rows: `UPDATE articles SET security_attempts = 0, screening_claimed_at = NULL WHERE security_screened_at IS NULL AND security_attempts >= 3;`
- Reconsider whether the every-3h olla restart cron is still needed, since it's the recurring trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)