### PR TITLE
fix(web): restore reader gauge on sidebar refresh

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1066,6 +1066,12 @@ func (h *handlers) handleSidebar(w http.ResponseWriter, r *http.Request) {
 	if newsletters, err := h.engine.GetNewsletterStats(uid); err == nil {
 		data.Newsletters = newsletters
 	}
+	// Gauge scopes to the active feed; group/starred views (feed_id == 0) show
+	// the all-feeds gauge for now (per-group/starred scoping is a follow-up).
+	if g, err := h.engine.GetReaderGauge(uid, data.ActiveFeed); err == nil {
+		rg := buildReaderGauge(g)
+		data.Gauge = &rg
+	}
 
 	h.renderFragment(w, "feed_sidebar_content", data)
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -839,6 +839,22 @@ func TestHandleSidebar(t *testing.T) {
 	}
 }
 
+// TestHandleSidebar_ReaderGauge guards against the gauge disappearing when the
+// sidebar is refetched via the feeds-changed htmx trigger (e.g. after opening
+// an article), which hits this endpoint directly rather than riding along on
+// an OOB swap from another handler.
+func TestHandleSidebar_ReaderGauge(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequest(t, tf, "GET", "/sidebar", map[string]string{"HX-Request": "true"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "reader-gauge") {
+		t.Error("sidebar refresh should include the reader status gauge")
+	}
+}
+
 func TestHandleFeedsManage(t *testing.T) {
 	tf := newTestFixtures(t)
 


### PR DESCRIPTION
## Summary
- The reader status gauge (#232) disappeared whenever a user opened an article, because opening an article fires a `feeds-changed` htmx event that triggers `GET /sidebar`, and `handleSidebar` never populated `data.Gauge` (unlike its siblings `handleHome` and `handleArticleList`).
- The gauge template uses `{{with .Gauge}}`, so a nil pointer silently dropped the whole widget.
- Fixed `handleSidebar` to call `GetReaderGauge` and populate `data.Gauge`, matching the existing pattern in `handleArticleList`.

## Test plan
- [x] Added `TestHandleSidebar_ReaderGauge`, which hits `/sidebar` directly and asserts the gauge markup is present
- [x] Verified the new test fails without the fix and passes with it
- [x] `go test -race -count=1 ./internal/web/...` passes
- [x] `golangci-lint run ./internal/web/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)