### PR TITLE
fix(web): put row vote buttons on the headline row

### DIFF
--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -579,3 +579,23 @@
 .vote-control { display: inline-flex; align-items: center; gap: 0.15rem; }
 .row-vote { opacity: 0.55; transition: opacity 0.12s ease-in-out; }
 .article-row:hover .row-vote, .row-vote:focus-within { opacity: 1; }
+
+/* Headline and vote buttons share one row: the list is scanned by headline, so
+   the buttons must not cost a line of their own. min-width:0 lets a long
+   headline shrink and wrap instead of pushing the buttons off the edge --
+   flex items default to min-width:auto and would refuse to shrink. */
+.article-row-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.article-row-head h4 {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.article-row-head .row-vote {
+    flex: 0 0 auto;
+    /* Nudge up to sit optically level with the headline's cap height. */
+    margin-top: -0.1rem;
+}

--- a/internal/web/templates/article_row.html
+++ b/internal/web/templates/article_row.html
@@ -3,21 +3,24 @@
      hx-get="/articles/{{.ID}}{{if .Surface}}?from={{.Surface}}{{if .Position}}&pos={{.Position}}{{end}}{{end}}"
      hx-target="#reading-pane"
      hx-swap="innerHTML">
-    <h4>
-        {{if .Starred}}<span class="starred" aria-label="starred">&#9733;</span> {{end}}
-        {{if .SecurityFlagged}}<span class="security-flag" title="Security flagged — not AI-summarized, pending audit" aria-label="security flagged">&#9888;</span> {{end}}
-        {{cleanTitle .Title}}
-    </h4>
+    {{/* Headline and vote share one row so the buttons cost no vertical space.
+         The compact vote consumes its click so voting never opens the article
+         by accident (#252). */}}
+    <div class="article-row-head">
+        <h4>
+            {{if .Starred}}<span class="starred" aria-label="starred">&#9733;</span> {{end}}
+            {{if .SecurityFlagged}}<span class="security-flag" title="Security flagged — not AI-summarized, pending audit" aria-label="security flagged">&#9888;</span> {{end}}
+            {{cleanTitle .Title}}
+        </h4>
+        <div class="row-vote">
+            {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "Compact" true)}}
+        </div>
+    </div>
     <div class="meta">
         {{if .FeedTitle}}{{.FeedTitle}} &middot; {{end}}
         {{if .Author}}{{.Author}} &middot; {{end}}
         {{.PublishedDateFmt}}
     </div>
     {{if .AISummary}}<p class="ai-summary-inline">{{.AISummary}}</p>{{end}}
-    {{/* Compact vote: the buttons consume their click so voting never opens
-         the article by accident (#252). */}}
-    <div class="row-vote" style="margin-top:0.25rem;">
-        {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "Compact" true)}}
-    </div>
 </div>
 {{end}}


### PR DESCRIPTION
Refs #252.

The vote buttons landed below the meta line, costing every article row a third line of vertical space. In a list whose whole job is scanning headlines, that measurably cuts how many fit on screen.

Headline and buttons now share a flex row with the buttons right-aligned, so the control costs no vertical space at all.

`min-width: 0` on the headline is the part worth not losing: flex items default to `min-width: auto` and refuse to shrink below their content width, so without it a long headline pushes the buttons past the right edge rather than wrapping.

Verified against rendered markup -- `h4` and `.row-vote` come out as siblings inside `.article-row-head`. The vote control re-render targets `#vote-{id}` inside `.row-vote`, so the layout survives a vote round-trip.

Before / after: three lines per row (headline, meta, buttons) becomes two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)