### PR TITLE
feat(web): label the reader gauge counts

### DIFF
--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -543,12 +543,18 @@
     font-size: 0.75rem;
     color: var(--pico-muted-color);
 }
+.rg-dot {
+    white-space: nowrap;
+    color: var(--pico-color);
+}
 .rg-dot::before {
     content: "\25CF";
     margin-right: 0.3rem;
     font-size: 0.7rem;
     vertical-align: baseline;
 }
+/* The count carries the emphasis; the label just says what it counts. */
+.rg-label { color: var(--pico-muted-color); }
 .rg-grey::before { color: var(--rg-grey); }
 .rg-yellow::before { color: var(--rg-yellow); }
 .rg-green::before { color: var(--rg-green); }

--- a/internal/web/templates/feed_sidebar.html
+++ b/internal/web/templates/feed_sidebar.html
@@ -1,6 +1,6 @@
 {{define "feed_sidebar_content"}}
 {{with .Gauge}}
-<div class="reader-gauge" title="Pending {{.Pending}} (screening) &middot; Unread {{.Ready}} &middot; Read {{.Read}} &mdash; last 7 days">
+<div class="reader-gauge" title="Last 7 days &mdash; pending: waiting on AI screening; unread: scored, not yet read; read: already seen">
     {{if .Total}}
     <div class="reader-gauge-ring" style="--grey-end:{{.GreyEnd}}%;--yellow-end:{{.YellowEnd}}%;">
         <span class="reader-gauge-center">{{.Ready}}</span>
@@ -9,9 +9,9 @@
     <div class="reader-gauge-ring reader-gauge-empty"><span class="reader-gauge-center">0</span></div>
     {{end}}
     <div class="reader-gauge-legend">
-        <span class="rg-dot rg-grey">{{.Pending}}</span>
-        <span class="rg-dot rg-yellow">{{.Ready}}</span>
-        <span class="rg-dot rg-green">{{.Read}}</span>
+        <span class="rg-dot rg-grey">{{.Pending}} <span class="rg-label">pending</span></span>
+        <span class="rg-dot rg-yellow">{{.Ready}} <span class="rg-label">unread</span></span>
+        <span class="rg-dot rg-green">{{.Read}} <span class="rg-label">read</span></span>
     </div>
 </div>
 {{end}}


### PR DESCRIPTION
The sidebar reader gauge showed three bare numbers; their meaning was only available on hover.

- Each count in the legend now carries its label: `0 pending` / `1 unread` / `5 read`.
- Counts use the normal text color, labels are muted, and `.rg-dot` is `nowrap` so a count never wraps away from its label.
- The tooltip no longer repeats the numbers -- it explains what each state means and that the window is the last 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)