### PR TITLE
fix(pipeline): refund claimed security batch on ctx cancellation

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -60,14 +60,18 @@ func (s *Stage) maxParallel() int {
 // returns, in input order, the articles for which fn returned a non-nil result
 // (i.e. those that advanced to the next stage). fn must be safe for concurrent
 // use; it only touches the store and the AI backend, both of which are.
+//
+// Every input is handed to fn exactly once, even under a cancelled ctx. That is
+// deliberate: the security stage claims its batch up front (an attempt and a
+// held claim per row), and fn is what refunds them, so short-circuiting the loop
+// on cancellation would strand the un-dispatched tail with a burned attempt and
+// a held claim (#245). fn is expected to check ctx and return cheaply when it is
+// cancelled -- a fast no-op for the non-claiming stages, a refund for security.
 func (s *Stage) mapArticles(ctx context.Context, in []storage.Article, fn func(context.Context, storage.Article) *storage.Article) []storage.Article {
 	results := make([]*storage.Article, len(in))
 	sem := make(chan struct{}, s.maxParallel())
 	var wg sync.WaitGroup
 	for i, article := range in {
-		if ctx.Err() != nil {
-			break
-		}
 		sem <- struct{}{}
 		wg.Add(1)
 		go func(i int, article storage.Article) {

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -39,6 +39,15 @@ func (s *Stage) Security(ctx context.Context, in []storage.Article) []storage.Ar
 }
 
 func (s *Stage) securityOne(ctx context.Context, article storage.Article) *storage.Article {
+	// The drain already claimed this article (attempt +1, claim stamped). If the
+	// ctx was cancelled before we got here (daemon shutdown mid-batch), we never
+	// screen it, so refund the claim rather than letting it strand at a burned
+	// attempt with a held claim (#245).
+	if ctx.Err() != nil {
+		s.Store.RefundSecurityClaim(article.ID) //nolint:errcheck
+		return nil
+	}
+
 	content := articleContent(article)
 	if content == "" {
 		s.Formatter.Warning("skipping article %d %q: no content", article.ID, article.Title)

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -322,6 +322,37 @@ func TestSecurityStageRefundsClaimWhenBreakerOpensAfterClaim(t *testing.T) {
 	}
 }
 
+func TestSecurityStageRefundsClaimWhenContextCancelled(t *testing.T) {
+	// #245: the drain claims a batch (attempt +1, claim stamped), then the ctx is
+	// cancelled mid-batch (daemon shutdown). Every claimed article must still be
+	// refunded -- the old mapArticles ctx-cancel break stranded the un-dispatched
+	// tail with a burned attempt and a held claim.
+	fake := &fakeAI{available: true}
+	st, store, feedID := newHarness(t, fake)
+	art := seed(t, store, feedID, "x", strings.Repeat("x", 500))
+
+	claimed, err := store.ClaimUnscreenedArticles(500, securityClaimLeaseSeconds)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed article, got %d", len(claimed))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the stage runs, standing in for a mid-batch shutdown
+
+	if passed := st.Security(ctx, claimed); len(passed) != 0 {
+		t.Fatalf("expected no articles to advance under a cancelled ctx, got %v", ids(passed))
+	}
+	if fake.secCalls != 0 {
+		t.Fatalf("expected zero security calls under a cancelled ctx, got %d", fake.secCalls)
+	}
+	if got := remainingClaimBudget(t, store, art.ID); got != 3 {
+		t.Fatalf("claim budget after cancelled-ctx skip = %d, want 3 (stranded tail burned the retry budget)", got)
+	}
+}
+
 func TestArticleContentSanitizes(t *testing.T) {
 	a := storage.Article{
 		Content:       `<p>Breaking news body.</p><script>steal()</script>`,


### PR DESCRIPTION
Follow-up to #244. Closes #245.

## The leak

`mapArticles` short-circuited its dispatch loop on a cancelled ctx:

```go
for i, article := range in {
	if ctx.Err() != nil {
		break   // <-- in[i:] were claimed (+1 attempt, held claim) but never handed to fn
	}
	sem <- struct{}{}
	...
}
```

The security stage claims its batch up front (attempt incremented, `screening_claimed_at` stamped), and `securityOne` is what refunds them on failure. When the ctx is cancelled mid-batch (daemon shutdown), the loop breaks and the un-dispatched tail never reaches `securityOne` -- those rows keep a burned attempt and a held claim. On repeated interrupted shutdowns within the lease window they climb `security_attempts` the same way #244's breaker-open drop parked whole batches, just at much lower volume (only on cancellation).

## The fix

- `mapArticles` now hands every input to `fn` exactly once, even under a cancelled ctx. Documented that this is deliberate for claim accounting.
- `securityOne` short-circuits to a `RefundSecurityClaim` when it sees a cancelled ctx, so a claimed article always gets a terminal disposition (and no wasted AI call / spurious failure log on shutdown).
- The non-claiming stages (summarize/curate/embed/cluster) already fail cheaply under a cancelled ctx, so handing them the tail is a fast no-op.

## Test

`TestSecurityStageRefundsClaimWhenContextCancelled` claims a batch, cancels the ctx, runs the stage, and asserts the retry budget is intact (3). Verified it fails with the `break` restored (budget = 2) and passes with the fix. Full suite green against a pgvector Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)