### PR TITLE
feat: version prompts, record provenance at scoring time (#258)

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1697,6 +1697,98 @@ func (e *Engine) GetPrompt(userID int64, promptType string) (*PromptDetail, erro
 	}, nil
 }
 
+// PromptHistoryEntry is one past version of a prompt, for the settings UI.
+type PromptHistoryEntry struct {
+	ID        int64
+	Hash      string
+	Template  string
+	Model     string
+	Source    string
+	CreatedAt time.Time
+	// Current marks the version whose text matches what is in force now.
+	Current bool
+}
+
+// ListPromptHistory returns past versions of a prompt, newest first (#258).
+// Access is scoped to the caller's own rows -- prompt text is user-authored
+// content and one reader's prompts are not another's to read.
+func (e *Engine) ListPromptHistory(userID int64, promptType string, limit int) ([]PromptHistoryEntry, error) {
+	if !allowedPromptTypes[promptType] {
+		return nil, fmt.Errorf("unknown or restricted prompt type: %q", promptType)
+	}
+	// The summarization prompt is global (#162): its history lives on user 0.
+	scope := userID
+	if promptType == "summarization" {
+		scope = 0
+	}
+	versions, err := e.store.ListPromptVersions(scope, promptType, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	currentHash := ""
+	if r, err := ai.NewPromptLoader(e.store, e.config).Resolve(scope, ai.PromptType(promptType)); err == nil {
+		currentHash = r.Hash
+	}
+
+	out := make([]PromptHistoryEntry, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, PromptHistoryEntry{
+			ID:        v.ID,
+			Hash:      v.TemplateHash,
+			Template:  v.Template,
+			Model:     v.Model,
+			Source:    v.Source,
+			CreatedAt: v.CreatedAt,
+			Current:   v.TemplateHash == currentHash,
+		})
+	}
+	return out, nil
+}
+
+// RevertPrompt makes an earlier version current again. It appends rather than
+// rewinding: the revert is itself an event, and a history that quietly dropped
+// the rejected version would lose the record of what was in force while the
+// scores under it were written.
+func (e *Engine) RevertPrompt(userID int64, promptType string, versionID int64) error {
+	if !allowedPromptTypes[promptType] {
+		return fmt.Errorf("unknown or restricted prompt type: %q", promptType)
+	}
+	if promptType == "summarization" && userID != 0 {
+		return fmt.Errorf("summarization prompt is global; revert it as admin")
+	}
+	v, err := e.store.GetPromptVersion(versionID)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return fmt.Errorf("prompt version %d not found", versionID)
+	}
+	// A version id is a bare integer, so ownership is checked rather than
+	// assumed: without this, guessing an id would read back another user's
+	// prompt text through the revert path.
+	scope := userID
+	if promptType == "summarization" {
+		scope = 0
+	}
+	if v.UserID != scope && v.UserID != 0 {
+		return fmt.Errorf("prompt version %d not found", versionID)
+	}
+	if v.PromptType != promptType {
+		return fmt.Errorf("prompt version %d is not a %s prompt", versionID, promptType)
+	}
+
+	var temp *float64
+	if v.Temperature > 0 {
+		temp = &v.Temperature
+	}
+	var model *string
+	if v.Model != "" {
+		model = &v.Model
+	}
+	return e.store.SetUserPrompt(scope, promptType, v.Template, temp, model)
+}
+
 // ListModels returns available Ollama models.
 func (e *Engine) ListModels(ctx context.Context) ([]string, error) {
 	if e.ai == nil {

--- a/engine_prompt_version_test.go
+++ b/engine_prompt_version_test.go
@@ -1,0 +1,116 @@
+package herald
+
+import (
+	"testing"
+)
+
+// TestRevertPromptRejectsOtherUsersVersion is the access check on the revert
+// path (#258). A version id is a bare integer in a URL, so without an ownership
+// test, guessing one would copy another account's prompt text into the caller's
+// own -- a read primitive for other people's prompts dressed up as a revert.
+func TestRevertPromptRejectsOtherUsersVersion(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	alice, err := engine.store.CreateUser("alice")
+	if err != nil {
+		t.Fatalf("CreateUser alice: %v", err)
+	}
+	bob, err := engine.store.CreateUser("bob")
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+
+	const secret = "alice's private curation prompt"
+	if err := engine.SetPrompt(alice, "curation", secret, nil, nil); err != nil {
+		t.Fatalf("SetPrompt alice: %v", err)
+	}
+	aliceHistory, err := engine.ListPromptHistory(alice, "curation", 10)
+	if err != nil {
+		t.Fatalf("ListPromptHistory alice: %v", err)
+	}
+	if len(aliceHistory) != 1 {
+		t.Fatalf("got %d versions for alice, want 1", len(aliceHistory))
+	}
+
+	if err := engine.RevertPrompt(bob, "curation", aliceHistory[0].ID); err == nil {
+		t.Fatal("bob reverted to alice's prompt version; want an error")
+	}
+
+	// And nothing leaked into bob's account.
+	bobDetail, err := engine.GetPrompt(bob, "curation")
+	if err != nil {
+		t.Fatalf("GetPrompt bob: %v", err)
+	}
+	if bobDetail.Template == secret {
+		t.Error("alice's prompt text ended up in bob's account")
+	}
+	bobHistory, err := engine.ListPromptHistory(bob, "curation", 10)
+	if err != nil {
+		t.Fatalf("ListPromptHistory bob: %v", err)
+	}
+	if len(bobHistory) != 0 {
+		t.Errorf("bob has %d versions, want 0", len(bobHistory))
+	}
+}
+
+// Reverting restores the older text and records the revert as its own version.
+func TestRevertPromptRestoresAndAppends(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	uid, err := engine.store.CreateUser("reader")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := engine.SetPrompt(uid, "curation", "original prompt", nil, nil); err != nil {
+		t.Fatalf("SetPrompt original: %v", err)
+	}
+	if err := engine.SetPrompt(uid, "curation", "regrettable rewrite", nil, nil); err != nil {
+		t.Fatalf("SetPrompt rewrite: %v", err)
+	}
+
+	history, err := engine.ListPromptHistory(uid, "curation", 10)
+	if err != nil {
+		t.Fatalf("ListPromptHistory: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("got %d versions, want 2", len(history))
+	}
+	// history[0] is the rewrite (newest); history[1] is the original.
+	if !history[0].Current {
+		t.Error("newest version is not marked current")
+	}
+
+	if err := engine.RevertPrompt(uid, "curation", history[1].ID); err != nil {
+		t.Fatalf("RevertPrompt: %v", err)
+	}
+
+	detail, err := engine.GetPrompt(uid, "curation")
+	if err != nil {
+		t.Fatalf("GetPrompt: %v", err)
+	}
+	if detail.Template != "original prompt" {
+		t.Errorf("template = %q, want the reverted-to text", detail.Template)
+	}
+
+	after, err := engine.ListPromptHistory(uid, "curation", 10)
+	if err != nil {
+		t.Fatalf("ListPromptHistory after revert: %v", err)
+	}
+	if len(after) != 3 {
+		t.Errorf("got %d versions after revert, want 3 -- the revert is an event, and the rejected version must survive", len(after))
+	}
+	// The rewrite is still on the record even though it is no longer in force:
+	// scores written under it must stay attributable.
+	var sawRewrite bool
+	for _, v := range after {
+		if v.Template == "regrettable rewrite" {
+			sawRewrite = true
+		}
+	}
+	if !sawRewrite {
+		t.Error("the reverted-away version was erased from history")
+	}
+}

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -68,6 +68,12 @@ type SecurityResult struct {
 type CurationResult struct {
 	InterestScore float64 `json:"interest_score"`
 	Reasoning     string  `json:"reasoning"`
+
+	// Provenance of this score, filled in by CurateArticle rather than by the
+	// model. Carried out to the caller so it can be recorded at scoring time,
+	// which is the only moment it is known for certain (#258).
+	Model      string `json:"-"`
+	PromptHash string `json:"-"`
 }
 
 // NewAIProcessor creates a new AI processor backed by an OpenAI-compatible
@@ -244,7 +250,7 @@ func (p *AIProcessor) CurateArticle(ctx context.Context, userID int64, title, co
 		keywordStr = strings.Join(keywords, ", ")
 	}
 
-	promptTemplate, err := p.promptLoader.GetPrompt(userID, PromptTypeCuration)
+	resolved, err := p.promptLoader.Resolve(userID, PromptTypeCuration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load curation prompt: %w", err)
 	}
@@ -254,15 +260,23 @@ func (p *AIProcessor) CurateArticle(ctx context.Context, userID int64, title, co
 		return nil, fmt.Errorf("failed to prepare curation prompt content: %w", err)
 	}
 	data["Keywords"] = keywordStr
-	prompt, err := ExecutePrompt(promptTemplate, data)
+	prompt, err := ExecutePrompt(resolved.Template, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render curation prompt: %w", err)
 	}
 
-	temperature := p.promptLoader.GetTemperature(userID, PromptTypeCuration)
-	model := p.promptLoader.GetModel(userID, PromptTypeCuration)
+	temperature := resolved.Temperature
+	model := resolved.Model
 	if model == "" {
 		model = p.curationModel
+	}
+	// The effective model can come from the processor default, below every tier
+	// the loader knows about, so provenance is stamped from what was actually
+	// sent rather than from what resolution proposed.
+	provenance := func(r *CurationResult) *CurationResult {
+		r.Model = model
+		r.PromptHash = resolved.Hash
+		return r
 	}
 
 	callCtx, cancel := p.withCallTimeout(ctx)
@@ -275,21 +289,21 @@ func (p *AIProcessor) CurateArticle(ctx context.Context, userID int64, title, co
 
 	extracted := extractJSON(responseText)
 	if strings.TrimSpace(extracted) == "" {
-		return &CurationResult{
+		return provenance(&CurationResult{
 			InterestScore: 0,
 			Reasoning:     "Curation returned no content (likely max_tokens exhausted by model reasoning) -- not scored",
-		}, nil
+		}), nil
 	}
 
 	var result CurationResult
 	if err := json.Unmarshal([]byte(extracted), &result); err != nil {
-		return &CurationResult{
+		return provenance(&CurationResult{
 			InterestScore: 0,
 			Reasoning:     "Curation response did not match expected JSON format -- possible prompt injection",
-		}, nil
+		}), nil
 	}
 
-	return &result, nil
+	return provenance(&result), nil
 }
 
 // ListModels returns the names of all models available at the configured endpoint.

--- a/internal/ai/resolve.go
+++ b/internal/ai/resolve.go
@@ -1,0 +1,172 @@
+package ai
+
+import (
+	"sync"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// Prompt tier names, recorded on a version row so a hash can be traced back to
+// how it came to be in force. Descriptive only: the hash identifies the text,
+// these say which layer supplied it. Aliases of the storage constants, which
+// the store also writes on save.
+const (
+	SourceBuiltin = storage.SourceBuiltin
+	SourceConfig  = storage.SourceConfig
+	SourceAdmin   = storage.SourceAdmin
+	SourceUser    = storage.SourceUser
+)
+
+// ResolvedPrompt is the effective prompt configuration for one (user, type)
+// after all four tiers have been applied.
+//
+// Resolution returns template, model, temperature and hash together because
+// callers need them as a set: the score a model produces is only interpretable
+// alongside the prompt that produced it. Fetching them through separate
+// accessors invited exactly the bug #258 exists to fix -- the feedback log
+// recorded a prompt hash resolved at a different moment than the score it was
+// attached to.
+type ResolvedPrompt struct {
+	Template    string
+	Model       string
+	Temperature float64
+	// Hash is the sha256 of Template, lowercase hex. Stable across tiers, so a
+	// stock instance running the embedded default records the same identity as
+	// a user who pasted that text into their own prompt.
+	Hash string
+	// Source is the tier Template came from. Model and Temperature resolve
+	// through their own chains and may originate elsewhere.
+	Source string
+}
+
+// HashTemplate returns the content address of a prompt template. Thin alias of
+// storage.HashPromptTemplate so resolution and the store cannot drift apart.
+func HashTemplate(t string) string { return storage.HashPromptTemplate(t) }
+
+// registeredHashes tracks which template hashes this process has already
+// written to prompt_versions. Package level, not per loader: PromptLoader is
+// constructed per call in several paths, so an instance-scoped guard would
+// re-issue the same write on every summary and every settings page render.
+var registeredHashes sync.Map
+
+// Resolve returns the effective prompt configuration for a user and type.
+//
+// The built-in and config tiers have no row to version, so the first time this
+// process resolves to one it registers the text in prompt_versions. That write
+// happens once per distinct hash per process and never on a cached path: prompt
+// resolution runs per article per user and must stay a single indexed read.
+func (pl *PromptLoader) Resolve(userID int64, promptType PromptType) (ResolvedPrompt, error) {
+	r, err := pl.resolveTiers(userID, promptType)
+	if err != nil {
+		return ResolvedPrompt{}, err
+	}
+	// Model and temperature fall through their own chains when the winning
+	// tier does not set them: a user may override the prompt text while
+	// leaving the model to the config file.
+	if r.Model == "" {
+		r.Model = pl.GetModel(userID, promptType)
+	}
+	if r.Temperature == 0 {
+		r.Temperature = pl.GetTemperature(userID, promptType)
+	}
+	r.Hash = HashTemplate(r.Template)
+	pl.registerIfUnrowed(promptType, r)
+	return r, nil
+}
+
+// resolveTiers walks the same four tiers as GetPrompt and reports which one
+// answered. The database tiers are read in a single query each rather than one
+// per field, so every value in the result describes the same row -- reading
+// them separately is what let a hash and a model come from different prompts.
+func (pl *PromptLoader) resolveTiers(userID int64, promptType PromptType) (ResolvedPrompt, error) {
+	if store, ok := pl.storeIface(); ok {
+		scopes := []struct {
+			id     int64
+			source string
+		}{{userID, SourceUser}}
+		if userID != 0 {
+			scopes = append(scopes, struct {
+				id     int64
+				source string
+			}{0, SourceAdmin})
+		}
+		for _, sc := range scopes {
+			tmpl, _, temp, model, err := store.GetUserPromptResolved(sc.id, string(promptType))
+			if err == nil && tmpl != "" {
+				return ResolvedPrompt{Template: tmpl, Model: model, Temperature: temp, Source: sc.source}, nil
+			}
+		}
+	}
+	if p := pl.configPrompt(promptType); p != "" {
+		return ResolvedPrompt{Template: p, Source: SourceConfig}, nil
+	}
+	p, err := DefaultPrompt(promptType)
+	if err != nil {
+		return ResolvedPrompt{}, err
+	}
+	return ResolvedPrompt{Template: p, Source: SourceBuiltin}, nil
+}
+
+// registerIfUnrowed records builtin and config prompts in prompt_versions.
+// The user and admin tiers already get a version row when they are saved, so
+// re-registering them here would append a duplicate on every resolution.
+func (pl *PromptLoader) registerIfUnrowed(promptType PromptType, r ResolvedPrompt) {
+	if r.Source != SourceBuiltin && r.Source != SourceConfig {
+		return
+	}
+	if _, seen := registeredHashes.LoadOrStore(r.Hash, struct{}{}); seen {
+		return
+	}
+	store, ok := pl.storeIface()
+	if !ok {
+		return
+	}
+	// Scoped to user 0: these tiers are instance-wide, not per user, and one
+	// row per hash is the whole point of content addressing.
+	//
+	// Best effort. A prompt that cannot be registered must not stop an article
+	// from being scored -- losing provenance is bad, losing the score is worse.
+	_ = store.RegisterPromptVersion(storage.PromptVersion{
+		UserID:       0,
+		PromptType:   string(promptType),
+		Template:     r.Template,
+		TemplateHash: r.Hash,
+		Temperature:  r.Temperature,
+		Model:        r.Model,
+		Source:       r.Source,
+	})
+}
+
+func (pl *PromptLoader) storeIface() (storage.Store, bool) {
+	if pl.store == nil {
+		return nil, false
+	}
+	s, ok := pl.store.(storage.Store)
+	return s, ok
+}
+
+func (pl *PromptLoader) configPrompt(promptType PromptType) string {
+	if pl.config == nil {
+		return ""
+	}
+	config, ok := pl.config.(*storage.Config)
+	if !ok {
+		return ""
+	}
+	switch promptType {
+	case PromptTypeSecurity:
+		return config.Prompts.Security
+	case PromptTypeCuration:
+		return config.Prompts.Curation
+	case PromptTypeSummarization:
+		return config.Prompts.Summarization
+	case PromptTypeGroupSummary:
+		return config.Prompts.GroupSummary
+	case PromptTypeNewsletter:
+		return config.Prompts.Newsletter
+	case PromptTypeSummary:
+		return config.Prompts.Summary
+	default:
+		return ""
+	}
+}

--- a/internal/ai/resolve_test.go
+++ b/internal/ai/resolve_test.go
@@ -1,0 +1,147 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// Every tier must yield a usable hash. Before #258 the two bottom tiers -- which
+// are what a stock instance actually runs -- recorded nothing at all, so every
+// feedback event on a default install was unattributable.
+func TestResolveHashesEveryTier(t *testing.T) {
+	t.Run("builtin", func(t *testing.T) {
+		pl := NewPromptLoader(nil, nil)
+		r, err := pl.Resolve(1, PromptTypeCuration)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if r.Source != SourceBuiltin {
+			t.Errorf("source = %q, want %q", r.Source, SourceBuiltin)
+		}
+		if r.Hash != HashTemplate(r.Template) || r.Hash == "" {
+			t.Errorf("hash %q does not address the resolved template", r.Hash)
+		}
+	})
+
+	t.Run("config", func(t *testing.T) {
+		cfg := &storage.Config{}
+		cfg.Prompts.Curation = "config curation prompt"
+		pl := NewPromptLoader(nil, cfg)
+		r, err := pl.Resolve(1, PromptTypeCuration)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if r.Source != SourceConfig {
+			t.Errorf("source = %q, want %q", r.Source, SourceConfig)
+		}
+		if r.Template != "config curation prompt" {
+			t.Errorf("template = %q", r.Template)
+		}
+		if r.Hash != HashTemplate("config curation prompt") {
+			t.Errorf("hash does not match config text")
+		}
+	})
+
+	t.Run("user", func(t *testing.T) {
+		store, cleanup := newTestStore(t)
+		defer cleanup()
+		uid, err := store.CreateUser("reader")
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		model := "user-model"
+		if err := store.SetUserPrompt(uid, "curation", "user text", nil, &model); err != nil {
+			t.Fatalf("SetUserPrompt: %v", err)
+		}
+
+		pl := NewPromptLoader(store, nil)
+		r, err := pl.Resolve(uid, PromptTypeCuration)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if r.Source != SourceUser {
+			t.Errorf("source = %q, want %q", r.Source, SourceUser)
+		}
+		if r.Template != "user text" {
+			t.Errorf("template = %q, want %q", r.Template, "user text")
+		}
+		if r.Model != model {
+			t.Errorf("model = %q, want %q", r.Model, model)
+		}
+		if r.Hash != HashTemplate("user text") {
+			t.Error("hash does not address the user template")
+		}
+	})
+}
+
+// The hash the loader computes and the hash the store writes must be the same
+// string. If they ever diverged, the corpus would split into halves that cannot
+// be joined and nothing would report an error.
+func TestResolveHashMatchesStoredHash(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+	uid, err := store.CreateUser("reader")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	const text = "shared text"
+	if err := store.SetUserPrompt(uid, "curation", text, nil, nil); err != nil {
+		t.Fatalf("SetUserPrompt: %v", err)
+	}
+
+	r, err := NewPromptLoader(store, nil).Resolve(uid, PromptTypeCuration)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	versions, err := store.ListPromptVersions(uid, "curation", 1)
+	if err != nil {
+		t.Fatalf("ListPromptVersions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("got %d versions, want 1", len(versions))
+	}
+	if r.Hash != versions[0].TemplateHash {
+		t.Errorf("resolver hash %q != stored hash %q", r.Hash, versions[0].TemplateHash)
+	}
+	if r.Hash != storage.HashPromptTemplate(text) {
+		t.Errorf("resolver hash disagrees with storage.HashPromptTemplate")
+	}
+}
+
+// Resolving a builtin prompt registers it so the hash recorded on a score can
+// later be turned back into text. Repeated resolution must not append a row per
+// call -- resolution runs per article and would otherwise flood the table.
+func TestResolveRegistersUnrowedTiersOnce(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	cfg := &storage.Config{}
+	cfg.Prompts.Curation = "a config prompt worth versioning"
+
+	for i := 0; i < 3; i++ {
+		// A fresh loader each time, as the per-call construction in the engine
+		// does -- the registration guard must not be per instance.
+		if _, err := NewPromptLoader(store, cfg).Resolve(7, PromptTypeCuration); err != nil {
+			t.Fatalf("Resolve %d: %v", i, err)
+		}
+	}
+
+	versions, err := store.ListPromptVersions(0, "curation", 10)
+	if err != nil {
+		t.Fatalf("ListPromptVersions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("got %d rows, want 1 after repeated resolution", len(versions))
+	}
+	if versions[0].Source != SourceConfig {
+		t.Errorf("source = %q, want %q", versions[0].Source, SourceConfig)
+	}
+	got, err := store.GetPromptTemplateByHash(HashTemplate(cfg.Prompts.Curation))
+	if err != nil {
+		t.Fatalf("GetPromptTemplateByHash: %v", err)
+	}
+	if got != cfg.Prompts.Curation {
+		t.Errorf("registered text = %q, want %q", got, cfg.Prompts.Curation)
+	}
+}

--- a/internal/pipeline/clusterstage_test.go
+++ b/internal/pipeline/clusterstage_test.go
@@ -78,7 +78,7 @@ func TestClusterFormsNewGroupFromSiblings(t *testing.T) {
 		if err := store.UpdateArticleAISummary(art.ID, "summary of "+art.GUID); err != nil {
 			t.Fatal(err)
 		}
-		if err := store.SetInterestScore(1, art.ID, 8); err != nil {
+		if err := store.SetInterestScore(1, art.ID, 8, "", ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -128,7 +128,7 @@ func TestClusterSkipsTopicRefineOnEmptySummary(t *testing.T) {
 		if err := store.UpdateArticleAISummary(art.ID, "summary of "+art.GUID); err != nil {
 			t.Fatal(err)
 		}
-		if err := store.SetInterestScore(1, art.ID, 8); err != nil {
+		if err := store.SetInterestScore(1, art.ID, 8, "", ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -167,7 +167,7 @@ func TestClusterRecentRespectsToggle(t *testing.T) {
 			if err := store.ScreenArticleSecurity(art.ID, 1, "none", false, false); err != nil {
 				t.Fatal(err)
 			}
-			if err := store.SetInterestScore(1, art.ID, 8); err != nil {
+			if err := store.SetInterestScore(1, art.ID, 8, "", ""); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -217,7 +217,11 @@ func (s *Stage) curateOne(ctx context.Context, article storage.Article, security
 	}
 	// Record only the interest score; the security verdict was written by the
 	// security stage and must not be clobbered (SetInterestScore leaves it).
-	s.Store.SetInterestScore(s.UserID, article.ID, curResult.InterestScore) //nolint:errcheck
+	// Model and prompt hash go down with it: this is the one point where which
+	// prompt produced this score is known, and reconstructing it later reads
+	// back whatever is current instead (#258).
+	s.Store.SetInterestScore(s.UserID, article.ID, curResult.InterestScore, //nolint:errcheck
+		curResult.Model, curResult.PromptHash)
 	s.Formatter.OutputProcessingStatus(article.ID, article.Title, curResult.InterestScore, securityScore, true)
 	s.Formatter.Info("scored article %d: interest=%.1f security=%.1f: %s", article.ID, curResult.InterestScore, securityScore, article.Title)
 	return &article

--- a/internal/storage/db/article.sql.go
+++ b/internal/storage/db/article.sql.go
@@ -790,21 +790,36 @@ func (q *Queries) ScreenArticleSecurity(ctx context.Context, arg ScreenArticleSe
 }
 
 const setInterestScore = `-- name: SetInterestScore :exec
-INSERT INTO read_state (user_id, article_id, read, interest_score, ai_scored)
-VALUES ($1, $2, FALSE, $3::double precision, TRUE)
+INSERT INTO read_state (user_id, article_id, read, interest_score, ai_scored, score_model, prompt_hash)
+VALUES ($1, $2, FALSE, $3::double precision, TRUE,
+        NULLIF($4::text, ''), NULLIF($5::text, ''))
 ON CONFLICT (user_id, article_id) DO UPDATE SET
   interest_score = excluded.interest_score,
-  ai_scored = TRUE
+  ai_scored = TRUE,
+  score_model = excluded.score_model,
+  prompt_hash = excluded.prompt_hash
 `
 
 type SetInterestScoreParams struct {
 	UserID        int64
 	ArticleID     int64
 	InterestScore float64
+	ScoreModel    string
+	PromptHash    string
 }
 
+// score_model/prompt_hash are captured here, at scoring time, because this is
+// the only point where which model and prompt produced the score is known for
+// certain (#258). Reconstructing them later reads back whatever is current, not
+// what was in force.
 func (q *Queries) SetInterestScore(ctx context.Context, arg SetInterestScoreParams) error {
-	_, err := q.db.Exec(ctx, setInterestScore, arg.UserID, arg.ArticleID, arg.InterestScore)
+	_, err := q.db.Exec(ctx, setInterestScore,
+		arg.UserID,
+		arg.ArticleID,
+		arg.InterestScore,
+		arg.ScoreModel,
+		arg.PromptHash,
+	)
 	return err
 }
 

--- a/internal/storage/db/models.go
+++ b/internal/storage/db/models.go
@@ -238,6 +238,18 @@ type NewsletterIssue struct {
 	SentAt         *time.Time
 }
 
+type PromptVersion struct {
+	ID             int64
+	UserID         int64
+	PromptType     string
+	PromptTemplate string
+	TemplateHash   string
+	Temperature    *float64
+	Model          *string
+	Source         string
+	CreatedAt      time.Time
+}
+
 type ReadState struct {
 	UserID        int64
 	ArticleID     int64
@@ -247,6 +259,8 @@ type ReadState struct {
 	ReadDate      *time.Time
 	AiScored      bool
 	AiRetries     int
+	ScoreModel    *string
+	PromptHash    *string
 }
 
 type Session struct {
@@ -291,4 +305,5 @@ type UserPrompt struct {
 	Model          *string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
+	TemplateHash   *string
 }

--- a/internal/storage/db/prompt.sql.go
+++ b/internal/storage/db/prompt.sql.go
@@ -67,6 +67,45 @@ func (q *Queries) GetAllUserPreferences(ctx context.Context, userID int64) ([]Ge
 	return items, nil
 }
 
+const getPromptTemplateByHash = `-- name: GetPromptTemplateByHash :one
+SELECT prompt_template FROM prompt_versions
+WHERE template_hash = $1
+ORDER BY id ASC
+LIMIT 1
+`
+
+// Recover the text behind a hash recorded elsewhere (feedback events, scores).
+// Any scope will do: the hash identifies the text, not who used it.
+func (q *Queries) GetPromptTemplateByHash(ctx context.Context, templateHash string) (string, error) {
+	row := q.db.QueryRow(ctx, getPromptTemplateByHash, templateHash)
+	var prompt_template string
+	err := row.Scan(&prompt_template)
+	return prompt_template, err
+}
+
+const getPromptVersion = `-- name: GetPromptVersion :one
+SELECT id, user_id, prompt_type, prompt_template, template_hash, temperature, model, source, created_at
+FROM prompt_versions
+WHERE id = $1
+`
+
+func (q *Queries) GetPromptVersion(ctx context.Context, id int64) (PromptVersion, error) {
+	row := q.db.QueryRow(ctx, getPromptVersion, id)
+	var i PromptVersion
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.PromptType,
+		&i.PromptTemplate,
+		&i.TemplateHash,
+		&i.Temperature,
+		&i.Model,
+		&i.Source,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getUserPreference = `-- name: GetUserPreference :one
 SELECT value FROM user_preferences WHERE user_id = $1 AND key = $2
 `
@@ -117,6 +156,37 @@ func (q *Queries) GetUserPromptModel(ctx context.Context, arg GetUserPromptModel
 	return model, err
 }
 
+const getUserPromptResolved = `-- name: GetUserPromptResolved :one
+SELECT prompt_template, template_hash, temperature, model FROM user_prompts
+WHERE user_id = $1 AND prompt_type = $2
+`
+
+type GetUserPromptResolvedParams struct {
+	UserID     int64
+	PromptType string
+}
+
+type GetUserPromptResolvedRow struct {
+	PromptTemplate string
+	TemplateHash   *string
+	Temperature    *float64
+	Model          *string
+}
+
+// One lookup for everything resolution needs, replacing the three separate
+// GetUserPrompt* round trips per article per user.
+func (q *Queries) GetUserPromptResolved(ctx context.Context, arg GetUserPromptResolvedParams) (GetUserPromptResolvedRow, error) {
+	row := q.db.QueryRow(ctx, getUserPromptResolved, arg.UserID, arg.PromptType)
+	var i GetUserPromptResolvedRow
+	err := row.Scan(
+		&i.PromptTemplate,
+		&i.TemplateHash,
+		&i.Temperature,
+		&i.Model,
+	)
+	return i, err
+}
+
 const getUserPromptTemperature = `-- name: GetUserPromptTemperature :one
 SELECT temperature FROM user_prompts
 WHERE user_id = $1 AND prompt_type = $2
@@ -132,6 +202,84 @@ func (q *Queries) GetUserPromptTemperature(ctx context.Context, arg GetUserPromp
 	var temperature *float64
 	err := row.Scan(&temperature)
 	return temperature, err
+}
+
+const insertPromptVersion = `-- name: InsertPromptVersion :one
+INSERT INTO prompt_versions
+  (user_id, prompt_type, prompt_template, template_hash, temperature, model, source)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id
+`
+
+type InsertPromptVersionParams struct {
+	UserID         int64
+	PromptType     string
+	PromptTemplate string
+	TemplateHash   string
+	Temperature    *float64
+	Model          *string
+	Source         string
+}
+
+// Append-only (#258): every call adds a row. A revert appends the older text as
+// a new version rather than rewinding, so ordering stays a truthful record.
+func (q *Queries) InsertPromptVersion(ctx context.Context, arg InsertPromptVersionParams) (int64, error) {
+	row := q.db.QueryRow(ctx, insertPromptVersion,
+		arg.UserID,
+		arg.PromptType,
+		arg.PromptTemplate,
+		arg.TemplateHash,
+		arg.Temperature,
+		arg.Model,
+		arg.Source,
+	)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
+const listPromptVersions = `-- name: ListPromptVersions :many
+SELECT id, user_id, prompt_type, prompt_template, template_hash, temperature, model, source, created_at
+FROM prompt_versions
+WHERE user_id = $1 AND prompt_type = $2
+ORDER BY id DESC
+LIMIT $3
+`
+
+type ListPromptVersionsParams struct {
+	UserID     int64
+	PromptType string
+	Lim        int32
+}
+
+func (q *Queries) ListPromptVersions(ctx context.Context, arg ListPromptVersionsParams) ([]PromptVersion, error) {
+	rows, err := q.db.Query(ctx, listPromptVersions, arg.UserID, arg.PromptType, arg.Lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []PromptVersion{}
+	for rows.Next() {
+		var i PromptVersion
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.PromptType,
+			&i.PromptTemplate,
+			&i.TemplateHash,
+			&i.Temperature,
+			&i.Model,
+			&i.Source,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listUserPrompts = `-- name: ListUserPrompts :many
@@ -177,6 +325,42 @@ func (q *Queries) ListUserPrompts(ctx context.Context, userID int64) ([]ListUser
 	return items, nil
 }
 
+const registerPromptVersion = `-- name: RegisterPromptVersion :exec
+INSERT INTO prompt_versions
+  (user_id, prompt_type, prompt_template, template_hash, temperature, model, source)
+SELECT $1, $2, $3, $4, $5, $6, $7
+WHERE NOT EXISTS (
+  SELECT 1 FROM prompt_versions
+  WHERE user_id = $1 AND prompt_type = $2 AND template_hash = $4
+)
+`
+
+type RegisterPromptVersionParams struct {
+	UserID         int64
+	PromptType     string
+	PromptTemplate string
+	TemplateHash   string
+	Temperature    *float64
+	Model          *string
+	Source         string
+}
+
+// Idempotent registration for the tiers with no row of their own (embedded
+// default, config file). Called once per process per distinct hash, never on
+// the hot path -- prompt resolution is cached and must not write.
+func (q *Queries) RegisterPromptVersion(ctx context.Context, arg RegisterPromptVersionParams) error {
+	_, err := q.db.Exec(ctx, registerPromptVersion,
+		arg.UserID,
+		arg.PromptType,
+		arg.PromptTemplate,
+		arg.TemplateHash,
+		arg.Temperature,
+		arg.Model,
+		arg.Source,
+	)
+	return err
+}
+
 const setUserPreference = `-- name: SetUserPreference :exec
 INSERT INTO user_preferences (user_id, key, value)
 VALUES ($1, $2, $3)
@@ -195,10 +379,11 @@ func (q *Queries) SetUserPreference(ctx context.Context, arg SetUserPreferencePa
 }
 
 const setUserPrompt = `-- name: SetUserPrompt :exec
-INSERT INTO user_prompts (user_id, prompt_type, prompt_template, temperature, model, updated_at)
-VALUES ($1, $2, $3, $4, $5, NOW())
+INSERT INTO user_prompts (user_id, prompt_type, prompt_template, template_hash, temperature, model, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW())
 ON CONFLICT (user_id, prompt_type) DO UPDATE SET
   prompt_template = excluded.prompt_template,
+  template_hash = excluded.template_hash,
   temperature = excluded.temperature,
   model = COALESCE(excluded.model, user_prompts.model),
   updated_at = NOW()
@@ -208,15 +393,20 @@ type SetUserPromptParams struct {
 	UserID         int64
 	PromptType     string
 	PromptTemplate string
+	TemplateHash   *string
 	Temperature    *float64
 	Model          *string
 }
 
+// The current pointer. History lives in prompt_versions (#258); this row is
+// what prompt resolution reads on the hot path, so it keeps its own copy of the
+// hash rather than joining to find it.
 func (q *Queries) SetUserPrompt(ctx context.Context, arg SetUserPromptParams) error {
 	_, err := q.db.Exec(ctx, setUserPrompt,
 		arg.UserID,
 		arg.PromptType,
 		arg.PromptTemplate,
+		arg.TemplateHash,
 		arg.Temperature,
 		arg.Model,
 	)

--- a/internal/storage/db/queries/article.sql
+++ b/internal/storage/db/queries/article.sql
@@ -144,11 +144,18 @@ UPDATE articles SET linked_url = @linked_url, linked_content = @linked_content W
 UPDATE articles SET full_text_fetched = TRUE WHERE id = @id;
 
 -- name: SetInterestScore :exec
-INSERT INTO read_state (user_id, article_id, read, interest_score, ai_scored)
-VALUES (@user_id, @article_id, FALSE, @interest_score::double precision, TRUE)
+-- score_model/prompt_hash are captured here, at scoring time, because this is
+-- the only point where which model and prompt produced the score is known for
+-- certain (#258). Reconstructing them later reads back whatever is current, not
+-- what was in force.
+INSERT INTO read_state (user_id, article_id, read, interest_score, ai_scored, score_model, prompt_hash)
+VALUES (@user_id, @article_id, FALSE, @interest_score::double precision, TRUE,
+        NULLIF(@score_model::text, ''), NULLIF(@prompt_hash::text, ''))
 ON CONFLICT (user_id, article_id) DO UPDATE SET
   interest_score = excluded.interest_score,
-  ai_scored = TRUE;
+  ai_scored = TRUE,
+  score_model = excluded.score_model,
+  prompt_hash = excluded.prompt_hash;
 
 -- name: ScreenArticleSecurity :exec
 UPDATE articles

--- a/internal/storage/db/queries/prompt.sql
+++ b/internal/storage/db/queries/prompt.sql
@@ -11,13 +11,23 @@ SELECT model FROM user_prompts
 WHERE user_id = @user_id AND prompt_type = @prompt_type;
 
 -- name: SetUserPrompt :exec
-INSERT INTO user_prompts (user_id, prompt_type, prompt_template, temperature, model, updated_at)
-VALUES (@user_id, @prompt_type, @prompt_template, @temperature, @model, NOW())
+-- The current pointer. History lives in prompt_versions (#258); this row is
+-- what prompt resolution reads on the hot path, so it keeps its own copy of the
+-- hash rather than joining to find it.
+INSERT INTO user_prompts (user_id, prompt_type, prompt_template, template_hash, temperature, model, updated_at)
+VALUES (@user_id, @prompt_type, @prompt_template, @template_hash, @temperature, @model, NOW())
 ON CONFLICT (user_id, prompt_type) DO UPDATE SET
   prompt_template = excluded.prompt_template,
+  template_hash = excluded.template_hash,
   temperature = excluded.temperature,
   model = COALESCE(excluded.model, user_prompts.model),
   updated_at = NOW();
+
+-- name: GetUserPromptResolved :one
+-- One lookup for everything resolution needs, replacing the three separate
+-- GetUserPrompt* round trips per article per user.
+SELECT prompt_template, template_hash, temperature, model FROM user_prompts
+WHERE user_id = @user_id AND prompt_type = @prompt_type;
 
 -- name: DeleteUserPrompt :exec
 DELETE FROM user_prompts WHERE user_id = @user_id AND prompt_type = @prompt_type;
@@ -41,3 +51,43 @@ SELECT key, value FROM user_preferences WHERE user_id = @user_id;
 
 -- name: DeleteUserPreference :exec
 DELETE FROM user_preferences WHERE user_id = @user_id AND key = @key;
+
+-- name: InsertPromptVersion :one
+-- Append-only (#258): every call adds a row. A revert appends the older text as
+-- a new version rather than rewinding, so ordering stays a truthful record.
+INSERT INTO prompt_versions
+  (user_id, prompt_type, prompt_template, template_hash, temperature, model, source)
+VALUES (@user_id, @prompt_type, @prompt_template, @template_hash, @temperature, @model, @source)
+RETURNING id;
+
+-- name: RegisterPromptVersion :exec
+-- Idempotent registration for the tiers with no row of their own (embedded
+-- default, config file). Called once per process per distinct hash, never on
+-- the hot path -- prompt resolution is cached and must not write.
+INSERT INTO prompt_versions
+  (user_id, prompt_type, prompt_template, template_hash, temperature, model, source)
+SELECT @user_id, @prompt_type, @prompt_template, @template_hash, @temperature, @model, @source
+WHERE NOT EXISTS (
+  SELECT 1 FROM prompt_versions
+  WHERE user_id = @user_id AND prompt_type = @prompt_type AND template_hash = @template_hash
+);
+
+-- name: ListPromptVersions :many
+SELECT id, user_id, prompt_type, prompt_template, template_hash, temperature, model, source, created_at
+FROM prompt_versions
+WHERE user_id = @user_id AND prompt_type = @prompt_type
+ORDER BY id DESC
+LIMIT @lim;
+
+-- name: GetPromptVersion :one
+SELECT id, user_id, prompt_type, prompt_template, template_hash, temperature, model, source, created_at
+FROM prompt_versions
+WHERE id = @id;
+
+-- name: GetPromptTemplateByHash :one
+-- Recover the text behind a hash recorded elsewhere (feedback events, scores).
+-- Any scope will do: the hash identifies the text, not who used it.
+SELECT prompt_template FROM prompt_versions
+WHERE template_hash = @template_hash
+ORDER BY id ASC
+LIMIT 1;

--- a/internal/storage/feedback.go
+++ b/internal/storage/feedback.go
@@ -142,12 +142,16 @@ type FeedbackEventRow struct {
 	HasEmbedding  bool
 }
 
-// insertArticleFeedback snapshots provenance for article-scoped events. The
-// prompt hash is a fingerprint used to partition the corpus by prompt
-// generation, not a security control -- user_prompts is mutated in place and
-// keeps no history (#258), so this is the most that can be recovered. A NULL
-// hash means the user has no custom curation prompt and the built-in default
-// was in force.
+// insertArticleFeedback snapshots provenance for article-scoped events.
+//
+// score_model and prompt_hash are copied forward from read_state, where the
+// curation stage wrote them at scoring time (#258). They are deliberately NOT
+// re-derived from user_prompts here: that would resolve the prompt in force
+// when the READER acted, which is a different prompt whenever one was edited
+// between scoring and reading -- precisely when the labels matter most. NULL
+// means the score predates provenance recording and its origin is unknown; it
+// does not mean "the current prompt".
+//
 // content_length counts the body the reader could actually see in Herald: the
 // feed's content (falling back to the summary when the feed sends none) plus
 // any fetched full text. has_full_text says whether the linked article had been
@@ -167,7 +171,7 @@ INSERT INTO feedback_events (
 SELECT
     $1, a.id, a.feed_id, a.title, a.url, ae.embedding,
     $3, NULLIF($4, ''), NULLIF($5, ''),
-    rs.interest_score, up.model, encode(sha256(up.prompt_template::bytea), 'hex'),
+    rs.interest_score, rs.score_model, rs.prompt_hash,
     $6, $7, $8, f.status, f.consecutive_errors,
     length(COALESCE(NULLIF(a.content, ''), a.summary, '')) + length(COALESCE(a.linked_content, '')),
     COALESCE(a.linked_content, '') <> ''
@@ -176,7 +180,6 @@ JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = $1
 LEFT JOIN article_embeddings ae ON ae.article_id = a.id
 LEFT JOIN read_state rs ON rs.article_id = a.id AND rs.user_id = $1
 LEFT JOIN feeds f ON f.id = a.feed_id
-LEFT JOIN user_prompts up ON up.user_id = $1 AND up.prompt_type = 'curation'
 WHERE a.id = ANY($2::bigint[])`
 
 // RecordFeedbackEvent appends one article-scoped event. An event for an article

--- a/internal/storage/feedback_test.go
+++ b/internal/storage/feedback_test.go
@@ -42,13 +42,12 @@ func TestRecordFeedbackEventSnapshotsProvenance(t *testing.T) {
 	eachStore(t, func(t *testing.T, store Store) {
 		userID, _, articleID := feedbackFixture(t, store)
 
-		score := 7.5
-		if err := store.UpdateReadState(userID, articleID, false, &score); err != nil {
-			t.Fatalf("UpdateReadState: %v", err)
-		}
 		model := "qwen3:14b"
-		if err := store.SetUserPrompt(userID, "curation", "score this: {{.Title}}", nil, &model); err != nil {
-			t.Fatalf("SetUserPrompt: %v", err)
+		promptHash := HashPromptTemplate("score this: {{.Title}}")
+		// Provenance is written where the score is written (#258), not looked
+		// up later from whatever prompt happens to be current.
+		if err := store.SetInterestScore(userID, articleID, 7.5, model, promptHash); err != nil {
+			t.Fatalf("SetInterestScore: %v", err)
 		}
 
 		pos := 4
@@ -60,10 +59,12 @@ func TestRecordFeedbackEventSnapshotsProvenance(t *testing.T) {
 			t.Fatalf("RecordFeedbackEvent: %v", err)
 		}
 
-		// Everything the event referenced now changes underneath it.
-		newScore := 1.0
-		if err := store.UpdateReadState(userID, articleID, true, &newScore); err != nil {
-			t.Fatalf("UpdateReadState (rescore): %v", err)
+		// Everything the event referenced now changes underneath it: the
+		// article is rescored by a different model under a different prompt,
+		// and the user's prompt row is edited too.
+		if err := store.SetInterestScore(userID, articleID, 1.0, "other-model",
+			HashPromptTemplate("COMPLETELY DIFFERENT PROMPT")); err != nil {
+			t.Fatalf("SetInterestScore (rescore): %v", err)
 		}
 		if err := store.SetUserPrompt(userID, "curation", "COMPLETELY DIFFERENT PROMPT", nil, &model); err != nil {
 			t.Fatalf("SetUserPrompt (edit): %v", err)
@@ -84,8 +85,8 @@ func TestRecordFeedbackEventSnapshotsProvenance(t *testing.T) {
 		if ev.ScoreModel == nil || *ev.ScoreModel != model {
 			t.Errorf("score_model = %v, want %q", ev.ScoreModel, model)
 		}
-		if ev.PromptHash == nil || *ev.PromptHash == "" {
-			t.Errorf("prompt_hash not captured")
+		if ev.PromptHash == nil || *ev.PromptHash != promptHash {
+			t.Errorf("prompt_hash = %v, want the hash in force when the score was written (%q)", ev.PromptHash, promptHash)
 		}
 		if ev.ListPosition == nil || *ev.ListPosition != 4 {
 			t.Errorf("list_position = %v, want 4", ev.ListPosition)
@@ -455,4 +456,92 @@ func testVector(v float32) []float32 {
 		vec[i] = v
 	}
 	return vec
+}
+
+// TestFeedbackUsesScoringTimeProvenance is the regression this change exists
+// for. The prompt is edited between the moment the article is scored and the
+// moment the reader acts on it. The event must report the prompt that produced
+// the score, not the one in force when the click happened -- and a prompt edit
+// is precisely when that distinction matters, because evaluating the edit is
+// the reason the labels are collected at all.
+func TestFeedbackUsesScoringTimeProvenance(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		scoringHash := HashPromptTemplate("the prompt that scored it")
+		if err := store.SetInterestScore(userID, articleID, 9.0, "scoring-model", scoringHash); err != nil {
+			t.Fatalf("SetInterestScore: %v", err)
+		}
+
+		// The reader edits their curation prompt before working the queue.
+		newModel := "rewritten-model"
+		if err := store.SetUserPrompt(userID, "curation", "a rewritten prompt", nil, &newModel); err != nil {
+			t.Fatalf("SetUserPrompt: %v", err)
+		}
+
+		if err := store.RecordFeedbackEvent(FeedbackEvent{
+			UserID: userID, ArticleID: articleID,
+			Kind: FeedbackArticleOpened, Surface: SurfaceWebList,
+		}); err != nil {
+			t.Fatalf("RecordFeedbackEvent: %v", err)
+		}
+
+		events, err := store.ListFeedbackEvents(userID, 10)
+		if err != nil {
+			t.Fatalf("ListFeedbackEvents: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		ev := events[0]
+
+		if ev.PromptHash == nil || *ev.PromptHash != scoringHash {
+			t.Errorf("prompt_hash = %v, want the scoring-time hash %q -- the read-time prompt leaked in",
+				ev.PromptHash, scoringHash)
+		}
+		if ev.ScoreModel == nil || *ev.ScoreModel != "scoring-model" {
+			t.Errorf("score_model = %v, want %q", ev.ScoreModel, "scoring-model")
+		}
+	})
+}
+
+// A score written before provenance existed leaves both columns NULL. NULL must
+// read as "unknown", never as "whatever is current" -- a consumer that fills the
+// gap from user_prompts would attribute old scores to a prompt that never saw
+// them.
+func TestFeedbackProvenanceNullWhenUnrecorded(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		// Scored the old way: a score, no provenance.
+		score := 5.0
+		if err := store.UpdateReadState(userID, articleID, false, &score); err != nil {
+			t.Fatalf("UpdateReadState: %v", err)
+		}
+		model := "current-model"
+		if err := store.SetUserPrompt(userID, "curation", "the current prompt", nil, &model); err != nil {
+			t.Fatalf("SetUserPrompt: %v", err)
+		}
+
+		if err := store.RecordFeedbackEvent(FeedbackEvent{
+			UserID: userID, ArticleID: articleID,
+			Kind: FeedbackArticleOpened, Surface: SurfaceWebList,
+		}); err != nil {
+			t.Fatalf("RecordFeedbackEvent: %v", err)
+		}
+
+		events, err := store.ListFeedbackEvents(userID, 10)
+		if err != nil {
+			t.Fatalf("ListFeedbackEvents: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		if events[0].PromptHash != nil {
+			t.Errorf("prompt_hash = %q, want NULL -- an unrecorded origin must not be backfilled from the current prompt", *events[0].PromptHash)
+		}
+		if events[0].ScoreModel != nil {
+			t.Errorf("score_model = %q, want NULL", *events[0].ScoreModel)
+		}
+	})
 }

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 10 {
-		t.Errorf("goose max version = %d, want 10", maxVersion)
+	if maxVersion != 12 {
+		t.Errorf("goose max version = %d, want 12", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0011_prompt_versions.sql
+++ b/internal/storage/migrations/0011_prompt_versions.sql
@@ -1,0 +1,79 @@
+-- +goose Up
+--
+-- Append-only prompt history (#258). user_prompts is keyed (user_id,
+-- prompt_type) and edits overwrite prompt_template in place, so the text that
+-- produced any already-written score is gone. That makes "did the rewrite
+-- help?" unanswerable after the fact and leaves no way back from a bad edit.
+--
+-- The table is CONTENT-ADDRESSED: rows are identified by template_hash, the
+-- sha256 of the template text. That matters because an effective prompt does
+-- not always come from a database row. PromptLoader resolves through four
+-- tiers -- embedded default, config file, admin override (user_id = 0), user
+-- row -- and the bottom two have no row to version. Hashing the resolved text
+-- gives every tier a stable identity, so a feedback event recorded on a stock
+-- instance is as attributable as one from a user who wrote their own prompt.
+-- Before this, both columns were simply NULL on every event.
+--
+-- source records which tier the text came from. It is descriptive, not a key:
+-- the same text promoted from config into a user row keeps its hash and gains
+-- a second row. Hash answers "which prompt", source answers "how did it get
+-- used", and they are deliberately separate questions.
+--
+-- Rows are never updated or deleted by the application. A revert appends a new
+-- row carrying an older hash rather than rewinding history, so the sequence of
+-- ids stays a truthful record of what was in force and when.
+
+CREATE TABLE IF NOT EXISTS prompt_versions (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+
+    -- 0 for the non-user tiers (embedded default, config file, admin
+    -- override), matching PromptLoader's own use of user_id = 0 as the global
+    -- scope. Not a foreign key: a version must outlive the account that wrote
+    -- it, or deleting a user would erase the provenance of scores that other
+    -- tables still reference by hash.
+    user_id         BIGINT NOT NULL,
+    prompt_type     TEXT NOT NULL,
+
+    prompt_template TEXT NOT NULL,
+    -- sha256 of prompt_template, lowercase hex. Computed once, at write time,
+    -- so the scoring path, the feedback log (#251) and this table cannot
+    -- disagree about which prompt a score came from.
+    template_hash   TEXT NOT NULL,
+
+    temperature     DOUBLE PRECISION,
+    model           TEXT,
+
+    -- 'builtin' | 'config' | 'admin' | 'user'
+    source          TEXT NOT NULL,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- History reads: one scope, newest first.
+CREATE INDEX IF NOT EXISTS idx_prompt_versions_scope ON prompt_versions(user_id, prompt_type, id DESC);
+-- Hash reads: recover the text behind a hash recorded elsewhere, from any scope.
+CREATE INDEX IF NOT EXISTS idx_prompt_versions_hash ON prompt_versions(template_hash);
+
+-- The current pointer keeps its own copy of the hash so prompt resolution stays
+-- a single indexed lookup on the hot path -- it runs per article per user and
+-- must not gain a join.
+ALTER TABLE user_prompts ADD COLUMN IF NOT EXISTS template_hash TEXT;
+
+-- Backfill: existing rows are real prompts in force, they just have no history.
+-- Seed each as its own first version so the record starts complete rather than
+-- with an unexplained gap before the first post-migration edit.
+UPDATE user_prompts
+SET template_hash = encode(sha256(prompt_template::bytea), 'hex')
+WHERE template_hash IS NULL;
+
+INSERT INTO prompt_versions (user_id, prompt_type, prompt_template, template_hash, temperature, model, source, created_at)
+SELECT user_id, prompt_type, prompt_template,
+       encode(sha256(prompt_template::bytea), 'hex'),
+       temperature, model,
+       CASE WHEN user_id = 0 THEN 'admin' ELSE 'user' END,
+       COALESCE(updated_at, created_at, NOW())
+FROM user_prompts;
+
+-- +goose Down
+ALTER TABLE user_prompts DROP COLUMN IF EXISTS template_hash;
+DROP TABLE IF EXISTS prompt_versions;

--- a/internal/storage/migrations/0012_read_state_provenance.sql
+++ b/internal/storage/migrations/0012_read_state_provenance.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+--
+-- Scoring-time provenance for the curation score (#258).
+--
+-- read_state.interest_score records what the curation model decided, but not
+-- which model or prompt decided it. The feedback log (#251) worked around that
+-- by joining user_prompts when the READER acted, which answers a different
+-- question: it reconstructs the prompt in force at read time, not the one that
+-- produced the score. Any edit between scoring and reading silently mislabels
+-- every event in the queue -- and a prompt edit is exactly the moment the
+-- labels matter most, since evaluating the edit is the whole point.
+--
+-- Recording at the point of scoring is the only place the answer is known for
+-- certain. The feedback log now copies these forward instead of re-deriving
+-- them, which also makes the snapshot rule in migration 0010 true rather than
+-- aspirational.
+--
+-- Both stay NULL for scores written before this migration. That is honest --
+-- their provenance was never recorded and cannot be recovered -- and consumers
+-- must treat NULL as "unknown", never as "current".
+
+ALTER TABLE read_state ADD COLUMN IF NOT EXISTS score_model TEXT;
+ALTER TABLE read_state ADD COLUMN IF NOT EXISTS prompt_hash TEXT;
+
+-- +goose Down
+ALTER TABLE read_state DROP COLUMN IF EXISTS score_model;
+ALTER TABLE read_state DROP COLUMN IF EXISTS prompt_hash;

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -287,14 +287,73 @@ func (s *PostgresStore) GetUserPromptModel(userID int64, promptType string) (str
 	return derefString(model), nil
 }
 
+// SetUserPrompt moves the current pointer and appends a version (#258). Both
+// happen here rather than at the call sites so an edit cannot land without
+// history: overwriting in place is the exact failure this replaces.
+//
+// The version is appended first. A save that writes history but fails to move
+// the pointer leaves a harmless orphan; the reverse would lose the record of a
+// prompt that is now live.
 func (s *PostgresStore) SetUserPrompt(userID int64, promptType, promptTemplate string, temperature *float64, model *string) error {
+	hash := HashPromptTemplate(promptTemplate)
+
+	source := SourceUser
+	if userID == 0 {
+		source = SourceAdmin
+	}
+	v := PromptVersion{
+		UserID:       userID,
+		PromptType:   promptType,
+		Template:     promptTemplate,
+		TemplateHash: hash,
+		Source:       source,
+	}
+	if temperature != nil {
+		v.Temperature = *temperature
+	}
+	if model != nil {
+		v.Model = *model
+	}
+	if _, err := s.InsertPromptVersion(v); err != nil {
+		return err
+	}
+
 	return s.q.SetUserPrompt(context.Background(), db.SetUserPromptParams{
 		UserID:         userID,
 		PromptType:     promptType,
 		PromptTemplate: promptTemplate,
+		TemplateHash:   &hash,
 		Temperature:    temperature,
 		Model:          model,
 	})
+}
+
+// GetUserPromptResolved returns template, hash, temperature and model in one
+// lookup. Prompt resolution runs per article per user, and fetching these
+// through three separate queries was both slower and the structural cause of
+// the provenance bug in #258: values fetched at different moments could
+// describe different prompts.
+func (s *PostgresStore) GetUserPromptResolved(userID int64, promptType string) (template, hash string, temperature float64, model string, err error) {
+	row, err := s.q.GetUserPromptResolved(context.Background(), db.GetUserPromptResolvedParams{
+		UserID:     userID,
+		PromptType: promptType,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", "", 0, "", nil
+		}
+		return "", "", 0, "", fmt.Errorf("get user prompt resolved: %w", err)
+	}
+	if row.TemplateHash != nil {
+		hash = *row.TemplateHash
+	}
+	if row.Temperature != nil {
+		temperature = *row.Temperature
+	}
+	if row.Model != nil {
+		model = *row.Model
+	}
+	return row.PromptTemplate, hash, temperature, model, nil
 }
 
 func (s *PostgresStore) DeleteUserPrompt(userID int64, promptType string) error {
@@ -831,12 +890,16 @@ func (s *PostgresStore) GetUnsummarizedScoredArticles(maxSecurityThreat float64,
 }
 
 // SetInterestScore records the curation interest score without touching the
-// security verdict. See the SQLite implementation.
-func (s *PostgresStore) SetInterestScore(userID, articleID int64, interestScore float64) error {
+// security verdict, along with the model and prompt hash that produced it
+// (#258). Empty provenance strings are stored as NULL, which reads as "origin
+// unknown" rather than "the prompt currently in force".
+func (s *PostgresStore) SetInterestScore(userID, articleID int64, interestScore float64, scoreModel, promptHash string) error {
 	if err := s.q.SetInterestScore(context.Background(), db.SetInterestScoreParams{
 		UserID:        userID,
 		ArticleID:     articleID,
 		InterestScore: interestScore,
+		ScoreModel:    scoreModel,
+		PromptHash:    promptHash,
 	}); err != nil {
 		return fmt.Errorf("set interest score: %w", err)
 	}

--- a/internal/storage/prompt_version.go
+++ b/internal/storage/prompt_version.go
@@ -1,0 +1,178 @@
+package storage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/matthewjhunter/herald/internal/storage/db"
+)
+
+// PromptVersion is one entry in the append-only prompt history (#258).
+//
+// Identity is TemplateHash, not ID: the same text used by two users, or
+// promoted from the config file into a user row, is one prompt with several
+// rows recording where it was in force. Scores and feedback events reference
+// the hash, so a version row is what makes a recorded hash legible after the
+// fact.
+type PromptVersion struct {
+	ID           int64
+	UserID       int64
+	PromptType   string
+	Template     string
+	TemplateHash string
+	Temperature  float64
+	Model        string
+	// Source is the tier that supplied the text: builtin, config, admin, user.
+	Source    string
+	CreatedAt time.Time
+}
+
+func nullableFloat(f float64) *float64 {
+	if f == 0 {
+		return nil
+	}
+	return &f
+}
+
+func nullableText(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// InsertPromptVersion appends a version unconditionally. Used for user and
+// admin edits, where every save is a distinct event even when the text is
+// unchanged from an earlier one -- reverting to a previous prompt appends
+// rather than rewinding, so the history stays a record of what was in force
+// and when.
+func (s *PostgresStore) InsertPromptVersion(v PromptVersion) (int64, error) {
+	id, err := s.q.InsertPromptVersion(context.Background(), db.InsertPromptVersionParams{
+		UserID:         v.UserID,
+		PromptType:     v.PromptType,
+		PromptTemplate: v.Template,
+		TemplateHash:   v.TemplateHash,
+		Temperature:    nullableFloat(v.Temperature),
+		Model:          nullableText(v.Model),
+		Source:         v.Source,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("insert prompt version: %w", err)
+	}
+	return id, nil
+}
+
+// RegisterPromptVersion records a version only if that hash is not already
+// present in the same scope. Used for the builtin and config tiers, which have
+// no save event to hang a version off and would otherwise accumulate a row per
+// process start.
+func (s *PostgresStore) RegisterPromptVersion(v PromptVersion) error {
+	if err := s.q.RegisterPromptVersion(context.Background(), db.RegisterPromptVersionParams{
+		UserID:         v.UserID,
+		PromptType:     v.PromptType,
+		PromptTemplate: v.Template,
+		TemplateHash:   v.TemplateHash,
+		Temperature:    nullableFloat(v.Temperature),
+		Model:          nullableText(v.Model),
+		Source:         v.Source,
+	}); err != nil {
+		return fmt.Errorf("register prompt version: %w", err)
+	}
+	return nil
+}
+
+// ListPromptVersions returns a scope's history, newest first.
+func (s *PostgresStore) ListPromptVersions(userID int64, promptType string, limit int) ([]PromptVersion, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.q.ListPromptVersions(context.Background(), db.ListPromptVersionsParams{
+		UserID:     userID,
+		PromptType: promptType,
+		Lim:        int32(limit), //nolint:gosec // bounded above
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list prompt versions: %w", err)
+	}
+	out := make([]PromptVersion, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, promptVersionFrom(r.ID, r.UserID, r.PromptType, r.PromptTemplate,
+			r.TemplateHash, r.Temperature, r.Model, r.Source, r.CreatedAt))
+	}
+	return out, nil
+}
+
+// GetPromptVersion fetches one version by id. Returns nil when absent so a
+// stale link from the settings UI is a not-found rather than an error.
+func (s *PostgresStore) GetPromptVersion(id int64) (*PromptVersion, error) {
+	r, err := s.q.GetPromptVersion(context.Background(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get prompt version: %w", err)
+	}
+	v := promptVersionFrom(r.ID, r.UserID, r.PromptType, r.PromptTemplate,
+		r.TemplateHash, r.Temperature, r.Model, r.Source, r.CreatedAt)
+	return &v, nil
+}
+
+// GetPromptTemplateByHash recovers the text behind a hash recorded on a score
+// or a feedback event. Any scope will do -- the hash identifies the text, not
+// who used it. Returns "" when the hash is unknown, which is the expected
+// answer for scores written before provenance was recorded.
+func (s *PostgresStore) GetPromptTemplateByHash(hash string) (string, error) {
+	t, err := s.q.GetPromptTemplateByHash(context.Background(), hash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get prompt template by hash: %w", err)
+	}
+	return t, nil
+}
+
+func promptVersionFrom(id, userID int64, promptType, template, hash string,
+	temperature *float64, model *string, source string, created time.Time,
+) PromptVersion {
+	v := PromptVersion{
+		ID:           id,
+		UserID:       userID,
+		PromptType:   promptType,
+		Template:     template,
+		TemplateHash: hash,
+		Source:       source,
+		CreatedAt:    created,
+	}
+	if temperature != nil {
+		v.Temperature = *temperature
+	}
+	if model != nil {
+		v.Model = *model
+	}
+	return v
+}
+
+// Prompt tier names recorded on a version row. Defined here rather than in the
+// ai package because the store writes them when a prompt is saved, and ai
+// imports storage.
+const (
+	SourceBuiltin = "builtin"
+	SourceConfig  = "config"
+	SourceAdmin   = "admin"
+	SourceUser    = "user"
+)
+
+// HashPromptTemplate returns the content address of a prompt template: sha256,
+// lowercase hex. Single definition shared by the store, prompt resolution and
+// the migration backfill -- if any two disagreed, the corpus would split into
+// halves that cannot be joined.
+func HashPromptTemplate(t string) string {
+	sum := sha256.Sum256([]byte(t))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/storage/prompt_version_test.go
+++ b/internal/storage/prompt_version_test.go
@@ -1,0 +1,195 @@
+package storage
+
+import (
+	"testing"
+)
+
+func mustUser(t *testing.T, store Store) int64 {
+	t.Helper()
+	uid, err := store.CreateUser("reader")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return uid
+}
+
+// TestSetUserPromptAppendsVersion is the core guarantee of #258: an edit must
+// not destroy the text it replaced.
+func TestSetUserPromptAppendsVersion(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	uid := mustUser(t, s)
+
+	if err := s.SetUserPrompt(uid, "curation", "first draft", nil, nil); err != nil {
+		t.Fatalf("set first: %v", err)
+	}
+	if err := s.SetUserPrompt(uid, "curation", "second draft", nil, nil); err != nil {
+		t.Fatalf("set second: %v", err)
+	}
+
+	versions, err := s.ListPromptVersions(uid, "curation", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("got %d versions, want 2", len(versions))
+	}
+	// Newest first.
+	if versions[0].Template != "second draft" {
+		t.Errorf("newest = %q, want %q", versions[0].Template, "second draft")
+	}
+	if versions[1].Template != "first draft" {
+		t.Errorf("oldest = %q, want %q -- the overwritten text must survive", versions[1].Template, "first draft")
+	}
+	for _, v := range versions {
+		if v.Source != SourceUser {
+			t.Errorf("source = %q, want %q", v.Source, SourceUser)
+		}
+		if v.TemplateHash != HashPromptTemplate(v.Template) {
+			t.Errorf("hash %q does not match its own template", v.TemplateHash)
+		}
+	}
+}
+
+// A revert appends rather than rewinding, so history stays a truthful record of
+// what was in force and when.
+func TestRevertAppendsRatherThanRewinds(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	uid := mustUser(t, s)
+
+	for _, text := range []string{"A", "B", "A"} {
+		if err := s.SetUserPrompt(uid, "curation", text, nil, nil); err != nil {
+			t.Fatalf("set %q: %v", text, err)
+		}
+	}
+
+	versions, err := s.ListPromptVersions(uid, "curation", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(versions) != 3 {
+		t.Fatalf("got %d versions, want 3 -- a revert is an event, not an erasure", len(versions))
+	}
+	if versions[0].Template != "A" || versions[1].Template != "B" {
+		t.Errorf("history = %q,%q,... want A,B,A newest-first",
+			versions[0].Template, versions[1].Template)
+	}
+	// Same text, same content address, distinct rows.
+	if versions[0].TemplateHash != versions[2].TemplateHash {
+		t.Error("identical text produced different hashes")
+	}
+	if versions[0].ID == versions[2].ID {
+		t.Error("revert reused the original row instead of appending")
+	}
+}
+
+// RegisterPromptVersion backs the builtin and config tiers, which resolve on
+// every process start. It must not accumulate a row each time.
+func TestRegisterPromptVersionIsIdempotent(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	v := PromptVersion{
+		UserID:       0,
+		PromptType:   "curation",
+		Template:     "built-in text",
+		TemplateHash: HashPromptTemplate("built-in text"),
+		Source:       SourceBuiltin,
+	}
+	for i := 0; i < 3; i++ {
+		if err := s.RegisterPromptVersion(v); err != nil {
+			t.Fatalf("register %d: %v", i, err)
+		}
+	}
+
+	versions, err := s.ListPromptVersions(0, "curation", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("got %d rows after 3 registrations, want 1", len(versions))
+	}
+	if versions[0].Source != SourceBuiltin {
+		t.Errorf("source = %q, want %q", versions[0].Source, SourceBuiltin)
+	}
+}
+
+// A hash recorded on a score or a feedback event must be resolvable back to the
+// text, or provenance is just an opaque string.
+func TestGetPromptTemplateByHash(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	uid := mustUser(t, s)
+
+	const text = "score this article"
+	if err := s.SetUserPrompt(uid, "curation", text, nil, nil); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	got, err := s.GetPromptTemplateByHash(HashPromptTemplate(text))
+	if err != nil {
+		t.Fatalf("by hash: %v", err)
+	}
+	if got != text {
+		t.Errorf("got %q, want %q", got, text)
+	}
+
+	// An unknown hash is the normal answer for scores written before
+	// provenance existed, and must not be an error.
+	missing, err := s.GetPromptTemplateByHash(HashPromptTemplate("never saved"))
+	if err != nil {
+		t.Fatalf("unknown hash errored: %v", err)
+	}
+	if missing != "" {
+		t.Errorf("unknown hash returned %q, want empty", missing)
+	}
+}
+
+// A version id is a bare integer in a URL. Reverting to another user's version
+// must fail rather than copying their prompt text into the caller's account,
+// which would turn the revert path into a read primitive for other people's
+// prompts.
+func TestPromptVersionScopeIsCheckable(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	alice := mustUser(t, s)
+	bob, err := s.CreateUser("bob")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := s.SetUserPrompt(alice, "curation", "alice private prompt", nil, nil); err != nil {
+		t.Fatalf("set alice: %v", err)
+	}
+	aliceVersions, err := s.ListPromptVersions(alice, "curation", 10)
+	if err != nil {
+		t.Fatalf("list alice: %v", err)
+	}
+	if len(aliceVersions) != 1 {
+		t.Fatalf("got %d alice versions, want 1", len(aliceVersions))
+	}
+
+	// Bob's own history must not contain it.
+	bobVersions, err := s.ListPromptVersions(bob, "curation", 10)
+	if err != nil {
+		t.Fatalf("list bob: %v", err)
+	}
+	if len(bobVersions) != 0 {
+		t.Fatalf("bob sees %d versions, want 0", len(bobVersions))
+	}
+
+	// Fetching by id still returns the row -- the store is not the access
+	// boundary -- so it must carry the owner for the caller to check.
+	got, err := s.GetPromptVersion(aliceVersions[0].ID)
+	if err != nil {
+		t.Fatalf("get by id: %v", err)
+	}
+	if got == nil {
+		t.Fatal("version not found by id")
+	}
+	if got.UserID != alice {
+		t.Errorf("UserID = %d, want %d -- ownership must be checkable by the caller", got.UserID, alice)
+	}
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2567,7 +2567,7 @@ func TestMarkSecurityScoredAndCurationQueue(t *testing.T) {
 		if err := store.ScreenArticleSecurity(scored, 2, "none", false, false); err != nil {
 			t.Fatalf("ScreenArticleSecurity scored: %v", err)
 		}
-		if err := store.SetInterestScore(1, scored, 6.0); err != nil {
+		if err := store.SetInterestScore(1, scored, 6.0, "", ""); err != nil {
 			t.Fatalf("SetInterestScore: %v", err)
 		}
 
@@ -2589,7 +2589,7 @@ func TestMarkSecurityScoredAndCurationQueue(t *testing.T) {
 
 		// Curate it, then re-screen: the interest score must survive (security and
 		// interest live in different tables now) and it must drop out of curation.
-		if err := store.SetInterestScore(1, passed, 7.5); err != nil {
+		if err := store.SetInterestScore(1, passed, 7.5, "", ""); err != nil {
 			t.Fatalf("SetInterestScore passed: %v", err)
 		}
 		if err := store.ScreenArticleSecurity(passed, 2, "none", false, false); err != nil {
@@ -2618,7 +2618,7 @@ func TestSetInterestScorePreservesSecurity(t *testing.T) {
 		if err := store.ScreenArticleSecurity(id, 2, "none", false, false); err != nil {
 			t.Fatalf("ScreenArticleSecurity: %v", err)
 		}
-		if err := store.SetInterestScore(1, id, 6.0); err != nil {
+		if err := store.SetInterestScore(1, id, 6.0, "", ""); err != nil {
 			t.Fatalf("SetInterestScore: %v", err)
 		}
 
@@ -2735,7 +2735,7 @@ func TestGetProcessingStats(t *testing.T) {
 	if err := store.ScreenArticleSecurity(a2, 2, "none", false, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetInterestScore(1, a2, 7); err != nil {
+	if err := store.SetInterestScore(1, a2, 7, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.UpdateArticleAISummary(a2, "a real summary"); err != nil {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -108,6 +108,16 @@ type Store interface {
 	GetUserPromptTemperature(userID int64, promptType string) (float64, error)
 	GetUserPromptModel(userID int64, promptType string) (string, error)
 	SetUserPrompt(userID int64, promptType, promptTemplate string, temperature *float64, model *string) error
+
+	// Append-only prompt history (#258). Versions are content-addressed by the
+	// sha256 of the template, so the builtin and config tiers -- which have no
+	// row of their own -- get stable identities too.
+	GetUserPromptResolved(userID int64, promptType string) (template, hash string, temperature float64, model string, err error)
+	InsertPromptVersion(v PromptVersion) (int64, error)
+	RegisterPromptVersion(v PromptVersion) error
+	ListPromptVersions(userID int64, promptType string, limit int) ([]PromptVersion, error)
+	GetPromptVersion(id int64) (*PromptVersion, error)
+	GetPromptTemplateByHash(hash string) (string, error)
 	DeleteUserPrompt(userID int64, promptType string) error
 	ListUserPrompts(userID int64) ([]UserPrompt, error)
 
@@ -147,7 +157,7 @@ type Store interface {
 	// GetLowSafetyArticleSample returns the lowest-scoring screened articles first,
 	// for the harness's --unsafe-first mode. Diagnostic; read-only.
 	GetLowSafetyArticleSample(limit int) ([]ScreenedArticle, error)
-	SetInterestScore(userID, articleID int64, interestScore float64) error
+	SetInterestScore(userID, articleID int64, interestScore float64, scoreModel, promptHash string) error
 	IncrementAIRetries(userID, articleID int64) error
 	ResetScores(userID int64, securityOnly bool, belowScore float64) (int64, error)
 	GetScoreStats(userID int64) (*ScoreStatsResult, error)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -80,6 +80,9 @@ type promptUIEntry struct {
 	Model           string
 	IsCustom        bool
 	AvailableModels []string
+	// History is the append-only version list for this prompt (#258), newest
+	// first. Empty for a prompt that has never been edited.
+	History []promptVersionUI
 }
 
 // userPromptTypeOrder and adminPromptTypeOrder define the display order for
@@ -97,6 +100,34 @@ var promptLabels = map[string]string{
 	"newsletter":    "Newsletter",
 }
 
+// promptVersionUI is one row of prompt history in the settings UI.
+type promptVersionUI struct {
+	ID        int64
+	ShortHash string
+	Preview   string
+	Source    string
+	When      string
+	Current   bool
+}
+
+// promptHistoryLimit bounds the history shown per prompt. The table is
+// append-only and a heavy editor accumulates rows indefinitely, so the UI shows
+// a recent window rather than everything.
+const promptHistoryLimit = 20
+
+// promptPreviewLen is how much of a past template the history list shows. Full
+// text stays out of the list: these are multi-kilobyte prompts and the list is
+// for picking one, not reading it.
+const promptPreviewLen = 120
+
+func promptPreview(t string) string {
+	t = strings.Join(strings.Fields(t), " ")
+	if len(t) <= promptPreviewLen {
+		return t
+	}
+	return t[:promptPreviewLen] + "..."
+}
+
 // loadPromptEntries builds the UI entry list for a given userID and prompt
 // type list (userPromptTypeOrder or adminPromptTypeOrder).
 func (h *handlers) loadPromptEntries(userID int64, promptTypes []string) []promptUIEntry {
@@ -107,14 +138,33 @@ func (h *handlers) loadPromptEntries(userID int64, promptTypes []string) []promp
 		if err != nil {
 			continue
 		}
-		entries = append(entries, promptUIEntry{
+		entry := promptUIEntry{
 			Type:            pt,
 			Label:           promptLabels[pt],
 			Template:        detail.Template,
 			Model:           detail.Model,
 			IsCustom:        detail.IsCustom,
 			AvailableModels: models,
-		})
+		}
+		// History is best effort: a prompt that cannot list its past versions
+		// still renders and stays editable.
+		if history, herr := h.engine.ListPromptHistory(userID, pt, promptHistoryLimit); herr == nil {
+			for _, v := range history {
+				hash := v.Hash
+				if len(hash) > 8 {
+					hash = hash[:8]
+				}
+				entry.History = append(entry.History, promptVersionUI{
+					ID:        v.ID,
+					ShortHash: hash,
+					Preview:   promptPreview(v.Template),
+					Source:    v.Source,
+					When:      v.CreatedAt.Local().Format("Jan 2, 2006 3:04 PM"),
+					Current:   v.Current,
+				})
+			}
+		}
+		entries = append(entries, entry)
 	}
 	return entries
 }
@@ -1803,6 +1853,28 @@ func (h *handlers) handleFeverCredentialDelete(w http.ResponseWriter, r *http.Re
 }
 
 // --- AI prompt handlers ---
+
+// handleUserPromptRevert makes an earlier version of a prompt current again
+// (#258). The revert appends a new version rather than rewinding history.
+func (h *handlers) handleUserPromptRevert(w http.ResponseWriter, r *http.Request) {
+	uid := userFromContext(r.Context()).ID
+	promptType := r.PathValue("promptType")
+
+	versionID, err := strconv.ParseInt(r.PathValue("versionID"), 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid version")
+		return
+	}
+	// Ownership is enforced in the engine: a version id is a bare integer and
+	// must not be usable to read back another account's prompt text.
+	if err := h.engine.RevertPrompt(uid, promptType, versionID); err != nil {
+		log.Printf("herald-web: revert prompt failed for user %d type %q version %d: %v", uid, promptType, versionID, err)
+		h.renderError(w, http.StatusBadRequest, "Could not revert to that version")
+		return
+	}
+	w.Header().Set("HX-Refresh", "true")
+	w.WriteHeader(http.StatusNoContent)
+}
 
 func (h *handlers) handleUserPromptSave(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -180,6 +180,9 @@ func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	// "curation" prompt so the two don't interact.
 	mux.Handle("POST /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptSave)), smoke.Example("promptType", "group_summary"), smoke.Form(url.Values{"template": {"Summarize the group: {{.Articles}}"}}))
 	mux.Handle("DELETE /settings/prompts/{promptType}", auth(http.HandlerFunc(h.handleUserPromptReset)), smoke.Example("promptType", "curation"))
+	// Revert a prompt to an earlier version (#258). Appends a new version
+	// rather than rewinding, so the history stays a record of what was in force.
+	mux.Handle("POST /settings/prompts/{promptType}/revert/{versionID}", auth(http.HandlerFunc(h.handleUserPromptRevert)), smoke.Example("promptType", "curation"), smoke.Example("versionID", "1"))
 
 	// Admin-only routes.
 	adminAuth := h.requireAdmin

--- a/internal/web/smoke-manifest.json
+++ b/internal/web/smoke-manifest.json
@@ -473,6 +473,16 @@
       "complete": true
     },
     {
+      "method": "POST",
+      "pattern": "/settings/prompts/{promptType}/revert/{versionID}",
+      "effect": "mutating",
+      "example_params": {
+        "promptType": "curation",
+        "versionID": "1"
+      },
+      "complete": true
+    },
+    {
       "method": "GET",
       "pattern": "/settings/sync",
       "effect": "read_only",

--- a/internal/web/templates/settings_prompts.html
+++ b/internal/web/templates/settings_prompts.html
@@ -39,6 +39,38 @@
                 {{end}}
             </div>
         </form>
+        {{if .History}}
+        <details style="margin-top:0.75rem;">
+            <summary style="cursor:pointer;font-size:0.9em;">History ({{len .History}})</summary>
+            <p class="secondary" style="font-size:0.8em;margin:0.5rem 0;">
+                Reverting appends a new version rather than erasing the one you are replacing,
+                so scores already written keep pointing at the prompt that produced them.
+            </p>
+            <table style="font-size:0.8em;">
+                <tbody>
+                    {{range .History}}
+                    <tr>
+                        <td style="white-space:nowrap;">{{.When}}</td>
+                        <td><code>{{.ShortHash}}</code></td>
+                        <td class="secondary">{{.Source}}</td>
+                        <td style="font-family:monospace;">{{.Preview}}</td>
+                        <td style="white-space:nowrap;">
+                            {{if .Current}}
+                            <small class="secondary">in force</small>
+                            {{else}}
+                            <button type="button" class="outline secondary" style="margin:0;padding:0.15rem 0.5rem;font-size:0.85em;"
+                                    hx-post="/settings/prompts/{{$entry.Type}}/revert/{{.ID}}"
+                                    hx-confirm="Make this version of '{{$entry.Label}}' current again?">
+                                Revert
+                            </button>
+                            {{end}}
+                        </td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </details>
+        {{end}}
     </article>
     {{else}}
     <p class="secondary">No AI prompts configured.</p>


### PR DESCRIPTION
Closes #258.

`user_prompts` is keyed `(user_id, prompt_type)` and edits overwrite the template in place, so the text behind any already-written score is gone. That makes "did the rewrite help?" unanswerable and leaves no way back from a bad edit.

## What this changes

**Prompt history is content-addressed.** `prompt_versions` is keyed by the sha256 of the template rather than being a plain history table. That is not gold-plating: prompt resolution walks four tiers -- embedded default, config file, admin override, user row -- and the bottom two have no row to version. Hashing the resolved text gives every tier an identity.

This was not hypothetical. On the production instance `user_prompts` is **empty** and there is no `[prompts]` config section, so curation runs on the built-in template. Every feedback event recorded there had `score_model` and `prompt_hash` NULL -- the default deployment was the unattributable one.

**Provenance is recorded where the score is written.** The feedback log previously joined `user_prompts` when the *reader* acted, which reconstructs the prompt in force at read time. That is a different prompt whenever one was edited between scoring and reading -- precisely when the labels matter, since evaluating the edit is the point. `read_state` now carries `score_model` and `prompt_hash`, written by the curation stage, and the feedback insert copies them forward. This makes the snapshot rule in migration 0010 true rather than aspirational.

**Resolution returns one unit.** `Resolve()` hands back template, model, temperature and hash together. Fetching them through separate accessors is what allowed a hash and a model to describe different prompts, and it cost three queries per article per user where one now does.

**History and revert in settings.** Reverting appends rather than rewinding: a version you rejected stays on the record, because scores written under it must remain attributable.

## Security

`RevertPrompt` checks ownership. A version id is a bare integer in a URL, so without the check, guessing one would copy another account's prompt text into the caller's own -- a read primitive for other people's prompts dressed up as a revert. Covered by `TestRevertPromptRejectsOtherUsersVersion`.

## Notes

- Both new columns stay NULL for rows written earlier. NULL means unknown, never "current" -- backfilling from the present prompt would attribute old scores to a prompt that never saw them.
- Existing `read_state` rows gain provenance only when rescored, so the columns fill in gradually rather than at deploy.
- 11 new tests against real Postgres. Full suite passes with `-race`; lint clean, `sqlc diff` clean, govulncheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)