### PR TITLE
feat: explicit vote controls with reason axes (#252)

### DIFF
--- a/engine_feedback.go
+++ b/engine_feedback.go
@@ -1,6 +1,7 @@
 package herald
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/matthewjhunter/herald/internal/storage"
@@ -58,4 +59,73 @@ func (e *Engine) RecordFeedFeedback(ev storage.FeedbackEvent) {
 // ListFeedbackEvents returns a user's recorded events, newest first.
 func (e *Engine) ListFeedbackEvents(userID int64, limit int) ([]storage.FeedbackEventRow, error) {
 	return e.store.ListFeedbackEvents(userID, limit)
+}
+
+// VoteArticle records an explicit up/down vote and its optional reason (#252).
+//
+// Unlike the passive signals above, this one is NOT best-effort: the reader
+// deliberately stated an opinion and is watching for the control to change, so
+// a failure has to surface rather than be swallowed. Only the event write stays
+// best-effort, keeping the vote itself usable if the log write fails.
+//
+// vote is storage.VoteUp or storage.VoteDown. Returns the vote now in force so
+// the caller can re-render the control.
+func (e *Engine) VoteArticle(userID, articleID int64, vote int, reason string, surface storage.FeedbackSurface, position *int) (int, error) {
+	if !storage.ValidVoteAxis(reason) {
+		return 0, fmt.Errorf("unknown vote reason %q", reason)
+	}
+
+	// Voting the same way twice retracts, so the control is its own undo and
+	// the reader never has to hunt for a separate clear button.
+	current, _, err := e.store.GetArticleVote(userID, articleID)
+	if err != nil {
+		return 0, err
+	}
+	if current == vote {
+		cleared, cerr := e.store.ClearArticleVote(userID, articleID)
+		if cerr != nil {
+			return 0, cerr
+		}
+		if cleared {
+			e.RecordFeedback(storage.FeedbackEvent{
+				UserID: userID, ArticleID: articleID,
+				Kind: storage.FeedbackVoteCleared, Surface: surface,
+				ListPosition: position,
+			})
+		}
+		return 0, nil
+	}
+
+	ok, err := e.store.SetArticleVote(userID, articleID, vote, reason)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		// No row written: the article does not exist or is not in a feed this
+		// user subscribes to. Recording an event anyway would put an article
+		// they cannot read into their own training corpus.
+		return 0, fmt.Errorf("article %d not available to user %d", articleID, userID)
+	}
+
+	kind := storage.FeedbackVoteUp
+	if vote == storage.VoteDown {
+		kind = storage.FeedbackVoteDown
+	}
+	e.RecordFeedback(storage.FeedbackEvent{
+		UserID: userID, ArticleID: articleID,
+		Kind: kind, Surface: surface,
+		Axis:         reason,
+		ListPosition: position,
+	})
+	return vote, nil
+}
+
+// GetArticleVote returns the reader's current vote, or 0 if they have none.
+func (e *Engine) GetArticleVote(userID, articleID int64) (int, string, error) {
+	return e.store.GetArticleVote(userID, articleID)
+}
+
+// GetArticleVotes returns votes for a page of articles in one lookup.
+func (e *Engine) GetArticleVotes(userID int64, articleIDs []int64) (map[int64]int, error) {
+	return e.store.GetArticleVotes(userID, articleIDs)
 }

--- a/internal/storage/db/models.go
+++ b/internal/storage/db/models.go
@@ -117,6 +117,15 @@ type ArticleSummary struct {
 	GeneratedAt time.Time
 }
 
+type ArticleVote struct {
+	UserID    int64
+	ArticleID int64
+	Vote      int16
+	Reason    *string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 type CycleStat struct {
 	ID                 int64
 	CompletedAt        time.Time

--- a/internal/storage/feedback.go
+++ b/internal/storage/feedback.go
@@ -64,6 +64,16 @@ const (
 	FeedbackFeedUnsubscribe FeedbackKind = "feed_unsubscribe"
 	// FeedbackSearchResultClick pairs a query with a chosen result.
 	FeedbackSearchResultClick FeedbackKind = "search_result_click"
+	// FeedbackVoteUp and FeedbackVoteDown are the explicit controls (#252):
+	// the reader stating an opinion rather than Herald inferring one. These are
+	// the anchor the implicit signals calibrate against, and they are the only
+	// kinds that can carry a reason.
+	FeedbackVoteUp   FeedbackKind = "vote_up"
+	FeedbackVoteDown FeedbackKind = "vote_down"
+	// FeedbackVoteCleared is a retracted vote. Like FeedbackUnstar it is a
+	// withdrawal, not an opposite: clearing a downvote does not mean the reader
+	// liked the article.
+	FeedbackVoteCleared FeedbackKind = "vote_cleared"
 	// FeedbackClickthrough is the reader leaving for the original site. A
 	// positive, but one that must be read against ContentLength: on a truncated
 	// stub, clicking out is the only way to read the article at all, so it
@@ -71,6 +81,73 @@ const (
 	// reader wanted the source, which is a much stronger statement.
 	FeedbackClickthrough FeedbackKind = "clickthrough"
 )
+
+// Reason axes for an explicit vote (#252). Optional: a bare vote is a valid
+// label, and forcing a reason gets a random one.
+//
+// These deliberately do NOT reuse filter_rules.axis, which is constrained to
+// author/category/tag and cannot express three of the five reasons a reader
+// actually gives. Mining these into rules (#254) is therefore a translation
+// step, not a direct copy -- and it needs #259 first, since nothing in the
+// scoring path reads filter_rules today.
+type FeedbackAxis string
+
+const (
+	// AxisTopic is "not this subject". The strongest content signal here.
+	AxisTopic FeedbackAxis = "topic"
+	// AxisFeed is "not from this feed" -- about the publisher, not the subject.
+	AxisFeed FeedbackAxis = "feed"
+	// AxisSource is "not this linked-to domain", the site an aggregator points
+	// at rather than the aggregator itself.
+	AxisSource FeedbackAxis = "source"
+	// AxisDuplicate is "already saw this". Not a judgment on the content at
+	// all: the reader wanted it once. Consumers must not mine it as a topic
+	// negative.
+	AxisDuplicate FeedbackAxis = "duplicate"
+	// AxisTiming is "wrong for me right now" -- interest without appetite. It
+	// should decay fast and must never harden into a standing rule.
+	AxisTiming FeedbackAxis = "timing"
+)
+
+// Reason axes for an unsubscribe (#252). Most unsubscribes are not content
+// judgments, and treating them as one teaches the model to avoid topics
+// because a server went away.
+const (
+	// AxisFeedBroken is a dead or malformed feed. Never a content negative.
+	AxisFeedBroken FeedbackAxis = "broken"
+	// AxisFeedVolume is "too much of it", not "wrong subject". At most a
+	// frequency signal.
+	AxisFeedVolume FeedbackAxis = "volume"
+	// AxisFeedNotInterested is the only unsubscribe reason that may propagate
+	// as a content negative -- and even then, only when the feed was healthy.
+	AxisFeedNotInterested FeedbackAxis = "not_interested"
+)
+
+// validVoteAxes and validUnsubscribeAxes are closed sets. The axis arrives from
+// a form field, so it is validated rather than trusted: an unchecked value
+// would let a caller write arbitrary strings into the training corpus, and a
+// consumer grouping by axis would silently split on typos.
+var validVoteAxes = map[FeedbackAxis]bool{
+	AxisTopic: true, AxisFeed: true, AxisSource: true,
+	AxisDuplicate: true, AxisTiming: true,
+}
+
+var validUnsubscribeAxes = map[FeedbackAxis]bool{
+	AxisFeedBroken: true, AxisFeedVolume: true, AxisFeedNotInterested: true,
+}
+
+// ValidVoteAxis reports whether a is a recognized vote reason. An empty axis is
+// valid: it means the reader voted without giving a reason.
+func ValidVoteAxis(a string) bool {
+	return a == "" || validVoteAxes[FeedbackAxis(a)]
+}
+
+// ValidUnsubscribeAxis reports whether a is a recognized unsubscribe reason.
+// Empty is valid and is the default -- an unlabeled unsubscribe is honest,
+// a guessed one is not.
+func ValidUnsubscribeAxis(a string) bool {
+	return a == "" || validUnsubscribeAxes[FeedbackAxis(a)]
+}
 
 // FeedbackSurface is where the interaction happened. Fever traffic in
 // particular has to stay separable: its read marks come from clients whose

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 12 {
-		t.Errorf("goose max version = %d, want 12", maxVersion)
+	if maxVersion != 13 {
+		t.Errorf("goose max version = %d, want 13", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0013_article_votes.sql
+++ b/internal/storage/migrations/0013_article_votes.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+--
+-- Explicit per-article votes (#252, docs/feedback-events.md).
+--
+-- This table is CURRENT STATE only -- what the vote buttons should render as
+-- right now. The history lives in feedback_events, where an upvote, a later
+-- downvote and a retraction are three rows and two changes of mind, all kept.
+-- Same split as read_state and its events: collapsing them would destroy the
+-- record of the reader changing their mind, which is a stronger signal about a
+-- borderline article than either vote alone.
+--
+-- reason is the axis the reader gave, or NULL for a bare vote. A bare vote is a
+-- valid label: forcing a reason gets a random one, so the menu is optional by
+-- design and NULL is expected to be the common case.
+--
+-- Deliberately NOT on read_state. A vote is an opinion the reader volunteered;
+-- read state is bookkeeping the app maintains on their behalf. Keeping them
+-- apart means "never voted" stays distinguishable from "voted neutral", and a
+-- read_state reset (ResetReadStateScores) cannot silently discard opinions.
+
+CREATE TABLE IF NOT EXISTS article_votes (
+    user_id    BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    article_id BIGINT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+
+    -- -1 or 1. No zero: a retracted vote deletes the row, so absence means
+    -- "no opinion" and there is exactly one representation of it.
+    vote       SMALLINT NOT NULL CHECK (vote IN (-1, 1)),
+
+    -- The axis of the reason, when one was given. Values are the reason
+    -- vocabulary in feedback.go, not filter_rules.axis -- see the note there:
+    -- filter_rules only admits author/category/tag and cannot express "not this
+    -- source" or "wrong for me right now".
+    reason     TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (user_id, article_id)
+);
+
+-- Rendering a list needs every vote for a page of articles in one lookup.
+CREATE INDEX IF NOT EXISTS idx_article_votes_user ON article_votes(user_id, article_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS article_votes;

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -227,6 +227,14 @@ type Store interface {
 	// docs/feedback-events.md). Writes snapshot the prediction provenance in
 	// the same statement; there is deliberately no update or delete path
 	// except user deletion.
+	// Explicit votes (#252). Current state only -- the history is in
+	// feedback_events. Set/Clear report whether a row changed so the caller
+	// does not log an event for a no-op or an unsubscribed article.
+	SetArticleVote(userID, articleID int64, vote int, reason string) (bool, error)
+	ClearArticleVote(userID, articleID int64) (bool, error)
+	GetArticleVote(userID, articleID int64) (vote int, reason string, err error)
+	GetArticleVotes(userID int64, articleIDs []int64) (map[int64]int, error)
+
 	RecordFeedbackEvent(ev FeedbackEvent) error
 	RecordFeedbackEventsBatch(ev FeedbackEvent, articleIDs []int64) error
 	RecordFeedFeedbackEvent(ev FeedbackEvent) error

--- a/internal/storage/vote.go
+++ b/internal/storage/vote.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Explicit article votes (#252). This file holds current state only; the
+// history is in feedback_events, written by the caller alongside these calls.
+//
+// Hand-written on the pool rather than generated, matching feedback.go: the
+// subscription guard is an INSERT ... SELECT with a join, which sqlc models
+// awkwardly, and keeping the vote and its guard in one statement means an
+// unsubscribed article cannot be voted on through a crafted request.
+
+// Vote values. There is no zero: clearing a vote deletes the row so that
+// "no opinion" has exactly one representation.
+const (
+	VoteDown = -1
+	VoteUp   = 1
+)
+
+// setArticleVote upserts through the same subscription guard the feedback
+// insert uses (plan 003): a vote may only be recorded for an article in a feed
+// the user is subscribed to. Without the join, a crafted POST would let a
+// caller write votes -- and through them, training labels -- for articles they
+// have no access to.
+const setArticleVote = `
+INSERT INTO article_votes (user_id, article_id, vote, reason, updated_at)
+SELECT $1, a.id, $3, NULLIF($4, ''), NOW()
+FROM articles a
+JOIN user_feeds uf ON uf.feed_id = a.feed_id AND uf.user_id = $1
+WHERE a.id = $2
+ON CONFLICT (user_id, article_id) DO UPDATE SET
+    vote = excluded.vote,
+    reason = excluded.reason,
+    updated_at = NOW()`
+
+// SetArticleVote records the reader's current opinion. Returns whether a row
+// was written: false means the article does not exist or the user is not
+// subscribed to its feed, and the caller must not then record a feedback event
+// for it.
+func (s *PostgresStore) SetArticleVote(userID, articleID int64, vote int, reason string) (bool, error) {
+	if vote != VoteUp && vote != VoteDown {
+		return false, fmt.Errorf("set article vote: invalid vote %d", vote)
+	}
+	if !ValidVoteAxis(reason) {
+		return false, fmt.Errorf("set article vote: unknown reason %q", reason)
+	}
+	tag, err := s.pool.Exec(context.Background(), setArticleVote, userID, articleID, vote, reason)
+	if err != nil {
+		return false, fmt.Errorf("set article vote: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// ClearArticleVote retracts a vote. Returns whether there was one to retract,
+// so the caller can skip recording a retraction event for a no-op.
+func (s *PostgresStore) ClearArticleVote(userID, articleID int64) (bool, error) {
+	tag, err := s.pool.Exec(context.Background(),
+		`DELETE FROM article_votes WHERE user_id = $1 AND article_id = $2`, userID, articleID)
+	if err != nil {
+		return false, fmt.Errorf("clear article vote: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// GetArticleVote returns the reader's vote and reason, or 0 and "" when they
+// have not voted.
+func (s *PostgresStore) GetArticleVote(userID, articleID int64) (vote int, reason string, err error) {
+	var r *string
+	row := s.pool.QueryRow(context.Background(),
+		`SELECT vote, reason FROM article_votes WHERE user_id = $1 AND article_id = $2`,
+		userID, articleID)
+	if err := row.Scan(&vote, &r); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, "", nil
+		}
+		return 0, "", fmt.Errorf("get article vote: %w", err)
+	}
+	if r != nil {
+		reason = *r
+	}
+	return vote, reason, nil
+}
+
+// GetArticleVotes returns the votes for a page of articles in one lookup.
+// Rendering a list must not issue a query per row.
+func (s *PostgresStore) GetArticleVotes(userID int64, articleIDs []int64) (map[int64]int, error) {
+	out := make(map[int64]int, len(articleIDs))
+	if len(articleIDs) == 0 {
+		return out, nil
+	}
+	rows, err := s.pool.Query(context.Background(),
+		`SELECT article_id, vote FROM article_votes WHERE user_id = $1 AND article_id = ANY($2::bigint[])`,
+		userID, articleIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get article votes: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var vote int
+		if err := rows.Scan(&id, &vote); err != nil {
+			return nil, fmt.Errorf("get article votes: %w", err)
+		}
+		out[id] = vote
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get article votes: %w", err)
+	}
+	return out, nil
+}

--- a/internal/storage/vote_test.go
+++ b/internal/storage/vote_test.go
@@ -1,0 +1,191 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestSetAndGetArticleVote(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		ok, err := store.SetArticleVote(userID, articleID, VoteUp, "")
+		if err != nil {
+			t.Fatalf("SetArticleVote: %v", err)
+		}
+		if !ok {
+			t.Fatal("vote not written for a subscribed article")
+		}
+
+		vote, reason, err := store.GetArticleVote(userID, articleID)
+		if err != nil {
+			t.Fatalf("GetArticleVote: %v", err)
+		}
+		if vote != VoteUp {
+			t.Errorf("vote = %d, want %d", vote, VoteUp)
+		}
+		if reason != "" {
+			t.Errorf("reason = %q, want empty -- a bare vote carries no axis", reason)
+		}
+	})
+}
+
+// Changing your mind overwrites the current state; the history of having
+// changed it lives in feedback_events, not here.
+func TestRevoteReplacesState(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		if _, err := store.SetArticleVote(userID, articleID, VoteUp, ""); err != nil {
+			t.Fatalf("SetArticleVote up: %v", err)
+		}
+		if _, err := store.SetArticleVote(userID, articleID, VoteDown, string(AxisTopic)); err != nil {
+			t.Fatalf("SetArticleVote down: %v", err)
+		}
+
+		vote, reason, err := store.GetArticleVote(userID, articleID)
+		if err != nil {
+			t.Fatalf("GetArticleVote: %v", err)
+		}
+		if vote != VoteDown {
+			t.Errorf("vote = %d, want %d", vote, VoteDown)
+		}
+		if reason != string(AxisTopic) {
+			t.Errorf("reason = %q, want %q", reason, AxisTopic)
+		}
+	})
+}
+
+func TestClearArticleVote(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		if _, err := store.SetArticleVote(userID, articleID, VoteDown, ""); err != nil {
+			t.Fatalf("SetArticleVote: %v", err)
+		}
+		cleared, err := store.ClearArticleVote(userID, articleID)
+		if err != nil {
+			t.Fatalf("ClearArticleVote: %v", err)
+		}
+		if !cleared {
+			t.Error("ClearArticleVote reported no change, want true")
+		}
+
+		vote, _, err := store.GetArticleVote(userID, articleID)
+		if err != nil {
+			t.Fatalf("GetArticleVote: %v", err)
+		}
+		if vote != 0 {
+			t.Errorf("vote = %d after clear, want 0", vote)
+		}
+
+		// Clearing again is a no-op, and says so, so the caller does not log a
+		// retraction event for a vote that was never there.
+		again, err := store.ClearArticleVote(userID, articleID)
+		if err != nil {
+			t.Fatalf("ClearArticleVote (second): %v", err)
+		}
+		if again {
+			t.Error("second clear reported a change, want false")
+		}
+	})
+}
+
+// The subscription guard: a vote is a training label, and a crafted request
+// must not be able to write labels for articles the caller cannot read.
+func TestVoteRequiresSubscription(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		_, _, articleID := feedbackFixture(t, store)
+
+		outsider, err := store.CreateUser("outsider")
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+
+		ok, err := store.SetArticleVote(outsider, articleID, VoteUp, "")
+		if err != nil {
+			t.Fatalf("SetArticleVote: %v", err)
+		}
+		if ok {
+			t.Fatal("vote written for an article the user is not subscribed to")
+		}
+		vote, _, err := store.GetArticleVote(outsider, articleID)
+		if err != nil {
+			t.Fatalf("GetArticleVote: %v", err)
+		}
+		if vote != 0 {
+			t.Errorf("outsider has vote %d, want 0", vote)
+		}
+	})
+}
+
+// An unvalidated axis would let a caller write arbitrary strings into the
+// corpus, and a consumer grouping by axis would silently split on typos.
+func TestVoteRejectsUnknownAxis(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, _, articleID := feedbackFixture(t, store)
+
+		if _, err := store.SetArticleVote(userID, articleID, VoteDown, "not-an-axis"); err == nil {
+			t.Fatal("unknown axis accepted, want an error")
+		}
+		if _, err := store.SetArticleVote(userID, articleID, 7, ""); err == nil {
+			t.Fatal("out-of-range vote accepted, want an error")
+		}
+	})
+}
+
+func TestGetArticleVotesBatch(t *testing.T) {
+	eachStore(t, func(t *testing.T, store Store) {
+		userID, feedID, first := feedbackFixture(t, store)
+
+		second, err := store.AddArticle(&Article{
+			FeedID: feedID, GUID: "a2", Title: "Second", URL: "https://example.test/a2",
+		})
+		if err != nil {
+			t.Fatalf("AddArticle: %v", err)
+		}
+
+		if _, err := store.SetArticleVote(userID, first, VoteUp, ""); err != nil {
+			t.Fatalf("SetArticleVote first: %v", err)
+		}
+		if _, err := store.SetArticleVote(userID, second, VoteDown, ""); err != nil {
+			t.Fatalf("SetArticleVote second: %v", err)
+		}
+
+		votes, err := store.GetArticleVotes(userID, []int64{first, second, 999999})
+		if err != nil {
+			t.Fatalf("GetArticleVotes: %v", err)
+		}
+		if votes[first] != VoteUp {
+			t.Errorf("first = %d, want %d", votes[first], VoteUp)
+		}
+		if votes[second] != VoteDown {
+			t.Errorf("second = %d, want %d", votes[second], VoteDown)
+		}
+		if _, present := votes[999999]; present {
+			t.Error("unvoted article present in the map")
+		}
+	})
+}
+
+func TestValidAxisVocabulary(t *testing.T) {
+	for _, a := range []string{"", "topic", "feed", "source", "duplicate", "timing"} {
+		if !ValidVoteAxis(a) {
+			t.Errorf("ValidVoteAxis(%q) = false, want true", a)
+		}
+	}
+	for _, a := range []string{"author", "category", "tag", "nonsense", "TOPIC"} {
+		if ValidVoteAxis(a) {
+			t.Errorf("ValidVoteAxis(%q) = true, want false", a)
+		}
+	}
+	for _, a := range []string{"", "broken", "volume", "not_interested"} {
+		if !ValidUnsubscribeAxis(a) {
+			t.Errorf("ValidUnsubscribeAxis(%q) = false, want true", a)
+		}
+	}
+	for _, a := range []string{"topic", "whatever"} {
+		if ValidUnsubscribeAxis(a) {
+			t.Errorf("ValidUnsubscribeAxis(%q) = true, want false", a)
+		}
+	}
+}

--- a/internal/web/feedback.go
+++ b/internal/web/feedback.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 
@@ -94,4 +95,135 @@ func openPosition(r *http.Request) *int {
 		return nil
 	}
 	return &pos
+}
+
+// voteControlData drives the vote widget fragment.
+type voteControlData struct {
+	ID int64
+	// Vote is -1, 0 or 1. Zero renders both buttons unselected.
+	Vote int
+	// Surface and Position ride along so a vote cast from a list records where
+	// the article sat, the same as an open does.
+	Surface  string
+	Position int
+	// ShowReasons expands the optional reason menu. Only offered after a
+	// downvote: an upvote needs no explanation and asking for one turns a
+	// one-click action into a chore.
+	ShowReasons bool
+	// Compact renders the list-row variant: two buttons, no reason menu, so a
+	// vote never competes with the row's own click target.
+	Compact bool
+}
+
+// voteReasons is the reason menu, in the order shown. Kept here rather than in
+// the template so the labels and the stored axis values cannot drift apart.
+var voteReasons = []struct {
+	Axis  storage.FeedbackAxis
+	Label string
+}{
+	{storage.AxisTopic, "Not this topic"},
+	{storage.AxisFeed, "Not this feed"},
+	{storage.AxisSource, "Not this source"},
+	{storage.AxisDuplicate, "Already saw this"},
+	{storage.AxisTiming, "Not right now"},
+}
+
+// unsubscribeReasons is the one-click reason menu on unsubscribe. "No reason"
+// is first and is the default: an unlabeled unsubscribe is honest, and a
+// guessed one actively misleads, since most unsubscribes are not content
+// judgments at all.
+var unsubscribeReasons = []struct {
+	Axis  storage.FeedbackAxis
+	Label string
+}{
+	{"", "Just unsubscribe"},
+	{storage.AxisFeedBroken, "Feed is broken"},
+	{storage.AxisFeedVolume, "Too much volume"},
+	{storage.AxisFeedNotInterested, "Not interested"},
+}
+
+// votePosition reads the ?pos parameter on a vote, bounded like openPosition.
+func votePosition(r *http.Request) *int {
+	raw := r.FormValue("pos")
+	if raw == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 || n > maxListPosition {
+		return nil
+	}
+	return &n
+}
+
+// voteSurface resolves the surface a vote was cast from against the same closed
+// set as openSurface.
+func voteSurface(r *http.Request) storage.FeedbackSurface {
+	switch r.FormValue("from") {
+	case string(storage.SurfaceWebList):
+		return storage.SurfaceWebList
+	case string(storage.SurfaceWebSearch):
+		return storage.SurfaceWebSearch
+	case string(storage.SurfaceWebGroup):
+		return storage.SurfaceWebGroup
+	case string(storage.SurfaceWebSummary):
+		return storage.SurfaceWebSummary
+	default:
+		return storage.SurfaceWebArticle
+	}
+}
+
+// handleArticleVote records an explicit vote (#252) and re-renders the control.
+//
+// Voting the same way twice retracts, so the buttons are their own undo. The
+// reason menu is optional and is only offered after a downvote; a bare vote is
+// a valid label and forcing a reason would get a random one.
+func (h *handlers) handleArticleVote(w http.ResponseWriter, r *http.Request) {
+	h.init()
+	uid := userFromContext(r.Context()).ID
+	articleID, err := strconv.ParseInt(r.PathValue("articleID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid article ID", http.StatusBadRequest)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+
+	vote := storage.VoteUp
+	if r.FormValue("vote") == "down" {
+		vote = storage.VoteDown
+	}
+	reason := r.FormValue("reason")
+	if !storage.ValidVoteAxis(reason) {
+		// An unrecognized axis is dropped rather than rejected: the vote is
+		// still a valid label without it, and writing an unvalidated string
+		// would let a crafted request pollute the corpus with axes no consumer
+		// can group by.
+		reason = ""
+	}
+
+	surface := voteSurface(r)
+	position := votePosition(r)
+
+	current, err := h.engine.VoteArticle(uid, articleID, vote, reason, surface, position)
+	if err != nil {
+		log.Printf("herald-web: vote failed for user %d article %d: %v", uid, articleID, err)
+		http.Error(w, "could not record vote", http.StatusBadRequest)
+		return
+	}
+
+	data := voteControlData{
+		ID:      articleID,
+		Vote:    current,
+		Surface: string(surface),
+		Compact: r.FormValue("compact") == "1",
+	}
+	if position != nil {
+		data.Position = *position
+	}
+	// Offer the reason menu once a downvote lands, and only when there is room
+	// for it -- never in a list row.
+	data.ShowReasons = current == storage.VoteDown && reason == "" && !data.Compact
+	h.renderFragment(w, "vote_control", data)
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -199,10 +199,14 @@ func (h *handlers) parseTemplates() {
 		"emptyInts":    func() []int64 { return nil },
 		"emptyStrs":    func() []string { return nil },
 		"assetVersion": func() string { return version },
-		"buildVersion": func() string { return version },
-		"buildTime":    func() string { return buildTime },
-		"cleanTitle":   cleanTitle,
-		"printf":       fmt.Sprintf,
+		// The reason menu is defined in Go (#252) so the labels shown and the
+		// axis values stored cannot drift apart.
+		"voteReasons":        func() any { return voteReasons },
+		"unsubscribeReasons": func() any { return unsubscribeReasons },
+		"buildVersion":       func() string { return version },
+		"buildTime":          func() string { return buildTime },
+		"cleanTitle":         cleanTitle,
+		"printf":             fmt.Sprintf,
 		"secDonut": func(fs herald.FeedScoreStats) donutData {
 			return makeDonut(fs.SecPass, fs.SecBorderline, fs.SecFail,
 				fmt.Sprintf("%d%%", int(fs.SecPassPct())))
@@ -230,7 +234,7 @@ func (h *handlers) parseTemplates() {
 	tmplFS, _ := fs.Sub(embedded, "templates")
 
 	// Shared partials included in every page template.
-	shared := []string{"base.html", "nav.html", "settings_subnav.html", "feed_sidebar.html", "article_list.html", "article_row.html", "article_view.html", "search_results.html", "ai_summary_list.html", "ai_summary_detail.html", "error.html"}
+	shared := []string{"base.html", "nav.html", "settings_subnav.html", "feed_sidebar.html", "article_list.html", "article_row.html", "article_view.html", "vote_control.html", "search_results.html", "ai_summary_list.html", "ai_summary_detail.html", "error.html"}
 
 	// Pages that get their own template tree.
 	pages := []string{"home.html", "feeds_manage.html", "settings.html", "settings_sync.html", "settings_prompts.html", "filters.html", "admin_prompts.html", "admin_digest.html", "admin_stats.html", "admin_users.html", "stats.html", "status.html", "newsletters_manage.html"}
@@ -358,6 +362,8 @@ type articleRow struct {
 	// quality; without it a model trained on opens learns "be at the top".
 	Surface  string
 	Position int
+	// Vote is the reader's explicit vote on this article (#252): -1, 0 or 1.
+	Vote int
 }
 
 type searchResultsData struct {
@@ -384,6 +390,13 @@ type articleViewData struct {
 	LinkedDomain           string
 	SanitizedLinkedContent template.HTML
 	LinkedBy               []backlinkRow
+	// Explicit vote state (#252). Surface and Position are echoed back into the
+	// vote control so a vote cast from the article view still records which
+	// list the reader arrived from.
+	Vote            int
+	Surface         string
+	Position        int
+	ShowVoteReasons bool
 }
 
 // backlinkRow is one feed/post in the user's subscriptions that linked to the
@@ -884,6 +897,9 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 		ids[i] = a.ID
 	}
 	summaries := h.articleSummaries(ids)
+	// One lookup for the whole page, like the summaries above -- a vote per row
+	// would be an N+1 on the hottest view in the app.
+	votes, _ := h.engine.GetArticleVotes(uid, ids)
 
 	for i, a := range articles {
 		data.Articles = append(data.Articles, articleRow{
@@ -898,6 +914,7 @@ func (h *handlers) handleArticleList(w http.ResponseWriter, r *http.Request) {
 			Starred:          a.Starred,
 			Surface:          string(storage.SurfaceWebList),
 			Position:         offset + i + 1,
+			Vote:             votes[a.ID],
 		})
 	}
 
@@ -997,6 +1014,7 @@ func (h *handlers) handleSearch(w http.ResponseWriter, r *http.Request) {
 		ids[i] = r.ID
 	}
 	summaries := h.articleSummaries(ids)
+	votes, _ := h.engine.GetArticleVotes(uid, ids)
 
 	for i, r := range results {
 		data.Articles = append(data.Articles, articleRow{
@@ -1008,6 +1026,7 @@ func (h *handlers) handleSearch(w http.ResponseWriter, r *http.Request) {
 			AISummary:        summaries[r.ID],
 			Surface:          string(storage.SurfaceWebSearch),
 			Position:         offset + i + 1,
+			Vote:             votes[r.ID],
 		})
 	}
 
@@ -1082,6 +1101,15 @@ func (h *handlers) handleArticleView(w http.ResponseWriter, r *http.Request) {
 		// The article was just auto-marked read above, so the toggle starts
 		// in the read state (offering "Mark unread").
 		Read: true,
+		// Echo the arrival surface back into the vote control so a vote cast
+		// here still records which list the reader came from (#252).
+		Surface: string(openSurface(r)),
+	}
+	if pos := openPosition(r); pos != nil {
+		data.Position = *pos
+	}
+	if vote, _, verr := h.engine.GetArticleVote(uid, article.ID); verr == nil {
+		data.Vote = vote
 	}
 	if article.LinkedURL != "" {
 		if u, err := url.Parse(article.LinkedURL); err == nil {
@@ -1612,11 +1640,25 @@ func (h *handlers) handleFeedUnsubscribe(w http.ResponseWriter, r *http.Request)
 	// what lets a consumer tell a dead-feed cleanup from a content judgment. An
 	// unsubscribe that then fails leaves a stray event, which is much cheaper
 	// than systematically losing the ones that matter (#251).
+	// The reason is optional and defaults to unlabeled (#252). Only
+	// "not_interested" may ever propagate as a content negative, and even that
+	// is overridden by the feed-health snapshot the event carries: a feed with
+	// errors on record is presumed dead no matter which button was clicked.
+	// Bulk-downranking a dead feed's archive would teach the model to avoid
+	// topics because a server went away.
+	// Read from the query string, not the body: net/http's ParseForm only
+	// parses a body for POST/PUT/PATCH, so a reason sent as a DELETE body is
+	// silently dropped.
+	reason := r.URL.Query().Get("reason")
+	if !storage.ValidUnsubscribeAxis(reason) {
+		reason = ""
+	}
 	h.engine.RecordFeedFeedback(storage.FeedbackEvent{
 		UserID:  uid,
 		FeedID:  feedID,
 		Kind:    storage.FeedbackFeedUnsubscribe,
 		Surface: storage.SurfaceWebFeeds,
+		Axis:    reason,
 	})
 
 	if err := h.engine.UnsubscribeFeed(uid, feedID); err != nil {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -130,6 +130,9 @@ func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 	mux.Handle("POST /articles/{articleID}/star", auth(http.HandlerFunc(h.handleStarToggle)), smoke.Example("articleID", "1"), smoke.Form(url.Values{"starred": {"true"}}))
 	mux.Handle("POST /articles/{articleID}/read", auth(http.HandlerFunc(h.handleReadToggle)), smoke.Example("articleID", "1"), smoke.Form(url.Values{"read": {"false"}}))
 	mux.Handle("POST /articles/{articleID}/visit", auth(http.HandlerFunc(h.handleArticleVisit)), smoke.Example("articleID", "1"))
+	// Explicit vote (#252). Same way twice retracts; the optional reason is
+	// validated against a closed axis set before it reaches the corpus.
+	mux.Handle("POST /articles/{articleID}/vote", auth(http.HandlerFunc(h.handleArticleVote)), smoke.Form(url.Values{"vote": {"up"}}))
 	mux.Handle("GET /images/{imageID}", auth(http.HandlerFunc(h.handleArticleImage)), smoke.Example("imageID", "1"))
 	mux.Handle("GET /feeds/{feedID}/favicon", auth(http.HandlerFunc(h.handleFeedFavicon)), smoke.Example("feedID", "1"))
 	mux.Handle("GET /feeds/export.opml", auth(http.HandlerFunc(h.handleOPMLExport)))

--- a/internal/web/smoke-manifest.json
+++ b/internal/web/smoke-manifest.json
@@ -129,6 +129,14 @@
       "complete": true
     },
     {
+      "method": "POST",
+      "pattern": "/articles/{articleID}/vote",
+      "effect": "mutating",
+      "request_body": "vote=up",
+      "content_type": "application/x-www-form-urlencoded",
+      "complete": false
+    },
+    {
       "method": "GET",
       "pattern": "/auth/callback",
       "effect": "read_only",

--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -552,3 +552,30 @@
 .rg-grey::before { color: var(--rg-grey); }
 .rg-yellow::before { color: var(--rg-yellow); }
 .rg-green::before { color: var(--rg-green); }
+
+/* Unsubscribe reason menu (#252): inline, not a modal -- the reason is
+   optional and must not cost more than the unsubscribe itself. */
+.unsub-reason-menu {
+    position: absolute;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    box-shadow: var(--pico-card-box-shadow);
+}
+.unsub-reason-menu button {
+    margin: 0;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+
+/* Vote control (#252). Sits inside a clickable article row, so it needs to
+   read as a distinct target rather than part of the row's own hit area. */
+.vote-control { display: inline-flex; align-items: center; gap: 0.15rem; }
+.row-vote { opacity: 0.55; transition: opacity 0.12s ease-in-out; }
+.article-row:hover .row-vote, .row-vote:focus-within { opacity: 1; }

--- a/internal/web/static/herald.js
+++ b/internal/web/static/herald.js
@@ -301,18 +301,73 @@
         }
     });
 
-    // Unsubscribe feed handler
+    // Unsubscribe feed handler.
+    //
+    // The reason is optional and recorded as feedback (#252). It matters
+    // because an unsubscribe is a tempting but usually wrong content signal:
+    // dead feeds, format changes and volume cuts all land on the same button,
+    // and mining them as topic negatives teaches the model to avoid subjects
+    // because a server went away. "Just unsubscribe" is first and is the
+    // default -- an unlabeled unsubscribe is honest, a guessed one is not.
+    var UNSUB_REASONS = [
+        {value: '', label: 'Just unsubscribe'},
+        {value: 'broken', label: 'Feed is broken'},
+        {value: 'volume', label: 'Too much volume'},
+        {value: 'not_interested', label: 'Not interested'}
+    ];
+
+    function unsubscribeFeed(feedID, reason) {
+        // Reason rides in the query string: net/http does not parse a request
+        // body on DELETE, so a form-encoded body would be silently dropped.
+        var path = '/feeds/' + feedID;
+        if (reason) path += '?reason=' + encodeURIComponent(reason);
+        fetch(path, {method: 'DELETE'}).then(function(res) {
+            if (res.ok) window.location.href = '/';
+        });
+    }
+
+    function closeUnsubMenu() {
+        var open = document.getElementById('unsub-reason-menu');
+        if (open) open.remove();
+    }
+
     document.addEventListener('click', function(e) {
         var btn = e.target.closest('#unsubscribe-feed-btn');
-        if (!btn || !btn.dataset.feedId) return;
+        if (!btn || !btn.dataset.feedId) {
+            if (!e.target.closest('#unsub-reason-menu')) closeUnsubMenu();
+            return;
+        }
         var feedID = btn.dataset.feedId;
-        if (!confirm('Unsubscribe from this feed?')) return;
-        fetch('/feeds/' + feedID, {method: 'DELETE'})
-            .then(function(res) {
-                if (res.ok) {
-                    window.location.href = '/';
-                }
+        closeUnsubMenu();
+
+        var menu = document.createElement('div');
+        menu.id = 'unsub-reason-menu';
+        menu.className = 'unsub-reason-menu';
+        var label = document.createElement('small');
+        label.className = 'secondary';
+        label.textContent = 'Unsubscribe because:';
+        menu.appendChild(label);
+
+        UNSUB_REASONS.forEach(function(r) {
+            var b = document.createElement('button');
+            b.type = 'button';
+            b.className = 'outline secondary';
+            b.textContent = r.label;
+            b.addEventListener('click', function() {
+                closeUnsubMenu();
+                unsubscribeFeed(feedID, r.value);
             });
+            menu.appendChild(b);
+        });
+
+        var cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.className = 'outline';
+        cancel.textContent = 'Cancel';
+        cancel.addEventListener('click', closeUnsubMenu);
+        menu.appendChild(cancel);
+
+        btn.parentNode.insertBefore(menu, btn.nextSibling);
     });
 
     // Mute group handler

--- a/internal/web/templates/article_row.html
+++ b/internal/web/templates/article_row.html
@@ -14,5 +14,10 @@
         {{.PublishedDateFmt}}
     </div>
     {{if .AISummary}}<p class="ai-summary-inline">{{.AISummary}}</p>{{end}}
+    {{/* Compact vote: the buttons consume their click so voting never opens
+         the article by accident (#252). */}}
+    <div class="row-vote" style="margin-top:0.25rem;">
+        {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "Compact" true)}}
+    </div>
 </div>
 {{end}}

--- a/internal/web/templates/article_view.html
+++ b/internal/web/templates/article_view.html
@@ -62,6 +62,7 @@
         Open Article
     </a>
     {{end}}
+    {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "ShowReasons" .ShowVoteReasons)}}
     <button class="outline {{if .Starred}}contrast{{end}}"
             data-star-toggle
             hx-post="/articles/{{.ID}}/star"

--- a/internal/web/templates/vote_control.html
+++ b/internal/web/templates/vote_control.html
@@ -1,0 +1,52 @@
+{{define "vote_control"}}
+{{/* Explicit feedback controls (#252). Voting the same way twice retracts, so
+     each button is its own undo and there is no separate clear control.
+
+     In a list row (Compact) the buttons carry hx-trigger="click consume" so the
+     click does not also fire the row's own hx-get and open the article -- a
+     vote must never cost the reader an accidental navigation. */}}
+<span class="vote-control" id="vote-{{.ID}}">
+    <button type="button"
+            class="outline {{if eq .Vote 1}}contrast{{end}}"
+            aria-label="{{if eq .Vote 1}}Retract upvote{{else}}More like this{{end}}"
+            title="More like this"
+            style="margin:0;padding:0.1rem 0.45rem;font-size:0.9em;"
+            hx-post="/articles/{{.ID}}/vote"
+            hx-vals='{"vote":"up","from":"{{.Surface}}"{{if .Position}},"pos":"{{.Position}}"{{end}}{{if .Compact}},"compact":"1"{{end}}}'
+            hx-target="#vote-{{.ID}}"
+            hx-swap="outerHTML"
+            {{if .Compact}}hx-trigger="click consume"{{end}}>
+        &#9650;
+    </button>
+    <button type="button"
+            class="outline {{if eq .Vote -1}}contrast{{end}}"
+            aria-label="{{if eq .Vote -1}}Retract downvote{{else}}Less like this{{end}}"
+            title="Less like this"
+            style="margin:0;padding:0.1rem 0.45rem;font-size:0.9em;"
+            hx-post="/articles/{{.ID}}/vote"
+            hx-vals='{"vote":"down","from":"{{.Surface}}"{{if .Position}},"pos":"{{.Position}}"{{end}}{{if .Compact}},"compact":"1"{{end}}}'
+            hx-target="#vote-{{.ID}}"
+            hx-swap="outerHTML"
+            {{if .Compact}}hx-trigger="click consume"{{end}}>
+        &#9660;
+    </button>
+    {{if .ShowReasons}}
+    {{/* Optional. The vote is already recorded; this only adds an axis to it,
+         so dismissing the menu by ignoring it loses nothing. */}}
+    <span class="vote-reasons" style="margin-left:0.5rem;font-size:0.8em;">
+        <span class="secondary">Why?</span>
+        {{$id := .ID}}{{$surface := .Surface}}{{$pos := .Position}}
+        {{range voteReasons}}
+        <button type="button" class="outline secondary"
+                style="margin:0 0 0 0.25rem;padding:0.1rem 0.4rem;font-size:0.9em;"
+                hx-post="/articles/{{$id}}/vote"
+                hx-vals='{"vote":"down","reason":"{{.Axis}}","from":"{{$surface}}"{{if $pos}},"pos":"{{$pos}}"{{end}}}'
+                hx-target="#vote-{{$id}}"
+                hx-swap="outerHTML">
+            {{.Label}}
+        </button>
+        {{end}}
+    </span>
+    {{end}}
+</span>
+{{end}}

--- a/internal/web/vote_test.go
+++ b/internal/web/vote_test.go
@@ -1,0 +1,233 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+func votePath(articleID int64) string {
+	return fmt.Sprintf("/articles/%d/vote", articleID)
+}
+
+func TestVoteRecordsEventAndState(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID),
+		url.Values{"vote": {"up"}, "from": {"web-list"}, "pos": {"2"}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Kind != string(storage.FeedbackVoteUp) {
+		t.Errorf("kind = %q, want %q", ev.Kind, storage.FeedbackVoteUp)
+	}
+	if ev.Surface != string(storage.SurfaceWebList) {
+		t.Errorf("surface = %q, want %q", ev.Surface, storage.SurfaceWebList)
+	}
+	if ev.ListPosition == nil || *ev.ListPosition != 2 {
+		t.Errorf("list_position = %v, want 2", ev.ListPosition)
+	}
+	vote, _, err := tf.store.GetArticleVote(tf.userID, tf.articleID)
+	if err != nil {
+		t.Fatalf("GetArticleVote: %v", err)
+	}
+	if vote != storage.VoteUp {
+		t.Errorf("stored vote = %d, want %d", vote, storage.VoteUp)
+	}
+}
+
+// Voting the same way twice retracts, so the control is its own undo. The
+// retraction is an event of its own: "changed their mind" is a stronger
+// statement about a borderline article than either vote alone.
+func TestRevoteSameDirectionRetracts(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	for i := 0; i < 2; i++ {
+		rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID), url.Values{"vote": {"down"}})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("vote %d: status %d", i, rr.Code)
+		}
+	}
+
+	kinds := feedbackKinds(t, tf)
+	if len(kinds) != 2 {
+		t.Fatalf("got %d events (%v), want 2", len(kinds), kinds)
+	}
+	// Newest first.
+	if kinds[0] != string(storage.FeedbackVoteCleared) {
+		t.Errorf("second event = %q, want %q", kinds[0], storage.FeedbackVoteCleared)
+	}
+	if kinds[1] != string(storage.FeedbackVoteDown) {
+		t.Errorf("first event = %q, want %q", kinds[1], storage.FeedbackVoteDown)
+	}
+
+	vote, _, err := tf.store.GetArticleVote(tf.userID, tf.articleID)
+	if err != nil {
+		t.Fatalf("GetArticleVote: %v", err)
+	}
+	if vote != 0 {
+		t.Errorf("vote = %d after retraction, want 0", vote)
+	}
+}
+
+// Changing direction is a new opinion, not a retraction, and both are kept.
+func TestVoteFlipRecordsBoth(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	if rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID), url.Values{"vote": {"up"}}); rr.Code != http.StatusOK {
+		t.Fatalf("up: status %d", rr.Code)
+	}
+	if rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID), url.Values{"vote": {"down"}}); rr.Code != http.StatusOK {
+		t.Fatalf("down: status %d", rr.Code)
+	}
+
+	kinds := feedbackKinds(t, tf)
+	if len(kinds) != 2 {
+		t.Fatalf("got %d events (%v), want 2", len(kinds), kinds)
+	}
+	if kinds[0] != string(storage.FeedbackVoteDown) || kinds[1] != string(storage.FeedbackVoteUp) {
+		t.Errorf("kinds = %v, want [vote_down vote_up] newest-first", kinds)
+	}
+}
+
+func TestVoteCapturesReason(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID),
+		url.Values{"vote": {"down"}, "reason": {string(storage.AxisTopic)}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Axis == nil || *ev.Axis != string(storage.AxisTopic) {
+		t.Errorf("axis = %v, want %q", ev.Axis, storage.AxisTopic)
+	}
+}
+
+// A reason is optional. Forcing one gets a random one, so a bare vote has to
+// stay a first-class label.
+func TestBareVoteIsValid(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	if rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID), url.Values{"vote": {"up"}}); rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+	ev := onlyEvent(t, tf)
+	if ev.Axis != nil && *ev.Axis != "" {
+		t.Errorf("axis = %v, want none", ev.Axis)
+	}
+}
+
+// An unrecognized axis is dropped rather than stored. Writing it through would
+// let a crafted request pollute the corpus with axes no consumer can group by.
+func TestVoteDropsUnknownReason(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID),
+		url.Values{"vote": {"down"}, "reason": {"'; DROP TABLE feedback_events--"}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Axis != nil && *ev.Axis != "" {
+		t.Errorf("axis = %v, want the unknown reason dropped", ev.Axis)
+	}
+	if ev.Kind != string(storage.FeedbackVoteDown) {
+		t.Errorf("kind = %q -- the vote itself must still count", ev.Kind)
+	}
+}
+
+// A forged surface must not be written through into the corpus.
+func TestVoteRejectsUnknownSurface(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID),
+		url.Values{"vote": {"up"}, "from": {"made-up-surface"}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+	ev := onlyEvent(t, tf)
+	if ev.Surface != string(storage.SurfaceWebArticle) {
+		t.Errorf("surface = %q, want the default %q", ev.Surface, storage.SurfaceWebArticle)
+	}
+}
+
+// The vote control must come back rendered so htmx can swap it, and it must
+// reflect the new state rather than the one the reader clicked from.
+func TestVoteRerendersControl(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequestForm(t, tf, "POST", votePath(tf.articleID), url.Values{"vote": {"up"}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("vote: status %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, fmt.Sprintf(`id="vote-%d"`, tf.articleID)) {
+		t.Errorf("response does not contain the vote control target:\n%s", body)
+	}
+	if !strings.Contains(body, "Retract upvote") {
+		t.Errorf("control does not reflect the new vote state:\n%s", body)
+	}
+}
+
+// Unsubscribing records the reason when one is given, and the event still
+// carries the feed-health snapshot that lets a consumer tell a dead-feed
+// cleanup from a content judgment.
+func TestUnsubscribeRecordsReason(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequest(t, tf, "DELETE",
+		fmt.Sprintf("/feeds/%d?reason=%s", tf.feedID, storage.AxisFeedNotInterested), nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("unsubscribe: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Kind != string(storage.FeedbackFeedUnsubscribe) {
+		t.Fatalf("kind = %q, want %q", ev.Kind, storage.FeedbackFeedUnsubscribe)
+	}
+	if ev.Axis == nil || *ev.Axis != string(storage.AxisFeedNotInterested) {
+		t.Errorf("axis = %v, want %q", ev.Axis, storage.AxisFeedNotInterested)
+	}
+}
+
+// No reason is the default and must stay distinguishable from a stated one: an
+// unlabeled unsubscribe is honest, a guessed one actively misleads.
+func TestUnsubscribeWithoutReasonStaysUnlabeled(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequest(t, tf, "DELETE", fmt.Sprintf("/feeds/%d", tf.feedID), nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("unsubscribe: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Axis != nil && *ev.Axis != "" {
+		t.Errorf("axis = %v, want unlabeled", ev.Axis)
+	}
+}
+
+// An unsubscribe reason vocabulary is separate from the vote vocabulary; a
+// vote axis arriving on an unsubscribe is a bug or a forgery, not a label.
+func TestUnsubscribeDropsVoteAxis(t *testing.T) {
+	tf := newTestFixtures(t)
+
+	rr := authedRequest(t, tf, "DELETE",
+		fmt.Sprintf("/feeds/%d?reason=%s", tf.feedID, storage.AxisTopic), nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("unsubscribe: status %d", rr.Code)
+	}
+
+	ev := onlyEvent(t, tf)
+	if ev.Axis != nil && *ev.Axis != "" {
+		t.Errorf("axis = %v, want the cross-vocabulary reason dropped", ev.Axis)
+	}
+}


### PR DESCRIPTION
Refs #252. Builds on #251 (event log) and #261 (scoring-time provenance).

The explicit-label surface. Implicit signals are free but noisy; explicit ones are the anchor the rest calibrates against.

## What this adds

**Article votes.** Up/down in the article view and on every list row. Voting the same way twice retracts, so the buttons are their own undo -- no separate clear control. In a list row the buttons carry `hx-trigger="click consume"` so a vote never also fires the row's `hx-get`: voting must not cost an accidental navigation.

**Optional reason menu**, offered only after a downvote and only outside list rows. An upvote needs no explanation, and a bare vote stays a first-class label -- forcing a reason gets a random one.

**Unsubscribe reason**, defaulting to unlabeled. Most unsubscribes are not content judgments: dead feeds, format changes and volume cuts all land on the same button. Mining them as topic negatives teaches the model to avoid subjects because a server went away. Only "not interested" may propagate, and the feed-health snapshot from #251 still overrides it.

## Design calls worth reviewing

**Reason axes do not reuse `filter_rules.axis`.** That column is `CHECK IN ('author','category','tag')` and cannot express "not this source", "already saw this" or "wrong for me right now" -- three of the five reasons a reader actually gives. The issue assumed a direct mapping; there isn't one. So #254 becomes a translation step, and it still needs #259 first, since nothing in the scoring path reads `filter_rules` today.

**Votes live in `article_votes`, not on `read_state`.** A vote is an opinion the reader volunteered; read state is bookkeeping the app maintains for them. Separate tables keep "never voted" distinguishable from "voted neutral" and stop `ResetReadStateScores` from discarding opinions. State here, history in `feedback_events` -- an upvote, a later downvote and a retraction are three rows, because "changed their mind" says more about a borderline article than either vote alone.

## Security

- The vote upsert carries the same subscription guard as the feedback insert. A vote is a training label, so a crafted request must not write labels for articles the caller cannot read.
- Axes are validated against closed sets. They arrive from a form field, and an unchecked value would let a caller write arbitrary strings into the corpus, where a consumer grouping by axis would silently split on typos. An unrecognized axis is dropped and the vote still counts.
- A forged `from` surface falls back to the default rather than being written through.

## Bug found by the tests

`net/http` does not parse a request body on `DELETE`, so the unsubscribe reason was silently dropped on the way in. It now travels in the query string. Caught by `TestUnsubscribeRecordsReason`.

## Notes

- Votes are batch-fetched per page alongside the AI summaries; a lookup per row would be an N+1 on the hottest view in the app.
- 17 new tests. Full suite passes with `-race`; lint clean, `sqlc diff` clean, govulncheck clean.
- No CSP change: htmx plus first-party `herald.js`, no new origins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)