### PR TITLE
fix(web): match vote button height, shrink the list-row pair

### DIFF
--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -576,18 +576,37 @@
 
 /* Vote control (#252). Sits inside a clickable article row, so it needs to
    read as a distinct target rather than part of the row's own hit area. */
-.vote-control { display: inline-flex; align-items: center; gap: 0.5rem; }
-/* Default sizing matches the surrounding buttons -- in the article view these
-   sit beside Star and Mark unread and a smaller pair reads as a different class
-   of control. */
-.vote-control button { margin: 0; }
+/* align-items:stretch, not center, is what makes these match their siblings in
+   the article view. The action row is a flex container, but the flex item there
+   is this wrapper span (it has to be -- it is the htmx swap target), so the
+   buttons inside it size to their own content and come out shorter than the
+   Star and Mark unread buttons beside them. Stretching passes the row's height
+   through to them. */
+.vote-control {
+    display: inline-flex;
+    align-items: stretch;
+    gap: 0.5rem;
+}
+.vote-control button {
+    margin: 0;
+    /* A single glyph would otherwise render a button a third the width of its
+       neighbours, which reads as a lesser control rather than a peer. */
+    min-width: 3.25rem;
+}
 /* The list row is scanned, not operated, so the buttons shrink out of the way
-   there and tighten their gap. */
-.vote-control-compact { gap: 0.15rem; }
+   there: no stretching, no minimum width, tighter gap. */
+.vote-control-compact {
+    align-items: center;
+    gap: 0.15rem;
+}
 .vote-control-compact button {
-    padding: 0.1rem 0.45rem;
-    font-size: 0.9em;
-    line-height: 1.2;
+    min-width: 0;
+    padding: 0 0.35rem;
+    font-size: 0.7em;
+    line-height: 1.5;
+    /* Pico gives buttons a border radius sized for full-height controls; at
+       this scale it reads as a lozenge unless it is tightened too. */
+    border-radius: 3px;
 }
 .row-vote { opacity: 0.55; transition: opacity 0.12s ease-in-out; }
 .article-row:hover .row-vote, .row-vote:focus-within { opacity: 1; }


### PR DESCRIPTION
Refs #252. Two separate size problems.

**Article view: buttons were shorter than their neighbours.** `.article-actions` is a flex container, but the flex item is the `.vote-control` wrapper span -- it has to be, since it is the htmx swap target -- so the buttons inside it sized to their own content rather than inheriting the row height. `align-items: stretch` passes the height through. A `min-width` stops a single-glyph button rendering a third the width of Star or Mark unread, which reads as a lesser control rather than a peer.

**List row: the pair was not visibly smaller than the article-view pair.** The list is scanned, not operated, so the compact variant now drops to `0.7em` with tighter padding and a smaller radius. Pico's default border radius is sized for full-height controls and reads as a lozenge at this scale.

## Note for anyone comparing against a running instance

Both problems look worse than they are on a page that was open across a deploy. Herald is htmx-driven, so an old page shell keeps its old stylesheet while swapping in freshly-rendered fragments -- new markup, old CSS. Verified that the deployed binary and the deployed `herald.css` both carry `article-row-head`, `vote-control-compact` and `row-vote`, and that assets are versioned per commit (`?v=<sha>`), so a hard reload picks them up.

Worth noting separately: static assets are served with no `Cache-Control` header at all, so browsers fall back to heuristic caching. The `?v=` parameter makes that mostly harmless, but an explicit immutable policy on versioned assets would be tidier. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)