### PR TITLE
feat(web): Cache-Control for static assets

### DIFF
--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -43,9 +43,11 @@ func NewRouter(engine *herald.Engine, validator *oidclient.Client, adminRole str
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	// Static files — no auth required.
+	// Static files — no auth required. Cached per staticCacheControl: assets are
+	// requested with ?v=<sha>, so a deploy changes the URL and the content at
+	// any one URL really is immutable.
 	staticFS, _ := fs.Sub(embedded, "static")
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticFS)),
+	mux.Handle("GET /static/", staticCacheControl(http.StripPrefix("/static/", http.FileServerFS(staticFS))),
 		smoke.Skip("static file server subtree"))
 
 	// The server-side session manager needs a validator (it is the Renewer and

--- a/internal/web/static_cache.go
+++ b/internal/web/static_cache.go
@@ -1,0 +1,52 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Cache lifetime for a versioned static asset. One year is the maximum
+// browsers honour and the conventional value for immutable content.
+const staticImmutableMaxAge = 31536000 // seconds
+
+// immutableCacheControl is built once rather than formatted per request.
+var immutableCacheControl = fmt.Sprintf("public, max-age=%d, immutable", staticImmutableMaxAge)
+
+// staticCacheControl sets caching policy on /static/ responses.
+//
+// Templates request assets as /static/herald.css?v=<commit sha>, so a deploy
+// changes the URL and the old entry is never consulted again. That makes the
+// content at any given URL genuinely immutable, which is what lets us send the
+// aggressive policy: `immutable` additionally tells the browser not to
+// revalidate on reload, so a user pressing refresh after a deploy gets the new
+// asset from the new URL rather than a conditional request for the old one.
+//
+// Two cases deliberately do not get it:
+//
+//   - **No version parameter.** A bare /static/herald.css is whatever is
+//     current, not a pinned artifact. Caching it for a year would pin a stale
+//     copy with no way to bust it. It revalidates instead.
+//   - **Unversioned builds.** When the binary carries no VCS stamp the version
+//     is the literal "dev" and never changes between rebuilds, so an immutable
+//     policy would serve yesterday's CSS through every local edit. Development
+//     is exactly where that is most painful and hardest to diagnose.
+//
+// Without this, Go's file server sends no Cache-Control at all and browsers
+// fall back to heuristic caching -- a fraction of the time since Last-Modified,
+// chosen per browser. That is unpredictable rather than wrong, and it made a
+// post-deploy stale stylesheet look like an application bug.
+func staticCacheControl(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case version == "dev":
+			// Unversioned build: never cache, so local edits show up.
+			w.Header().Set("Cache-Control", "no-store")
+		case r.URL.Query().Get("v") != "":
+			w.Header().Set("Cache-Control", immutableCacheControl)
+		default:
+			// Current-but-unpinned: cheap conditional requests, always fresh.
+			w.Header().Set("Cache-Control", "public, no-cache")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/web/static_cache_test.go
+++ b/internal/web/static_cache_test.go
@@ -1,0 +1,83 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// withVersion swaps the package-level build version for one test. The caching
+// policy is deliberately different for unversioned builds, and that branch is
+// the one that would otherwise only be discovered by a developer wondering why
+// their CSS edits do nothing.
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := version
+	version = v
+	t.Cleanup(func() { version = prev })
+}
+
+func cacheHeaderFor(t *testing.T, target string) string {
+	t.Helper()
+	h := staticCacheControl(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", target, nil))
+	return rr.Header().Get("Cache-Control")
+}
+
+func TestVersionedAssetIsImmutable(t *testing.T) {
+	withVersion(t, "abc1234")
+
+	got := cacheHeaderFor(t, "/static/herald.css?v=abc1234")
+	want := "public, max-age=31536000, immutable"
+	if got != want {
+		t.Errorf("Cache-Control = %q, want %q", got, want)
+	}
+}
+
+// A bare URL is "whatever is current", not a pinned artifact. Caching it for a
+// year would pin a stale copy with no way to bust it.
+func TestUnversionedURLRevalidates(t *testing.T) {
+	withVersion(t, "abc1234")
+
+	got := cacheHeaderFor(t, "/static/herald.css")
+	if got != "public, no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, no-cache")
+	}
+}
+
+// A dev build's version never changes between rebuilds, so an immutable policy
+// would serve stale assets through every local edit -- exactly where it is
+// most painful and hardest to diagnose.
+func TestDevBuildNeverCaches(t *testing.T) {
+	withVersion(t, "dev")
+
+	for _, target := range []string{"/static/herald.css", "/static/herald.css?v=dev"} {
+		if got := cacheHeaderFor(t, target); got != "no-store" {
+			t.Errorf("%s: Cache-Control = %q, want %q", target, got, "no-store")
+		}
+	}
+}
+
+// The header has to survive the real route, not just the middleware in
+// isolation -- the file server is wrapped, and a future refactor could easily
+// reorder that.
+func TestStaticRouteSetsCacheControl(t *testing.T) {
+	withVersion(t, "abc1234")
+	tf := newTestFixtures(t)
+
+	rr := httptest.NewRecorder()
+	tf.router.ServeHTTP(rr, httptest.NewRequest("GET", "/static/herald.css?v=abc1234", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q", got)
+	}
+	if rr.Body.Len() == 0 {
+		t.Error("no body served -- the middleware swallowed the response")
+	}
+}


### PR DESCRIPTION
Follow-up to #268, which surfaced this.

Go's `http.FileServerFS` sends no `Cache-Control` header at all, so browsers fall back to heuristic caching -- typically some fraction of the time since `Last-Modified`, chosen per browser. That is unpredictable rather than wrong, but it is why a post-deploy stale stylesheet looked like an application bug while the server had been serving the correct asset all along.

Templates already request assets as `/static/herald.css?v=<commit sha>`, so a deploy changes the URL and the content at any one URL genuinely is immutable. Those now get `public, max-age=31536000, immutable`.

The `immutable` directive is the part that actually matters here. Without it, a browser still issues a conditional request on reload -- for the *old* URL, from the old page shell. With it, a refresh after a deploy fetches the new URL outright.

## Two deliberate opt-outs

- **No `?v=` parameter.** A bare `/static/herald.css` is "whatever is current", not a pinned artifact. Pinning it for a year would strand a stale copy with no way to bust it. It revalidates instead (`public, no-cache`).
- **Unversioned builds.** When the binary carries no VCS stamp, `version` is the literal `"dev"` and never changes between rebuilds, so an immutable policy would serve yesterday's CSS through every local edit -- the case where this is most painful and hardest to diagnose. `no-store`.

## Tests

All three branches plus the wired route. The route test exists because the file server is *wrapped*, and a refactor could reorder the middleware without failing anything else -- it asserts both the header and that a body still comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)