### PR TITLE
fix(web): size vote buttons per surface, move them to the row end

### DIFF
--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -576,7 +576,19 @@
 
 /* Vote control (#252). Sits inside a clickable article row, so it needs to
    read as a distinct target rather than part of the row's own hit area. */
-.vote-control { display: inline-flex; align-items: center; gap: 0.15rem; }
+.vote-control { display: inline-flex; align-items: center; gap: 0.5rem; }
+/* Default sizing matches the surrounding buttons -- in the article view these
+   sit beside Star and Mark unread and a smaller pair reads as a different class
+   of control. */
+.vote-control button { margin: 0; }
+/* The list row is scanned, not operated, so the buttons shrink out of the way
+   there and tighten their gap. */
+.vote-control-compact { gap: 0.15rem; }
+.vote-control-compact button {
+    padding: 0.1rem 0.45rem;
+    font-size: 0.9em;
+    line-height: 1.2;
+}
 .row-vote { opacity: 0.55; transition: opacity 0.12s ease-in-out; }
 .article-row:hover .row-vote, .row-vote:focus-within { opacity: 1; }
 

--- a/internal/web/templates/article_view.html
+++ b/internal/web/templates/article_view.html
@@ -62,7 +62,6 @@
         Open Article
     </a>
     {{end}}
-    {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "ShowReasons" .ShowVoteReasons)}}
     <button class="outline {{if .Starred}}contrast{{end}}"
             data-star-toggle
             hx-post="/articles/{{.ID}}/star"
@@ -77,5 +76,9 @@
             data-feeds-changed>
         {{if .Read}}Mark unread{{else}}Mark read{{end}}
     </button>
+    {{/* Votes sit at the end of the row rather than among the navigation and
+         state controls: they are a judgment on the article, not an action on
+         it, and mixing them in makes both harder to find. */}}
+    {{template "vote_control" (dict "ID" .ID "Vote" .Vote "Surface" .Surface "Position" .Position "ShowReasons" .ShowVoteReasons)}}
 </div>
 {{end}}

--- a/internal/web/templates/vote_control.html
+++ b/internal/web/templates/vote_control.html
@@ -4,13 +4,16 @@
 
      In a list row (Compact) the buttons carry hx-trigger="click consume" so the
      click does not also fire the row's own hx-get and open the article -- a
-     vote must never cost the reader an accidental navigation. */}}
-<span class="vote-control" id="vote-{{.ID}}">
+     vote must never cost the reader an accidental navigation.
+
+     Sizing is a class, not an inline style: in the article view these sit in a
+     row with Star and Mark unread and must match them, while the list row wants
+     the shrunken variant. One hardcoded size cannot serve both. */}}
+<span class="vote-control{{if .Compact}} vote-control-compact{{end}}" id="vote-{{.ID}}">
     <button type="button"
             class="outline {{if eq .Vote 1}}contrast{{end}}"
             aria-label="{{if eq .Vote 1}}Retract upvote{{else}}More like this{{end}}"
             title="More like this"
-            style="margin:0;padding:0.1rem 0.45rem;font-size:0.9em;"
             hx-post="/articles/{{.ID}}/vote"
             hx-vals='{"vote":"up","from":"{{.Surface}}"{{if .Position}},"pos":"{{.Position}}"{{end}}{{if .Compact}},"compact":"1"{{end}}}'
             hx-target="#vote-{{.ID}}"
@@ -22,7 +25,6 @@
             class="outline {{if eq .Vote -1}}contrast{{end}}"
             aria-label="{{if eq .Vote -1}}Retract downvote{{else}}Less like this{{end}}"
             title="Less like this"
-            style="margin:0;padding:0.1rem 0.45rem;font-size:0.9em;"
             hx-post="/articles/{{.ID}}/vote"
             hx-vals='{"vote":"down","from":"{{.Surface}}"{{if .Position}},"pos":"{{.Position}}"{{end}}{{if .Compact}},"compact":"1"{{end}}}'
             hx-target="#vote-{{.ID}}"


### PR DESCRIPTION
Refs #252. Follow-up to #263.

Two problems in the article view, both from the vote control assuming one size fits every surface.

**Size.** The buttons rendered at the list-row size while sitting in a row with Open Original, Star and Mark unread. A smaller pair among full-size siblings reads as a different and lesser class of control.

Sizing moves from a hardcoded inline style to a class. The default now matches the surrounding buttons, and `.vote-control-compact` keeps the shrunken variant for list rows, which are scanned rather than operated. One hardcoded size could not serve both.

**Placement.** They sat between Open Original and Star, interleaved with the navigation and state controls. Votes are a judgment on the article rather than an action on it, so they now sit at the end of the row where they read as their own group.

Verified against rendered markup: the article view emits the control last with no compact class and no inline sizing, so it inherits normal button dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)