### PR TITLE
feat: filter rules match article text, with substring and regex patterns (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Filter rules can match article text, with substring and regex patterns.**
+  Three new axes -- `title`, `summary`, `content` -- match the article's own
+  text, which no rule could reach before, and a new match mode (`exact`,
+  `substring`, `regex`) says how the value is compared. This makes recurring
+  boilerplate filterable: a feed that publishes the same auto-generated post
+  every day under a title whose date changes has no distinguishing author or
+  category, so the title was the only usable signal and no rule could see it.
+  Patterns are RE2, compiled when the rule is saved so a bad one is refused
+  where you can fix it. Existing rules are untouched -- the mode defaults to
+  `exact` -- and take effect immediately as before, with nothing to reprocess.
+
+  Pattern rules are evaluated in Go at read time rather than in SQL, because
+  article text is attacker-supplied and Postgres regex backtracks. They carry
+  their own quotas (`max_pattern_filter_rules_per_user`, default 50;
+  `max_content_filter_rules_per_user`, default 5) since each is evaluated
+  against every candidate row, and content rules read whole article bodies.
+  Under an active filter a page can come back slightly short; the window is
+  bounded by `filter_overfetch_factor` and `filter_max_scan`. (#274)
+
+- **The reader gauge reports articles your filters are hiding.** Unread counts
+  have never applied the visibility gate, so a filtered list could show fewer
+  articles than the badge promised. The gap is now surfaced as its own count
+  rather than silently absorbed. (#274)
+
+### Fixed
+
+- **The Fever sync API now applies filter rules.** An article hidden in the web
+  reader still synced to every connected client. (#274)
+
 ### Changed
 
 - **Filter rules now adjust the interest score, not just visibility.** A rule's

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -351,12 +351,11 @@ func processCmd() *cobra.Command {
 			result := &output.FetchResult{}
 
 			// Get and output high-interest articles. These paths bypass the
-			// Engine, so the filter-rule check is done here explicitly --
-			// otherwise rules would shift the web ranking but not what gets
-			// notified, which is the surface that actually reaches the reader
-			// (#259). The visibility gate stays off here, as it always has.
-			hasRules, _ := store.HasFilterRules(userID)
-			highInterestArticles, scores, err := store.GetArticlesByInterestScore(userID, cfg.Thresholds.InterestScore, 10, 0, nil, hasRules)
+			// Engine, so they go through herald.HighInterestArticles -- rules
+			// that shifted the web ranking but not what gets notified would
+			// leave the surface that actually reaches the reader unfiltered
+			// (#259, #274). The visibility gate stays off here, as it always has.
+			highInterestArticles, scores, err := herald.HighInterestArticles(store, cfg, userID, cfg.Thresholds.InterestScore, 10, 0)
 			if err != nil {
 				return fmt.Errorf("failed to get high-interest articles: %w", err)
 			}
@@ -546,8 +545,7 @@ func runCycle(ctx context.Context, stages stageSet) error {
 	// Fetch-cycle summary + high-interest notification: only when this loop
 	// fetched (a screen/curate-only loop has no fetch tally to report).
 	if fetchResult != nil {
-		hasRules, _ := store.HasFilterRules(cfg.DefaultUserID)
-		highInterestArticles, scores, err := store.GetArticlesByInterestScore(cfg.DefaultUserID, cfg.Thresholds.InterestScore, 10, 0, nil, hasRules)
+		highInterestArticles, scores, err := herald.HighInterestArticles(store, cfg, cfg.DefaultUserID, cfg.Thresholds.InterestScore, 10, 0)
 		if err != nil {
 			return fmt.Errorf("failed to get high-interest articles: %w", err)
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,13 +103,38 @@ Keywords are incorporated into the prompt as preferences, not as hard filters. A
 
 ### Filter rules
 
-Filter rules (`filter_rules`, by author/category/tag) apply *after* the model, at query time. An article's effective interest score is the model's score plus the sum of the user's matching rules, clamped to 0-10. It drives the ranked list, digest and newsletter selection, and notifications.
+Filter rules (`filter_rules`) apply *after* the model, at read time. An article's effective interest score is the model's score plus the sum of the user's matching rules, clamped to 0-10. It drives the ranked list, digest and newsletter selection, notifications, and the Fever sync API.
 
-Query time, not scoring time. A rule therefore takes effect on articles that were scored long before it existed, with nothing re-run -- which is what a reader expects when they add one. The cost is that the stored `read_state.interest_score` stays the model's raw opinion, and the adjustment is recomputed per query. That split is deliberate: it keeps "what the model said" separately answerable from "what the reader saw", which is what makes the feedback corpus usable for evaluating the model.
+A rule names an **axis** and a **match mode**. Three axes match the labels a feed publishes -- `author`, `category`, `tag` -- and three match the article's own text: `title`, `summary`, `content`. The mode is `exact`, `substring` or `regex`, defaulting to `exact`, which is what every rule written before #274 was.
+
+Read time, not scoring time. A rule therefore takes effect on articles that were scored long before it existed, with nothing re-run -- which is what a reader expects when they add one. The cost is that the stored `read_state.interest_score` stays the model's raw opinion, and the adjustment is recomputed per request. That split is deliberate: it keeps "what the model said" separately answerable from "what the reader saw", which is what makes the feedback corpus usable for evaluating the model.
+
+#### Two evaluators, never at once
+
+Where a rule is evaluated follows from its (axis, mode) pair:
+
+| | `exact` | `substring` / `regex` |
+|---|---|---|
+| `author` / `category` / `tag` | SQL | Go |
+| `title` / `summary` / `content` | Go | Go |
+
+The SQL half is `filterRuleMatch` in `internal/storage/filterscore.go`: an indexed CITEXT equality inside a LATERAL join, which costs essentially nothing. The Go half is `internal/filtermatch`, evaluated in the engine against rows the query has already returned.
+
+Go rather than Postgres for patterns because article text is attacker-supplied and Postgres regex backtracks: a pattern that is merely careless, run over content a feed controls, is a wedged page load. Go's `regexp` is RE2, linear in the input with no catastrophic backtracking.
+
+**A user's rules are evaluated entirely in one place or entirely in the other.** A user with no pattern rules -- the common case -- takes the SQL path unchanged, with no extra queries. The moment one rule needs Go, Go takes all of them, including the exact ones SQL could have matched, and the SQL rule join and gate are switched off. The visibility gate forces this: it compares the *sum* of a user's matching rules against a threshold, and a rule set split between two evaluators leaves neither holding the number being compared. `filtermatch.New` encodes the choice by returning a nil matcher when SQL suffices.
+
+Two consequences worth knowing. On the Go path the score arithmetic leaves SQL as well: the store returns raw interest scores (`GetScoredUnreadArticles`) because the ranking query's number is clamped and clamping is not invertible, and the engine adds, clamps, decays and sorts. And the candidate window is bounded (`filter_overfetch_factor`, `filter_max_scan`), so a page can come back short and an article that a rule *boosts* hard can fall outside the window -- demotion, which is what nearly every rule does, is unaffected. Batch reading (#277) is where page composition gets designed properly.
+
+Pattern rules carry their own quotas, well below the general one, because each is evaluated against every candidate row: `max_pattern_filter_rules_per_user` (50) and `max_content_filter_rules_per_user` (5). Content rules scan whole article bodies and measure at roughly 2ms per rule per 50-article page, against about 30us for a title rule.
 
 Rules also feed a separate, opt-in **visibility gate**: when `filter_threshold` is non-zero, an article whose rule total falls below it is hidden entirely. The gate compares the rule total alone; the score adjustment compares model score plus rules. Two different numbers, and the settings page names both.
 
-Two known inconsistencies, both deliberate. A group's `max_interest_score` is computed at cluster time from raw scores and cached, so a group header can disagree with the articles inside it. The score-distribution stats stay raw as well, because they measure model calibration -- folding reader policy in would make a badly-calibrated prompt indistinguishable from an aggressive rule.
+Unread counts do not apply the gate and never have, so a filtered list can show fewer articles than the badge promises. Rather than make the counts exact -- which would mean evaluating every unread article on every page load -- the reader gauge reports the gap as its own figure: "12 unread, 7 hidden". Approximate, bounded by the same scan window, and honest about it.
+
+Three known inconsistencies, all deliberate. A group's `max_interest_score` is computed at cluster time from raw scores and cached, so a group header can disagree with the articles inside it. The score-distribution stats stay raw as well, because they measure model calibration -- folding reader policy in would make a badly-calibrated prompt indistinguishable from an aggressive rule. And a pattern rule on the `author` axis matches both the normalized `article_authors` names and the item's free-text `articles.author`, because feeds disagree about where the byline goes, while an exact rule -- matched in SQL -- sees only the normalized table.
+
+None of this is the **security screen**, which is sitewide: its regex layer comes from `airlock/detect`, applies to every user identically, and is stored on the article because the verdict is a property of the article. Filter rules are per-user taste, owned by their creator, and no filter rule can move an article's threat score or change what another user sees.
 
 ### Summarization
 
@@ -159,7 +184,7 @@ PostgreSQL schema managed by [goose](https://github.com/pressly/goose) migration
 | `article_group_members` | Many-to-many membership between groups and articles |
 | `group_summaries` | Cached group narrative summaries with max interest score |
 | `user_prompts` | Per-user custom prompt templates and temperatures |
-| `filter_rules` | Scoring rules by author, category, or tag (positive or negative) |
+| `filter_rules` | Per-user scoring rules: an axis (author/category/tag/title/summary/content), a match mode (exact/substring/regex), and a positive or negative score |
 | `users` | Registered users for multi-user deployments |
 
 Feeds are shared across users; `user_feeds` tracks subscriptions. Articles are stored once; `read_state` tracks per-user scores and read status. Summaries are per-article and shared by every subscriber, like the security verdict: each article is summarized once with the global summarization prompt.

--- a/engine.go
+++ b/engine.go
@@ -1502,7 +1502,12 @@ func (e *Engine) GetReaderGauge(userID, feedID int64) (ReaderGauge, error) {
 	if err != nil {
 		return ReaderGauge{}, err
 	}
-	return ReaderGauge{Pending: c.Pending, Ready: c.Ready, Read: c.Read}, nil
+	return ReaderGauge{
+		Pending: c.Pending,
+		Ready:   c.Ready,
+		Read:    c.Read,
+		Hidden:  e.filters().hiddenUnreadCount(userID, feedID),
+	}, nil
 }
 
 // GetRecentCycleStats returns the most recent completed daemon cycles, newest

--- a/engine.go
+++ b/engine.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1531,11 +1532,27 @@ var allowedPreferenceKeys = map[string]bool{
 	"notify_min_score":   true,
 }
 
-// allowedFilterAxes are the valid axis values for filter rules.
-var allowedFilterAxes = map[string]bool{
-	"author":   true,
-	"category": true,
-	"tag":      true,
+// filterAxisNames are the valid axis values for filter rules, in the order the
+// error message and the UI list them: metadata axes first, then the text axes
+// added by #274.
+var filterAxisNames = []string{
+	AxisAuthor, AxisCategory, AxisTag,
+	AxisTitle, AxisSummary, AxisContent,
+}
+
+var allowedFilterAxes = func() map[string]bool {
+	m := make(map[string]bool, len(filterAxisNames))
+	for _, a := range filterAxisNames {
+		m[a] = true
+	}
+	return m
+}()
+
+// allowedMatchModes are the valid comparison modes for a filter rule's value.
+var allowedMatchModes = map[string]bool{
+	MatchExact:     true,
+	MatchSubstring: true,
+	MatchRegex:     true,
 }
 
 // GetPreferences returns all user preferences, merging DB values over config defaults.
@@ -1939,11 +1956,25 @@ func userFromStorage(u storage.User) User {
 // AddFilterRule validates and stores a new filter rule. Returns the rule ID.
 func (e *Engine) AddFilterRule(userID int64, rule FilterRule) (int64, error) {
 	if !allowedFilterAxes[rule.Axis] {
-		return 0, fmt.Errorf("invalid filter axis: %q (must be author, category, or tag)", rule.Axis)
+		return 0, fmt.Errorf("invalid filter axis: %q (must be one of %s)", rule.Axis, strings.Join(filterAxisNames, ", "))
+	}
+	if rule.MatchMode == "" {
+		rule.MatchMode = MatchExact
+	}
+	if !allowedMatchModes[rule.MatchMode] {
+		return 0, fmt.Errorf("invalid match mode: %q (must be exact, substring, or regex)", rule.MatchMode)
 	}
 	if rule.Value == "" {
 		return 0, fmt.Errorf("filter rule value cannot be empty")
 	}
+	// Compile now so a bad pattern is reported to the person who wrote it. The
+	// evaluator runs deep in a listing query, where there is nobody to tell.
+	if rule.MatchMode == MatchRegex {
+		if _, err := regexp.Compile(rule.Value); err != nil {
+			return 0, fmt.Errorf("invalid regular expression: %w", err)
+		}
+	}
+
 	existingRules, err := e.GetFilterRules(userID, nil)
 	if err != nil {
 		return 0, fmt.Errorf("check filter rule quota: %w", err)
@@ -1951,14 +1982,37 @@ func (e *Engine) AddFilterRule(userID int64, rule FilterRule) (int64, error) {
 	if err := overQuota("filter rule", len(existingRules), e.config.Limits.MaxFilterRulesPerUser); err != nil {
 		return 0, err
 	}
+	// Pattern rules carry their own, much lower ceiling: each one is evaluated
+	// in Go against every candidate row of every listing query, where an exact
+	// rule costs an indexed equality in SQL.
+	if patternFilterRule(rule) {
+		patterns := 0
+		for _, r := range existingRules {
+			if patternFilterRule(r) {
+				patterns++
+			}
+		}
+		if err := overQuota("pattern filter rule", patterns, e.config.Limits.MaxPatternFilterRulesPerUser); err != nil {
+			return 0, err
+		}
+	}
+
 	sr := &storage.FilterRule{
-		UserID: userID,
-		FeedID: rule.FeedID,
-		Axis:   rule.Axis,
-		Value:  rule.Value,
-		Score:  rule.Score,
+		UserID:    userID,
+		FeedID:    rule.FeedID,
+		Axis:      rule.Axis,
+		MatchMode: rule.MatchMode,
+		Value:     rule.Value,
+		Score:     rule.Score,
 	}
 	return e.store.AddFilterRule(sr)
+}
+
+// patternFilterRule reports whether a rule is metered against the pattern
+// quota. Exact matching on a text axis is still a whole-string comparison in
+// Go, not a pattern scan, so it is not counted here.
+func patternFilterRule(r FilterRule) bool {
+	return r.MatchMode == MatchSubstring || r.MatchMode == MatchRegex
 }
 
 // GetFilterRules returns filter rules for a user, optionally scoped to a feed.
@@ -1974,6 +2028,7 @@ func (e *Engine) GetFilterRules(userID int64, feedID *int64) ([]FilterRule, erro
 			UserID:    r.UserID,
 			FeedID:    r.FeedID,
 			Axis:      r.Axis,
+			MatchMode: r.MatchMode,
 			Value:     r.Value,
 			Score:     r.Score,
 			CreatedAt: r.CreatedAt,

--- a/engine.go
+++ b/engine.go
@@ -20,7 +20,6 @@ import (
 	"github.com/matthewjhunter/herald/internal/ai"
 	emailpkg "github.com/matthewjhunter/herald/internal/email"
 	"github.com/matthewjhunter/herald/internal/feeds"
-	"github.com/matthewjhunter/herald/internal/filtermatch"
 	"github.com/matthewjhunter/herald/internal/storage"
 	"github.com/matthewjhunter/herald/internal/urlnorm"
 )
@@ -205,7 +204,8 @@ func (e *Engine) FetchAllFeeds(ctx context.Context) (*FetchResult, error) {
 // When includeRead is true, already-read articles are returned alongside unread
 // ones (each carrying its Read/Starred state); otherwise only unread are returned.
 func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	p := e.planFilters(userID)
+	rf := e.filters()
+	p := rf.plan(userID)
 	if !p.hides() {
 		articles, err := e.store.GetUnreadArticlesForUser(userID, limit, offset, p.sqlThreshold, includeRead)
 		if err != nil {
@@ -213,7 +213,7 @@ func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead 
 		}
 		return articlesFromInternal(articles), nil
 	}
-	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+	articles, err := rf.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
 		return e.store.GetUnreadArticlesForUser(userID, window, 0, nil, includeRead)
 	})
 	if err != nil {
@@ -224,7 +224,8 @@ func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead 
 
 // GetStarredArticles returns starred articles for a user.
 func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article, error) {
-	p := e.planFilters(userID)
+	rf := e.filters()
+	p := rf.plan(userID)
 	if !p.hides() {
 		articles, err := e.store.GetStarredArticles(userID, limit, offset, p.sqlThreshold)
 		if err != nil {
@@ -232,7 +233,7 @@ func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article,
 		}
 		return articlesFromInternal(articles), nil
 	}
-	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+	articles, err := rf.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
 		return e.store.GetStarredArticles(userID, window, 0, nil)
 	})
 	if err != nil {
@@ -244,7 +245,8 @@ func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article,
 // GetUnreadArticlesByFeed returns articles for a user filtered to a specific feed.
 // When includeRead is true, read articles are included alongside unread ones.
 func (e *Engine) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	p := e.planFilters(userID)
+	rf := e.filters()
+	p := rf.plan(userID)
 	if !p.hides() {
 		articles, err := e.store.GetUnreadArticlesByFeed(userID, feedID, limit, offset, p.sqlThreshold, includeRead)
 		if err != nil {
@@ -252,7 +254,7 @@ func (e *Engine) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int
 		}
 		return articlesFromInternal(articles), nil
 	}
-	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+	articles, err := rf.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
 		return e.store.GetUnreadArticlesByFeed(userID, feedID, window, 0, nil, includeRead)
 	})
 	if err != nil {
@@ -332,7 +334,7 @@ func (e *Engine) GetArticleSummaries(articleIDs []int64) (map[int64]string, erro
 
 // GetHighInterestArticles returns unread articles scored above the threshold.
 func (e *Engine) GetHighInterestArticles(userID int64, threshold float64, limit, offset int) ([]Article, []float64, error) {
-	articles, scores, err := e.store.GetArticlesByInterestScore(userID, threshold, limit, offset, e.resolveFilterThreshold(userID), e.applyFilterRules(userID))
+	articles, scores, err := e.filters().highInterest(userID, threshold, limit, offset, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1043,7 +1045,8 @@ func (e *Engine) GetGroupArticles(userID, groupID int64) (*ArticleGroup, error) 
 // GetUnreadGroupArticles returns articles belonging to a group. When includeRead
 // is true, read articles are included alongside unread ones.
 func (e *Engine) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	p := e.planFilters(userID)
+	rf := e.filters()
+	p := rf.plan(userID)
 	if !p.hides() {
 		articles, err := e.store.GetUnreadGroupArticles(userID, groupID, limit, offset, p.sqlThreshold, includeRead)
 		if err != nil {
@@ -1051,7 +1054,7 @@ func (e *Engine) GetUnreadGroupArticles(userID, groupID int64, limit, offset int
 		}
 		return articlesFromInternal(articles), nil
 	}
-	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+	articles, err := rf.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
 		return e.store.GetUnreadGroupArticles(userID, groupID, window, 0, nil, includeRead)
 	})
 	if err != nil {
@@ -1366,10 +1369,10 @@ func (e *Engine) GenerateBriefing(userID int64) (string, error) {
 	if e.ai == nil {
 		return "", nil
 	}
-	// Gate stays nil here, matching the pre-existing behaviour of this path;
-	// the rule-adjusted score applies regardless (#259).
-	articles, scores, err := e.store.GetArticlesByInterestScore(
-		userID, e.config.Thresholds.InterestScore, 20, 0, nil, e.applyFilterRules(userID))
+	// The gate stays off here, matching the pre-existing behaviour of this
+	// path; the rule-adjusted score applies regardless (#259).
+	articles, scores, err := e.filters().highInterest(
+		userID, e.config.Thresholds.InterestScore, 20, 0, false)
 	if err != nil {
 		return "", fmt.Errorf("get high-interest articles: %w", err)
 	}
@@ -2115,139 +2118,6 @@ func (e *Engine) GetFeedMetadata(feedID int64) (*FeedMetadata, error) {
 		Authors:    authors,
 		Categories: categories,
 	}, nil
-}
-
-// --- Pattern filter rules, evaluated at read time (#274) ---
-
-// filterPlan is how one listing request will apply a user's filter rules.
-//
-// The two fields are mutually exclusive by construction. Either SQL does the
-// whole job -- sqlThreshold set, matcher nil, exactly as before #274 -- or Go
-// does, with the SQL gate switched off. Never both: the gate compares the SUM
-// of a user's matching rules against a threshold, so a rule set split across
-// two evaluators leaves neither holding the number being compared.
-type filterPlan struct {
-	matcher      *filtermatch.Matcher // non-nil when Go owns this user's rules
-	sqlThreshold *int                 // the gate for the SQL path; nil when Go owns it or the gate is off
-	goThreshold  *int                 // the gate for the Go path; nil when the gate is off
-}
-
-// planFilters decides how a listing request applies this user's rules.
-//
-// A user with no pattern rules -- the common case -- gets a plan indis-
-// tinguishable from the pre-#274 behaviour, with no extra queries and no Go
-// evaluation. Errors are not fatal: a filter that cannot be resolved falls
-// back to showing everything, because failing to hide an article is a far
-// better outcome than failing to render the page.
-func (e *Engine) planFilters(userID int64) filterPlan {
-	threshold := e.resolveFilterThreshold(userID)
-
-	rules, err := e.GetFilterRules(userID, nil)
-	if err != nil {
-		log.Printf("herald: filter rules unavailable for user %d, showing everything: %v", userID, err)
-		return filterPlan{}
-	}
-	fmRules := make([]filtermatch.Rule, len(rules))
-	for i, r := range rules {
-		fmRules[i] = filtermatch.Rule{
-			ID: r.ID, FeedID: r.FeedID, Axis: r.Axis,
-			MatchMode: r.MatchMode, Value: r.Value, Score: r.Score,
-		}
-	}
-	matcher, err := filtermatch.New(fmRules)
-	if err != nil {
-		// Patterns are compiled at save time, so this is a bug or a
-		// hand-edited row. Log it and fall back to the SQL half.
-		log.Printf("herald: filter rules for user %d will not compile, using exact rules only: %v", userID, err)
-		return filterPlan{sqlThreshold: threshold}
-	}
-	if matcher.Empty() {
-		return filterPlan{sqlThreshold: threshold}
-	}
-	return filterPlan{matcher: matcher, goThreshold: threshold}
-}
-
-// hides reports whether the Go evaluator is doing visibility work for this
-// request. When it is not -- no pattern rules, or the gate is off -- the
-// listing paths can return the store's rows untouched.
-func (p filterPlan) hides() bool { return p.matcher != nil && p.goThreshold != nil }
-
-// subjects assembles the text each article will be matched against, loading
-// normalized authors and categories only if some rule actually needs them.
-func (e *Engine) subjects(articles []storage.Article, m *filtermatch.Matcher) []filtermatch.Subject {
-	var authors, categories map[int64][]string
-	if m.NeedsMetadata() {
-		ids := make([]int64, len(articles))
-		for i, a := range articles {
-			ids[i] = a.ID
-		}
-		var err error
-		authors, categories, err = e.store.GetArticleMetadataBatch(ids)
-		if err != nil {
-			// Rules on the metadata axes will not fire. Say so rather than
-			// silently under-filtering.
-			log.Printf("herald: article metadata unavailable for filtering: %v", err)
-		}
-	}
-
-	subjects := make([]filtermatch.Subject, len(articles))
-	for i, a := range articles {
-		subjects[i] = filtermatch.Subject{
-			Title:      a.Title,
-			Summary:    a.Summary,
-			Content:    a.Content,
-			Author:     a.Author,
-			Authors:    authors[a.ID],
-			Categories: categories[a.ID],
-		}
-	}
-	return subjects
-}
-
-// listFiltered runs a listing query through the Go evaluator.
-//
-// fetch takes a window size and returns rows from the top of the list; the
-// offset is applied here, AFTER filtering, because an offset counted in
-// unfiltered rows would skip or repeat articles as hidden rows shift the
-// boundary. That is why the window starts at zero and covers offset+limit
-// rather than paging in the store.
-//
-// The window is a small multiple of what the page needs and is capped: a page
-// may come back short of limit under an aggressive filter, which is the
-// deliberate trade against an unbounded fetch on every page load. See #277 --
-// batch reading is where page composition gets designed properly.
-func (e *Engine) listFiltered(p filterPlan, limit, offset int, fetch func(window int) ([]storage.Article, error)) ([]storage.Article, error) {
-	window := (offset + limit) * e.config.Limits.FilterOverfetchFactor
-	if maxScan := e.config.Limits.FilterMaxScan; maxScan > 0 && window > maxScan {
-		window = maxScan
-	}
-
-	articles, err := fetch(window)
-	if err != nil {
-		return nil, err
-	}
-	if len(articles) == window {
-		// The window filled, so there may be matching articles past it. Silent
-		// truncation would read as "that is all there is".
-		log.Printf("herald: filter scan window of %d rows filled; later pages may be incomplete", window)
-	}
-
-	subjects := e.subjects(articles, p.matcher)
-	kept := make([]storage.Article, 0, min(limit, len(articles)))
-	for i, a := range articles {
-		score, _ := p.matcher.Score(a.FeedID, subjects[i])
-		if score < *p.goThreshold {
-			continue
-		}
-		kept = append(kept, a)
-		if len(kept) >= offset+limit {
-			break
-		}
-	}
-	if offset >= len(kept) {
-		return nil, nil
-	}
-	return kept[offset:], nil
 }
 
 // resolveFilterThreshold returns the user's filter threshold as a pointer

--- a/engine.go
+++ b/engine.go
@@ -1986,14 +1986,26 @@ func (e *Engine) AddFilterRule(userID int64, rule FilterRule) (int64, error) {
 	// in Go against every candidate row of every listing query, where an exact
 	// rule costs an indexed equality in SQL.
 	if patternFilterRule(rule) {
-		patterns := 0
+		patterns, content := 0, 0
 		for _, r := range existingRules {
-			if patternFilterRule(r) {
-				patterns++
+			if !patternFilterRule(r) {
+				continue
+			}
+			patterns++
+			if r.Axis == AxisContent {
+				content++
 			}
 		}
 		if err := overQuota("pattern filter rule", patterns, e.config.Limits.MaxPatternFilterRulesPerUser); err != nil {
 			return 0, err
+		}
+		// Content rules scan full article bodies rather than titles, which
+		// costs roughly an order of magnitude more per rule, so they have a
+		// ceiling of their own well below the general pattern quota.
+		if rule.Axis == AxisContent {
+			if err := overQuota("content filter rule", content, e.config.Limits.MaxContentFilterRulesPerUser); err != nil {
+				return 0, err
+			}
 		}
 	}
 

--- a/engine.go
+++ b/engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matthewjhunter/herald/internal/ai"
 	emailpkg "github.com/matthewjhunter/herald/internal/email"
 	"github.com/matthewjhunter/herald/internal/feeds"
+	"github.com/matthewjhunter/herald/internal/filtermatch"
 	"github.com/matthewjhunter/herald/internal/storage"
 	"github.com/matthewjhunter/herald/internal/urlnorm"
 )
@@ -204,7 +205,17 @@ func (e *Engine) FetchAllFeeds(ctx context.Context) (*FetchResult, error) {
 // When includeRead is true, already-read articles are returned alongside unread
 // ones (each carrying its Read/Starred state); otherwise only unread are returned.
 func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	articles, err := e.store.GetUnreadArticlesForUser(userID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
+	p := e.planFilters(userID)
+	if !p.hides() {
+		articles, err := e.store.GetUnreadArticlesForUser(userID, limit, offset, p.sqlThreshold, includeRead)
+		if err != nil {
+			return nil, err
+		}
+		return articlesFromInternal(articles), nil
+	}
+	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+		return e.store.GetUnreadArticlesForUser(userID, window, 0, nil, includeRead)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +224,17 @@ func (e *Engine) GetUnreadArticles(userID int64, limit, offset int, includeRead 
 
 // GetStarredArticles returns starred articles for a user.
 func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article, error) {
-	articles, err := e.store.GetStarredArticles(userID, limit, offset, e.resolveFilterThreshold(userID))
+	p := e.planFilters(userID)
+	if !p.hides() {
+		articles, err := e.store.GetStarredArticles(userID, limit, offset, p.sqlThreshold)
+		if err != nil {
+			return nil, err
+		}
+		return articlesFromInternal(articles), nil
+	}
+	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+		return e.store.GetStarredArticles(userID, window, 0, nil)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +244,17 @@ func (e *Engine) GetStarredArticles(userID int64, limit, offset int) ([]Article,
 // GetUnreadArticlesByFeed returns articles for a user filtered to a specific feed.
 // When includeRead is true, read articles are included alongside unread ones.
 func (e *Engine) GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	articles, err := e.store.GetUnreadArticlesByFeed(userID, feedID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
+	p := e.planFilters(userID)
+	if !p.hides() {
+		articles, err := e.store.GetUnreadArticlesByFeed(userID, feedID, limit, offset, p.sqlThreshold, includeRead)
+		if err != nil {
+			return nil, err
+		}
+		return articlesFromInternal(articles), nil
+	}
+	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+		return e.store.GetUnreadArticlesByFeed(userID, feedID, window, 0, nil, includeRead)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1012,7 +1043,17 @@ func (e *Engine) GetGroupArticles(userID, groupID int64) (*ArticleGroup, error) 
 // GetUnreadGroupArticles returns articles belonging to a group. When includeRead
 // is true, read articles are included alongside unread ones.
 func (e *Engine) GetUnreadGroupArticles(userID, groupID int64, limit, offset int, includeRead bool) ([]Article, error) {
-	articles, err := e.store.GetUnreadGroupArticles(userID, groupID, limit, offset, e.resolveFilterThreshold(userID), includeRead)
+	p := e.planFilters(userID)
+	if !p.hides() {
+		articles, err := e.store.GetUnreadGroupArticles(userID, groupID, limit, offset, p.sqlThreshold, includeRead)
+		if err != nil {
+			return nil, err
+		}
+		return articlesFromInternal(articles), nil
+	}
+	articles, err := e.listFiltered(p, limit, offset, func(window int) ([]storage.Article, error) {
+		return e.store.GetUnreadGroupArticles(userID, groupID, window, 0, nil, includeRead)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -2074,6 +2115,139 @@ func (e *Engine) GetFeedMetadata(feedID int64) (*FeedMetadata, error) {
 		Authors:    authors,
 		Categories: categories,
 	}, nil
+}
+
+// --- Pattern filter rules, evaluated at read time (#274) ---
+
+// filterPlan is how one listing request will apply a user's filter rules.
+//
+// The two fields are mutually exclusive by construction. Either SQL does the
+// whole job -- sqlThreshold set, matcher nil, exactly as before #274 -- or Go
+// does, with the SQL gate switched off. Never both: the gate compares the SUM
+// of a user's matching rules against a threshold, so a rule set split across
+// two evaluators leaves neither holding the number being compared.
+type filterPlan struct {
+	matcher      *filtermatch.Matcher // non-nil when Go owns this user's rules
+	sqlThreshold *int                 // the gate for the SQL path; nil when Go owns it or the gate is off
+	goThreshold  *int                 // the gate for the Go path; nil when the gate is off
+}
+
+// planFilters decides how a listing request applies this user's rules.
+//
+// A user with no pattern rules -- the common case -- gets a plan indis-
+// tinguishable from the pre-#274 behaviour, with no extra queries and no Go
+// evaluation. Errors are not fatal: a filter that cannot be resolved falls
+// back to showing everything, because failing to hide an article is a far
+// better outcome than failing to render the page.
+func (e *Engine) planFilters(userID int64) filterPlan {
+	threshold := e.resolveFilterThreshold(userID)
+
+	rules, err := e.GetFilterRules(userID, nil)
+	if err != nil {
+		log.Printf("herald: filter rules unavailable for user %d, showing everything: %v", userID, err)
+		return filterPlan{}
+	}
+	fmRules := make([]filtermatch.Rule, len(rules))
+	for i, r := range rules {
+		fmRules[i] = filtermatch.Rule{
+			ID: r.ID, FeedID: r.FeedID, Axis: r.Axis,
+			MatchMode: r.MatchMode, Value: r.Value, Score: r.Score,
+		}
+	}
+	matcher, err := filtermatch.New(fmRules)
+	if err != nil {
+		// Patterns are compiled at save time, so this is a bug or a
+		// hand-edited row. Log it and fall back to the SQL half.
+		log.Printf("herald: filter rules for user %d will not compile, using exact rules only: %v", userID, err)
+		return filterPlan{sqlThreshold: threshold}
+	}
+	if matcher.Empty() {
+		return filterPlan{sqlThreshold: threshold}
+	}
+	return filterPlan{matcher: matcher, goThreshold: threshold}
+}
+
+// hides reports whether the Go evaluator is doing visibility work for this
+// request. When it is not -- no pattern rules, or the gate is off -- the
+// listing paths can return the store's rows untouched.
+func (p filterPlan) hides() bool { return p.matcher != nil && p.goThreshold != nil }
+
+// subjects assembles the text each article will be matched against, loading
+// normalized authors and categories only if some rule actually needs them.
+func (e *Engine) subjects(articles []storage.Article, m *filtermatch.Matcher) []filtermatch.Subject {
+	var authors, categories map[int64][]string
+	if m.NeedsMetadata() {
+		ids := make([]int64, len(articles))
+		for i, a := range articles {
+			ids[i] = a.ID
+		}
+		var err error
+		authors, categories, err = e.store.GetArticleMetadataBatch(ids)
+		if err != nil {
+			// Rules on the metadata axes will not fire. Say so rather than
+			// silently under-filtering.
+			log.Printf("herald: article metadata unavailable for filtering: %v", err)
+		}
+	}
+
+	subjects := make([]filtermatch.Subject, len(articles))
+	for i, a := range articles {
+		subjects[i] = filtermatch.Subject{
+			Title:      a.Title,
+			Summary:    a.Summary,
+			Content:    a.Content,
+			Author:     a.Author,
+			Authors:    authors[a.ID],
+			Categories: categories[a.ID],
+		}
+	}
+	return subjects
+}
+
+// listFiltered runs a listing query through the Go evaluator.
+//
+// fetch takes a window size and returns rows from the top of the list; the
+// offset is applied here, AFTER filtering, because an offset counted in
+// unfiltered rows would skip or repeat articles as hidden rows shift the
+// boundary. That is why the window starts at zero and covers offset+limit
+// rather than paging in the store.
+//
+// The window is a small multiple of what the page needs and is capped: a page
+// may come back short of limit under an aggressive filter, which is the
+// deliberate trade against an unbounded fetch on every page load. See #277 --
+// batch reading is where page composition gets designed properly.
+func (e *Engine) listFiltered(p filterPlan, limit, offset int, fetch func(window int) ([]storage.Article, error)) ([]storage.Article, error) {
+	window := (offset + limit) * e.config.Limits.FilterOverfetchFactor
+	if maxScan := e.config.Limits.FilterMaxScan; maxScan > 0 && window > maxScan {
+		window = maxScan
+	}
+
+	articles, err := fetch(window)
+	if err != nil {
+		return nil, err
+	}
+	if len(articles) == window {
+		// The window filled, so there may be matching articles past it. Silent
+		// truncation would read as "that is all there is".
+		log.Printf("herald: filter scan window of %d rows filled; later pages may be incomplete", window)
+	}
+
+	subjects := e.subjects(articles, p.matcher)
+	kept := make([]storage.Article, 0, min(limit, len(articles)))
+	for i, a := range articles {
+		score, _ := p.matcher.Score(a.FeedID, subjects[i])
+		if score < *p.goThreshold {
+			continue
+		}
+		kept = append(kept, a)
+		if len(kept) >= offset+limit {
+			break
+		}
+	}
+	if offset >= len(kept) {
+		return nil, nil
+	}
+	return kept[offset:], nil
 }
 
 // resolveFilterThreshold returns the user's filter threshold as a pointer

--- a/engine_fever.go
+++ b/engine_fever.go
@@ -41,8 +41,39 @@ func (e *Engine) GetFeverFeeds(userID int64) ([]storage.Feed, error) {
 }
 
 // GetFeverItems returns articles for the Fever items endpoint.
+//
+// Filter rules apply here for the same reason they apply to the web reader: a
+// Fever client is the reader's reader. Before #274 this path ignored them
+// entirely, so an article hidden in the web UI still synced to every phone.
+//
+// A batch can come back shorter than limit when rules hide part of it. Fever
+// clients page by since_id rather than by offset, so a short batch costs
+// nothing -- the next request picks up after the last id returned.
 func (e *Engine) GetFeverItems(userID int64, sinceID, maxID int64, withIDs []int64, limit int) ([]storage.FeverItemRow, error) {
-	return e.store.GetFeverItems(userID, sinceID, maxID, withIDs, limit)
+	rows, err := e.store.GetFeverItems(userID, sinceID, maxID, withIDs, limit)
+	if err != nil {
+		return nil, err
+	}
+	rf := e.filters()
+	p := rf.plan(userID)
+	if !p.hides() || len(rows) == 0 {
+		return rows, nil
+	}
+
+	articles := make([]storage.Article, len(rows))
+	for i, r := range rows {
+		articles[i] = r.Article
+	}
+	subjects := rf.subjects(articles, p.matcher)
+
+	kept := make([]storage.FeverItemRow, 0, len(rows))
+	for i, r := range rows {
+		if score, _ := p.matcher.Score(r.FeedID, subjects[i]); score < *p.goThreshold {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	return kept, nil
 }
 
 // GetFeverItemCount returns the total article count visible to a user.

--- a/filterpattern_hide_test.go
+++ b/filterpattern_hide_test.go
@@ -248,7 +248,7 @@ func TestExactOnlyRulesKeepTheSQLPath(t *testing.T) {
 	}
 	setFilterThreshold(t, engine, 1, 1)
 
-	if p := engine.planFilters(1); p.matcher != nil || p.sqlThreshold == nil {
+	if p := engine.filters().plan(1); p.matcher != nil || p.sqlThreshold == nil {
 		t.Errorf("exact-only rules should plan the SQL path: matcher=%v sqlThreshold=%v", p.matcher, p.sqlThreshold)
 	}
 

--- a/filterpattern_hide_test.go
+++ b/filterpattern_hide_test.go
@@ -1,0 +1,301 @@
+package herald
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// End-to-end hiding through the engine (#274). The evaluator itself is tested
+// in internal/filtermatch; what these cover is the wiring -- that a pattern
+// rule reaches the listing paths, that the SQL gate is off when Go owns the
+// rules, that paging stays consistent, and that one user's rules cannot touch
+// another's reader.
+
+// addArticles inserts n articles with the given titles and marks them scored,
+// so they behave like articles curation has already seen.
+func addFilterTestArticles(t *testing.T, e *Engine, userID, feedID int64, titles ...string) []int64 {
+	t.Helper()
+	ids := make([]int64, len(titles))
+	for i, title := range titles {
+		// Descending publish times so list order matches the argument order.
+		published := time.Now().Add(-time.Duration(i) * time.Hour)
+		id, err := e.store.AddArticle(&storage.Article{
+			FeedID:        feedID,
+			GUID:          fmt.Sprintf("guid-%s-%d", title, i),
+			Title:         title,
+			URL:           fmt.Sprintf("https://example.com/%d", i),
+			Content:       "Article body.",
+			Summary:       "Article summary.",
+			Author:        "Sundance",
+			PublishedDate: &published,
+		})
+		if err != nil {
+			t.Fatalf("AddArticle(%q): %v", title, err)
+		}
+		if err := e.store.SetInterestScore(userID, id, 5.0, "test-model", "hash"); err != nil {
+			t.Fatalf("SetInterestScore: %v", err)
+		}
+		ids[i] = id
+	}
+	return ids
+}
+
+func setFilterThreshold(t *testing.T, e *Engine, userID int64, threshold int) {
+	t.Helper()
+	if err := e.SetPreference(userID, "filter_threshold", fmt.Sprint(threshold)); err != nil {
+		t.Fatalf("SetPreference(filter_threshold): %v", err)
+	}
+}
+
+func titlesOf(articles []Article) []string {
+	out := make([]string, len(articles))
+	for i, a := range articles {
+		out[i] = a.Title
+	}
+	return out
+}
+
+// The case the feature exists for, end to end.
+func TestPatternRuleHidesRecurringPosts(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "The Last Refuge")
+	addFilterTestArticles(t, engine, 1, feedID,
+		"Sunday August 9th - Open Thread",
+		"August 9th - 2026 Presidential Politics - Trump Administration Day 567",
+		"Senate Votes Overnight to Confirm Todd Blanche as U.S. Attorney General",
+	)
+
+	// Without a threshold the gate is off, so nothing is hidden.
+	articles, err := engine.GetUnreadArticles(1, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles: %v", err)
+	}
+	if len(articles) != 3 {
+		t.Fatalf("before rules: got %d articles, want 3", len(articles))
+	}
+
+	feed := feedID
+	for _, pattern := range []string{`(?i)\bopen thread\b`, `(?i)trump administration day \d+`} {
+		if _, err := engine.AddFilterRule(1, FilterRule{
+			FeedID: &feed, Axis: AxisTitle, MatchMode: MatchRegex, Value: pattern, Score: -5,
+		}); err != nil {
+			t.Fatalf("AddFilterRule(%q): %v", pattern, err)
+		}
+	}
+	setFilterThreshold(t, engine, 1, 0)
+
+	// A threshold of 0 disables the gate, matching the pre-existing convention.
+	if articles, _ = engine.GetUnreadArticles(1, 50, 0, false); len(articles) != 3 {
+		t.Errorf("threshold 0: got %d articles, want 3 (gate disabled)", len(articles))
+	}
+
+	// Rules summing to -5 fall below a threshold of -1.
+	setFilterThreshold(t, engine, 1, -1)
+
+	articles, err = engine.GetUnreadArticles(1, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles: %v", err)
+	}
+	if len(articles) != 1 || articles[0].Title != "Senate Votes Overnight to Confirm Todd Blanche as U.S. Attorney General" {
+		t.Errorf("got %v, want only the Senate article", titlesOf(articles))
+	}
+}
+
+// Every listing path has to honour the rules, not just the one that was wired
+// first. A path that forgets stops filtering silently.
+func TestPatternRuleAppliesToEveryListingPath(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Open Thread", "Real News")
+	if err := engine.StarArticle(1, ids[0], true); err != nil {
+		t.Fatalf("StarArticle: %v", err)
+	}
+	if err := engine.StarArticle(1, ids[1], true); err != nil {
+		t.Fatalf("StarArticle: %v", err)
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+
+	for _, tc := range []struct {
+		name string
+		list func() ([]Article, error)
+	}{
+		{"unread", func() ([]Article, error) { return engine.GetUnreadArticles(1, 50, 0, false) }},
+		{"by feed", func() ([]Article, error) { return engine.GetUnreadArticlesByFeed(1, feedID, 50, 0, false) }},
+		{"starred", func() ([]Article, error) { return engine.GetStarredArticles(1, 50, 0) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			articles, err := tc.list()
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(articles) != 1 || articles[0].Title != "Real News" {
+				t.Errorf("got %v, want only [Real News]", titlesOf(articles))
+			}
+		})
+	}
+}
+
+// Pages are composed after filtering, so an offset counted in unfiltered rows
+// would skip or repeat articles as hidden rows shift the boundary.
+func TestFilteredPaginationIsConsistent(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	// Alternate hidden and kept so naive offsetting is guaranteed to go wrong.
+	var titles []string
+	for i := range 10 {
+		titles = append(titles, fmt.Sprintf("Open Thread %d", i), fmt.Sprintf("Keeper %d", i))
+	}
+	addFilterTestArticles(t, engine, 1, feedID, titles...)
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+
+	seen := map[string]bool{}
+	for page := range 5 {
+		articles, err := engine.GetUnreadArticles(1, 2, page*2, false)
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		for _, a := range articles {
+			if seen[a.Title] {
+				t.Errorf("page %d repeated %q", page, a.Title)
+			}
+			seen[a.Title] = true
+		}
+	}
+	if len(seen) != 10 {
+		t.Errorf("paged through %d articles, want all 10 keepers: %v", len(seen), seen)
+	}
+	for i := range 10 {
+		if !seen[fmt.Sprintf("Keeper %d", i)] {
+			t.Errorf("Keeper %d was never returned", i)
+		}
+	}
+}
+
+// A filter rule leaking across users is a security bug, not a display bug.
+func TestPatternRulesAreScopedToTheirOwner(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	if err := engine.store.SubscribeUserToFeed(2, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed(2): %v", err)
+	}
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Open Thread", "Real News")
+	for _, id := range ids {
+		if err := engine.store.SetInterestScore(2, id, 5.0, "test-model", "hash"); err != nil {
+			t.Fatalf("SetInterestScore(user 2): %v", err)
+		}
+	}
+
+	// User 1 hides open threads. User 2 has no rules at all.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+	setFilterThreshold(t, engine, 2, -1)
+
+	if articles, _ := engine.GetUnreadArticles(1, 50, 0, false); len(articles) != 1 {
+		t.Errorf("owner sees %v, want only the unfiltered article", titlesOf(articles))
+	}
+	articles, err := engine.GetUnreadArticles(2, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles(user 2): %v", err)
+	}
+	if len(articles) != 2 {
+		t.Errorf("other user sees %v, want both articles: one user's rule must not filter another's reader", titlesOf(articles))
+	}
+}
+
+// A user with only exact metadata rules must keep the untouched SQL path: no
+// pattern evaluation, no extra queries, and the same results as before #274.
+func TestExactOnlyRulesKeepTheSQLPath(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Boosted", "Ordinary")
+	if err := engine.store.StoreArticleAuthors(ids[0], []storage.ArticleAuthor{{Name: "Alice"}}); err != nil {
+		t.Fatalf("StoreArticleAuthors: %v", err)
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisAuthor, MatchMode: MatchExact, Value: "Alice", Score: 5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, 1)
+
+	if p := engine.planFilters(1); p.matcher != nil || p.sqlThreshold == nil {
+		t.Errorf("exact-only rules should plan the SQL path: matcher=%v sqlThreshold=%v", p.matcher, p.sqlThreshold)
+	}
+
+	articles, err := engine.GetUnreadArticles(1, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles: %v", err)
+	}
+	if len(articles) != 1 || articles[0].Title != "Boosted" {
+		t.Errorf("got %v, want only [Boosted]", titlesOf(articles))
+	}
+}
+
+// Once any rule needs Go, Go owns the whole set -- including the exact ones SQL
+// could have matched. If the SQL join were left on, those rules would count
+// twice and the gate would compare against the wrong number.
+func TestExactAndPatternRulesAreNotCountedTwice(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Open Thread", "Real News")
+	for _, id := range ids {
+		if err := engine.store.StoreArticleAuthors(id, []storage.ArticleAuthor{{Name: "Sundance"}}); err != nil {
+			t.Fatalf("StoreArticleAuthors: %v", err)
+		}
+	}
+
+	// -2 from the exact author rule, -2 more from the pattern rule on the open
+	// thread. Counted once each, the open thread sits at -4 and the other at
+	// -2; a threshold of -3 separates them. Counted twice, both fall below it.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisAuthor, MatchMode: MatchExact, Value: "Sundance", Score: -2,
+	}); err != nil {
+		t.Fatalf("AddFilterRule(exact): %v", err)
+	}
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -2,
+	}); err != nil {
+		t.Fatalf("AddFilterRule(pattern): %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -3)
+
+	articles, err := engine.GetUnreadArticles(1, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetUnreadArticles: %v", err)
+	}
+	if len(articles) != 1 || articles[0].Title != "Real News" {
+		t.Errorf("got %v, want only [Real News] -- rules are being double counted", titlesOf(articles))
+	}
+}

--- a/filterpattern_rank_test.go
+++ b/filterpattern_rank_test.go
@@ -1,0 +1,225 @@
+package herald
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// Ranking with pattern rules (#274). The interest list, the briefing and the
+// CLI notification paths all rank by a rule-adjusted score; when Go owns the
+// rules that arithmetic moves out of SQL, and it has to produce the same
+// answers.
+
+func addScoredArticle(t *testing.T, e *Engine, userID, feedID int64, title string, score float64, published time.Time) int64 {
+	t.Helper()
+	id, err := e.store.AddArticle(&storage.Article{
+		FeedID: feedID, GUID: title, Title: title,
+		URL: "https://example.com/" + title, PublishedDate: &published,
+	})
+	if err != nil {
+		t.Fatalf("AddArticle(%q): %v", title, err)
+	}
+	if err := e.store.SetInterestScore(userID, id, score, "test-model", "hash"); err != nil {
+		t.Fatalf("SetInterestScore: %v", err)
+	}
+	return id
+}
+
+// A demoting rule should move an article down the ranking, and past the
+// threshold drop it from the list entirely.
+func TestPatternRuleAffectsRanking(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	now := time.Now()
+	addScoredArticle(t, engine, 1, feedID, "Open Thread", 9.0, now)
+	addScoredArticle(t, engine, 1, feedID, "Real News", 8.0, now)
+
+	articles, _, err := engine.GetHighInterestArticles(1, 7.0, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHighInterestArticles: %v", err)
+	}
+	if len(articles) != 2 || articles[0].Title != "Open Thread" {
+		t.Fatalf("before rules: got %v, want the open thread ranked first", titlesOf(articles))
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -2,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	// 9 - 2 = 7, still above the threshold but now below the other article.
+	articles, scores, err := engine.GetHighInterestArticles(1, 7.0, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHighInterestArticles: %v", err)
+	}
+	if len(articles) != 2 {
+		t.Fatalf("got %v, want both articles", titlesOf(articles))
+	}
+	if articles[0].Title != "Real News" {
+		t.Errorf("got %v, want the demoted article ranked second", titlesOf(articles))
+	}
+	if len(scores) != 2 || scores[0] <= scores[1] {
+		t.Errorf("scores %v should descend", scores)
+	}
+
+	// A harsher rule drops it below the interest threshold entirely.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchRegex, Value: `(?i)^open thread$`, Score: -3,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	articles, _, err = engine.GetHighInterestArticles(1, 7.0, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHighInterestArticles: %v", err)
+	}
+	if len(articles) != 1 || articles[0].Title != "Real News" {
+		t.Errorf("got %v, want only [Real News]", titlesOf(articles))
+	}
+}
+
+// The Go ranking has to clamp exactly as the SQL expression does: add first,
+// then clamp to 0-10. Clamping before the addition would give a different
+// answer for a rule that pushes past a bound and back.
+func TestGoRankingClampsLikeSQL(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	now := time.Now()
+	addScoredArticle(t, engine, 1, feedID, "Boosted", 9.0, now)
+
+	// A rule of +5 and one of -6 against a raw score of 9. Summed first and
+	// then clamped, that is 8. Clamped at each step it would be min(10, 14) = 10
+	// and then 4 -- so the two orders give visibly different answers.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "boosted", Score: 5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchRegex, Value: `(?i)boost`, Score: -6,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	_, scores, err := engine.GetHighInterestArticles(1, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHighInterestArticles: %v", err)
+	}
+	if len(scores) != 1 {
+		t.Fatalf("got %d scores, want 1", len(scores))
+	}
+	// 9 + 5 - 6 = 8, decayed by a factor of ~1 for a just-published article.
+	// Clamping the intermediate 14 to 10 first would give 4.
+	if math.Abs(scores[0]-8.0) > 0.05 {
+		t.Errorf("score = %v, want ~8.0 (sum then clamp, not clamp then sum)", scores[0])
+	}
+}
+
+// Both evaluators decay recency the same way, or the same article ranks
+// differently depending on whether the user happens to own a pattern rule.
+func TestGoAndSQLRankingAgreeOnDecay(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	old := time.Now().Add(-72 * time.Hour)
+	addScoredArticle(t, engine, 1, feedID, "Stale", 9.0, old)
+
+	// SQL path: no rules at all.
+	_, sqlScores, err := engine.GetHighInterestArticles(1, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("SQL path: %v", err)
+	}
+
+	// Go path: a rule that matches nothing, so the score is unchanged and any
+	// difference is the decay arithmetic disagreeing.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchRegex, Value: `matches-nothing-at-all`, Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	_, goScores, err := engine.GetHighInterestArticles(1, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("Go path: %v", err)
+	}
+
+	if len(sqlScores) != 1 || len(goScores) != 1 {
+		t.Fatalf("got %d SQL scores and %d Go scores, want 1 each", len(sqlScores), len(goScores))
+	}
+	if math.Abs(sqlScores[0]-goScores[0]) > 0.01 {
+		t.Errorf("SQL scored %v, Go scored %v: the decay expressions have drifted", sqlScores[0], goScores[0])
+	}
+}
+
+// The notification paths hold a Store and no Engine, and must still see
+// rule-adjusted ranking.
+func TestHighInterestArticlesWithoutAnEngine(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	now := time.Now()
+	addScoredArticle(t, engine, 1, feedID, "Open Thread", 9.0, now)
+	addScoredArticle(t, engine, 1, feedID, "Real News", 8.0, now)
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	articles, _, err := HighInterestArticles(engine.store, engine.config, 1, 7.0, 10, 0)
+	if err != nil {
+		t.Fatalf("HighInterestArticles: %v", err)
+	}
+	if len(articles) != 1 || articles[0].Title != "Real News" {
+		names := make([]string, len(articles))
+		for i, a := range articles {
+			names[i] = a.Title
+		}
+		t.Errorf("got %v, want only [Real News]: 9-5=4 is below the 7.0 threshold", names)
+	}
+}
+
+// The gate hides from the reader's list, and has never applied to the briefing
+// or the notification paths. Ranking changes; visibility does not.
+func TestGateAppliesToTheListButNotTheNotificationPaths(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	now := time.Now()
+	addScoredArticle(t, engine, 1, feedID, "Demoted", 9.0, now)
+
+	// The score lands at 8, comfortably above the interest threshold, so only
+	// the gate can remove it: a rule sum of -1 against a gate of 1.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "demoted", Score: -1,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, 1)
+
+	articles, _, err := engine.GetHighInterestArticles(1, 7.0, 50, 0)
+	if err != nil {
+		t.Fatalf("GetHighInterestArticles: %v", err)
+	}
+	if len(articles) != 0 {
+		t.Errorf("reader list returned %v, want nothing: the gate should hide it", titlesOf(articles))
+	}
+
+	notified, _, err := HighInterestArticles(engine.store, engine.config, 1, 7.0, 10, 0)
+	if err != nil {
+		t.Fatalf("HighInterestArticles: %v", err)
+	}
+	if len(notified) != 1 {
+		t.Errorf("notification path returned %d articles, want 1: the gate has never applied here", len(notified))
+	}
+}

--- a/filterpattern_surface_test.go
+++ b/filterpattern_surface_test.go
@@ -1,0 +1,172 @@
+package herald
+
+import "testing"
+
+// The surfaces beyond the reader's own lists (#274): the Fever sync API, which
+// is somebody's phone, and the hidden count that tells a reader their filters
+// are eating something.
+
+func TestFeverItemsRespectFilterRules(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	addFilterTestArticles(t, engine, 1, feedID, "Open Thread", "Real News")
+
+	// No rules: Fever sees everything.
+	rows, err := engine.GetFeverItems(1, 0, 0, nil, 50)
+	if err != nil {
+		t.Fatalf("GetFeverItems: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("before rules: got %d items, want 2", len(rows))
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+
+	rows, err = engine.GetFeverItems(1, 0, 0, nil, 50)
+	if err != nil {
+		t.Fatalf("GetFeverItems: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Title != "Real News" {
+		got := make([]string, len(rows))
+		for i, r := range rows {
+			got[i] = r.Title
+		}
+		t.Errorf("got %v, want only [Real News]: an article hidden in the reader must not sync to a phone", got)
+	}
+}
+
+// Filtering must not leak across users on the sync API either.
+func TestFeverItemsScopedToTheRuleOwner(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	if err := engine.store.SubscribeUserToFeed(2, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed(2): %v", err)
+	}
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Open Thread", "Real News")
+	for _, id := range ids {
+		if err := engine.store.SetInterestScore(2, id, 5.0, "test-model", "hash"); err != nil {
+			t.Fatalf("SetInterestScore(user 2): %v", err)
+		}
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+	setFilterThreshold(t, engine, 2, -1)
+
+	if rows, _ := engine.GetFeverItems(1, 0, 0, nil, 50); len(rows) != 1 {
+		t.Errorf("owner got %d items, want 1", len(rows))
+	}
+	rows, err := engine.GetFeverItems(2, 0, 0, nil, 50)
+	if err != nil {
+		t.Fatalf("GetFeverItems(user 2): %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("other user got %d items, want 2", len(rows))
+	}
+}
+
+// A reader who cannot tell that filters are eating their feed has no way to
+// discover a rule that is too broad.
+func TestReaderGaugeReportsHiddenArticles(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	addFilterTestArticles(t, engine, 1, feedID,
+		"Open Thread A", "Open Thread B", "Real News")
+	gauge, err := engine.GetReaderGauge(1, 0)
+	if err != nil {
+		t.Fatalf("GetReaderGauge: %v", err)
+	}
+	if gauge.Hidden != 0 {
+		t.Errorf("with no rules, Hidden = %d, want 0", gauge.Hidden)
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	// A rule without a threshold hides nothing, so there is nothing to report.
+	if gauge, _ = engine.GetReaderGauge(1, 0); gauge.Hidden != 0 {
+		t.Errorf("with the gate off, Hidden = %d, want 0", gauge.Hidden)
+	}
+
+	setFilterThreshold(t, engine, 1, -1)
+	gauge, err = engine.GetReaderGauge(1, 0)
+	if err != nil {
+		t.Fatalf("GetReaderGauge: %v", err)
+	}
+	if gauge.Hidden != 2 {
+		t.Errorf("Hidden = %d, want 2", gauge.Hidden)
+	}
+}
+
+func TestReaderGaugeHiddenIsScopedToTheFeed(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	noisy := subscribeDirect(t, engine, 1, "https://example.com/noisy.xml", "Noisy")
+	quiet := subscribeDirect(t, engine, 1, "https://example.com/quiet.xml", "Quiet")
+	addFilterTestArticles(t, engine, 1, noisy, "Open Thread A", "Open Thread B")
+	addFilterTestArticles(t, engine, 1, quiet, "Real News")
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+
+	if g, _ := engine.GetReaderGauge(1, noisy); g.Hidden != 2 {
+		t.Errorf("noisy feed: Hidden = %d, want 2", g.Hidden)
+	}
+	if g, _ := engine.GetReaderGauge(1, quiet); g.Hidden != 0 {
+		t.Errorf("quiet feed: Hidden = %d, want 0", g.Hidden)
+	}
+}
+
+// The gauge's hidden count must not be charged to a user who has no rules.
+func TestReaderGaugeHiddenIsPerUser(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	feedID := subscribeDirect(t, engine, 1, "https://example.com/feed.xml", "Feed")
+	if err := engine.store.SubscribeUserToFeed(2, feedID); err != nil {
+		t.Fatalf("SubscribeUserToFeed(2): %v", err)
+	}
+	ids := addFilterTestArticles(t, engine, 1, feedID, "Open Thread")
+	for _, id := range ids {
+		if err := engine.store.SetInterestScore(2, id, 5.0, "test-model", "hash"); err != nil {
+			t.Fatalf("SetInterestScore(user 2): %v", err)
+		}
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+	}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+	setFilterThreshold(t, engine, 1, -1)
+
+	if g, _ := engine.GetReaderGauge(1, 0); g.Hidden != 1 {
+		t.Errorf("rule owner: Hidden = %d, want 1", g.Hidden)
+	}
+	if g, _ := engine.GetReaderGauge(2, 0); g.Hidden != 0 {
+		t.Errorf("other user: Hidden = %d, want 0", g.Hidden)
+	}
+}

--- a/filterpattern_test.go
+++ b/filterpattern_test.go
@@ -128,3 +128,35 @@ func TestPatternFilterRuleQuotaIsSeparate(t *testing.T) {
 		t.Errorf("exact rule refused by the pattern quota: %v", err)
 	}
 }
+
+// Content rules scan full article bodies, measured at roughly 2ms per rule per
+// 50-article page against about 30us for a title rule. They get a ceiling of
+// their own, well under the general pattern quota.
+func TestContentFilterRuleQuotaIsTighter(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	engine.config.Limits.MaxPatternFilterRulesPerUser = 50
+	engine.config.Limits.MaxContentFilterRulesPerUser = 2
+
+	for i, value := range []string{"one", "two"} {
+		if _, err := engine.AddFilterRule(1, FilterRule{
+			Axis: AxisContent, MatchMode: MatchSubstring, Value: value, Score: -1,
+		}); err != nil {
+			t.Fatalf("content rule %d: %v", i, err)
+		}
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisContent, MatchMode: MatchSubstring, Value: "three", Score: -1,
+	}); err == nil {
+		t.Error("expected the third content rule to be refused")
+	}
+
+	// Title rules are cheap and keep the general pattern quota.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: AxisTitle, MatchMode: MatchSubstring, Value: "three", Score: -1,
+	}); err != nil {
+		t.Errorf("title rule refused by the content quota: %v", err)
+	}
+}

--- a/filterpattern_test.go
+++ b/filterpattern_test.go
@@ -1,0 +1,130 @@
+package herald
+
+import (
+	"strings"
+	"testing"
+)
+
+// Validation for pattern filter rules (#274). A rule is accepted here or not at
+// all: the reader must never be handed a pattern that fails to compile deeper
+// in the pipeline, where there is no user to tell.
+
+func TestAddFilterRuleAcceptsTextAxes(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	for _, axis := range []string{"title", "summary", "content"} {
+		if _, err := engine.AddFilterRule(1, FilterRule{
+			Axis: axis, MatchMode: MatchSubstring, Value: "open thread", Score: -5,
+		}); err != nil {
+			t.Errorf("AddFilterRule(%s): %v", axis, err)
+		}
+	}
+}
+
+// An omitted mode has to mean exact, because every rule written before #274
+// omitted it.
+func TestAddFilterRuleDefaultsToExactMode(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	if _, err := engine.AddFilterRule(1, FilterRule{Axis: "author", Value: "Alice", Score: 5}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	rules, err := engine.GetFilterRules(1, nil)
+	if err != nil {
+		t.Fatalf("GetFilterRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	if rules[0].MatchMode != MatchExact {
+		t.Errorf("match mode = %q, want %q", rules[0].MatchMode, MatchExact)
+	}
+}
+
+func TestAddFilterRuleRejectsUnknownMatchMode(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	_, err := engine.AddFilterRule(1, FilterRule{
+		Axis: "title", MatchMode: "glob", Value: "x*", Score: 1,
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown match mode")
+	}
+	if !strings.Contains(err.Error(), "glob") {
+		t.Errorf("error should name the offending mode, got: %v", err)
+	}
+}
+
+// The pattern is compiled at save time so the error reaches the person who can
+// fix it. RE2 rejects lookahead, which is the mistake a user bringing PCRE
+// habits will make first.
+func TestAddFilterRuleRejectsUncompilablePattern(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	for _, pattern := range []string{
+		`(unclosed`,
+		`a{2,1}`,
+		`(?=lookahead)`,
+	} {
+		_, err := engine.AddFilterRule(1, FilterRule{
+			Axis: "title", MatchMode: MatchRegex, Value: pattern, Score: -1,
+		})
+		if err == nil {
+			t.Errorf("expected %q to be rejected as an invalid pattern", pattern)
+		}
+	}
+}
+
+func TestAddFilterRuleAcceptsValidPattern(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	for _, pattern := range []string{
+		`(?i)\bopen thread\b`,
+		`trump administration day \d+`,
+	} {
+		if _, err := engine.AddFilterRule(1, FilterRule{
+			Axis: "title", MatchMode: MatchRegex, Value: pattern, Score: -5,
+		}); err != nil {
+			t.Errorf("AddFilterRule(%q): %v", pattern, err)
+		}
+	}
+}
+
+// A substring or regex rule is evaluated in Go against every candidate row, so
+// pattern rules are metered separately and far more tightly than exact rules,
+// which are an indexed equality in SQL. The general MaxFilterRulesPerUser
+// default of 1000 is a sane ceiling for the latter and a denial of service for
+// the former.
+func TestPatternFilterRuleQuotaIsSeparate(t *testing.T) {
+	engine, cleanup := newTestEngine(t)
+	defer cleanup()
+
+	engine.config.Limits.MaxPatternFilterRulesPerUser = 2
+
+	for i, value := range []string{"one", "two"} {
+		if _, err := engine.AddFilterRule(1, FilterRule{
+			Axis: "title", MatchMode: MatchSubstring, Value: value, Score: -1,
+		}); err != nil {
+			t.Fatalf("pattern rule %d: %v", i, err)
+		}
+	}
+
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: "title", MatchMode: MatchSubstring, Value: "three", Score: -1,
+	}); err == nil {
+		t.Error("expected the third pattern rule to be refused")
+	}
+
+	// Exact rules are metered by MaxFilterRulesPerUser and must be unaffected.
+	if _, err := engine.AddFilterRule(1, FilterRule{
+		Axis: "author", MatchMode: MatchExact, Value: "Alice", Score: 5,
+	}); err != nil {
+		t.Errorf("exact rule refused by the pattern quota: %v", err)
+	}
+}

--- a/filterrules.go
+++ b/filterrules.go
@@ -272,3 +272,46 @@ func HighInterestArticles(store storage.Store, cfg *storage.Config, userID int64
 	// The visibility gate stays off here, as it always has been on this path.
 	return ruleFilter{store: store, cfg: cfg}.highInterest(userID, threshold, limit, offset, false)
 }
+
+// hiddenUnreadCount reports how many unread articles this user's filter rules
+// are currently suppressing, for the whole reader or one feed.
+//
+// The reader's unread counts have never applied the visibility gate, so a
+// filtered list has always been able to show fewer articles than the badge
+// promises. Rather than make the counts exact -- which would mean evaluating
+// every unread article on every page load -- the discrepancy is surfaced.
+// "12 unread, 7 hidden" tells the reader something true and useful, and gives
+// them a reason to go and look at what their rules are eating.
+//
+// Counted over the same bounded window everything else here uses, so it is an
+// indicator rather than an audited figure: with more unread articles than the
+// window covers, it undercounts.
+func (rf ruleFilter) hiddenUnreadCount(userID, feedID int64) int {
+	p := rf.plan(userID)
+	if !p.hides() {
+		return 0
+	}
+	window := rf.window(rf.cfg.Limits.FilterMaxScan, 0)
+
+	var (
+		articles []storage.Article
+		err      error
+	)
+	if feedID > 0 {
+		articles, err = rf.store.GetUnreadArticlesByFeed(userID, feedID, window, 0, nil, false)
+	} else {
+		articles, err = rf.store.GetUnreadArticlesForUser(userID, window, 0, nil, false)
+	}
+	if err != nil {
+		return 0
+	}
+
+	subjects := rf.subjects(articles, p.matcher)
+	hidden := 0
+	for i, a := range articles {
+		if score, _ := p.matcher.Score(a.FeedID, subjects[i]); score < *p.goThreshold {
+			hidden++
+		}
+	}
+	return hidden
+}

--- a/filterrules.go
+++ b/filterrules.go
@@ -1,0 +1,274 @@
+package herald
+
+import (
+	"log"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/matthewjhunter/herald/internal/filtermatch"
+	"github.com/matthewjhunter/herald/internal/storage"
+)
+
+// Read-time evaluation of pattern filter rules (#274).
+//
+// This lives on a type of its own rather than on Engine because two of the
+// consumers -- the CLI's fetch-cycle and cron notification paths -- hold a
+// Store and no Engine. Rules that shift the web ranking but not what gets
+// notified would be the #259 complaint over again, so both routes go through
+// the same code.
+
+// ruleFilter applies a user's filter rules to listing and ranking queries.
+type ruleFilter struct {
+	store storage.Store
+	cfg   *storage.Config
+}
+
+func (e *Engine) filters() ruleFilter { return ruleFilter{store: e.store, cfg: e.config} }
+
+// filterPlan is how one request will apply a user's filter rules.
+//
+// The two evaluators are mutually exclusive by construction. Either SQL does
+// the whole job -- sqlThreshold set, matcher nil, exactly as before #274 -- or
+// Go does, with the SQL rule join and gate switched off. Never both: the gate
+// compares the SUM of a user's matching rules against a threshold, so a rule
+// set split across two evaluators leaves neither holding the number being
+// compared.
+type filterPlan struct {
+	matcher      *filtermatch.Matcher // non-nil when Go owns this user's rules
+	sqlThreshold *int                 // gate for the SQL path; nil when Go owns it or the gate is off
+	goThreshold  *int                 // gate for the Go path; nil when the gate is off
+	applySQL     bool                 // whether the SQL rule join should compute a rule-adjusted score
+}
+
+// hides reports whether the Go evaluator is doing visibility work. When it is
+// not, the date-ordered listing paths can return the store's rows untouched.
+func (p filterPlan) hides() bool { return p.matcher != nil && p.goThreshold != nil }
+
+// plan decides how a request applies this user's rules.
+//
+// A user with no pattern rules -- the common case -- gets a plan indis-
+// tinguishable from the pre-#274 behaviour, with no extra queries and no Go
+// evaluation. Errors are not fatal: a filter that cannot be resolved falls back
+// to showing everything, because failing to hide an article is a far better
+// outcome than failing to render the page.
+func (rf ruleFilter) plan(userID int64) filterPlan {
+	rules, err := rf.store.GetFilterRules(userID, nil)
+	if err != nil {
+		log.Printf("herald: filter rules unavailable for user %d, showing everything: %v", userID, err)
+		return filterPlan{}
+	}
+	if len(rules) == 0 {
+		return filterPlan{}
+	}
+	threshold := rf.threshold(userID)
+
+	fmRules := make([]filtermatch.Rule, len(rules))
+	for i, r := range rules {
+		fmRules[i] = filtermatch.Rule{
+			ID: r.ID, FeedID: r.FeedID, Axis: r.Axis,
+			MatchMode: r.MatchMode, Value: r.Value, Score: r.Score,
+		}
+	}
+	matcher, err := filtermatch.New(fmRules)
+	if err != nil {
+		// Patterns are compiled at save time, so this is a bug or a hand-edited
+		// row. Log it and fall back to the half SQL can still do.
+		log.Printf("herald: filter rules for user %d will not compile, using exact rules only: %v", userID, err)
+		return filterPlan{sqlThreshold: threshold, applySQL: true}
+	}
+	if matcher.Empty() {
+		return filterPlan{sqlThreshold: threshold, applySQL: true}
+	}
+	return filterPlan{matcher: matcher, goThreshold: threshold}
+}
+
+// threshold returns the user's visibility threshold, or nil when the gate is
+// off. Zero means disabled, which is the pre-existing convention.
+func (rf ruleFilter) threshold(userID int64) *int {
+	prefs, err := rf.store.GetAllUserPreferences(userID)
+	if err != nil {
+		return nil
+	}
+	v, ok := prefs["filter_threshold"]
+	if !ok {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n == 0 {
+		return nil
+	}
+	return &n
+}
+
+// subjects assembles the text each article will be matched against, loading
+// normalized authors and categories only when some rule needs them.
+func (rf ruleFilter) subjects(articles []storage.Article, m *filtermatch.Matcher) []filtermatch.Subject {
+	var authors, categories map[int64][]string
+	if m.NeedsMetadata() {
+		ids := make([]int64, len(articles))
+		for i, a := range articles {
+			ids[i] = a.ID
+		}
+		var err error
+		authors, categories, err = rf.store.GetArticleMetadataBatch(ids)
+		if err != nil {
+			// Rules on the metadata axes will not fire. Say so rather than
+			// silently under-filtering.
+			log.Printf("herald: article metadata unavailable for filtering: %v", err)
+		}
+	}
+
+	subjects := make([]filtermatch.Subject, len(articles))
+	for i, a := range articles {
+		subjects[i] = filtermatch.Subject{
+			Title:      a.Title,
+			Summary:    a.Summary,
+			Content:    a.Content,
+			Author:     a.Author,
+			Authors:    authors[a.ID],
+			Categories: categories[a.ID],
+		}
+	}
+	return subjects
+}
+
+// window is how many rows to examine to compose one page of `limit` articles
+// starting at `offset`. Rows are hidden after the query returns, so a page has
+// to fetch more than it needs to stand a chance of filling.
+func (rf ruleFilter) window(limit, offset int) int {
+	factor := max(rf.cfg.Limits.FilterOverfetchFactor, 1)
+	w := (offset + limit) * factor
+	if maxScan := rf.cfg.Limits.FilterMaxScan; maxScan > 0 && w > maxScan {
+		w = maxScan
+	}
+	return w
+}
+
+// listFiltered runs a date-ordered listing query through the Go evaluator.
+//
+// fetch takes a window size and returns rows from the top of the list; the
+// offset is applied here, AFTER filtering, because an offset counted in
+// unfiltered rows would skip or repeat articles as hidden rows shift the page
+// boundary. That is why the window starts at zero and covers offset+limit
+// rather than paging in the store.
+//
+// A page may come back short of limit under an aggressive filter, which is the
+// deliberate trade against an unbounded fetch on every page load. See #277 --
+// batch reading is where page composition gets designed properly.
+func (rf ruleFilter) listFiltered(p filterPlan, limit, offset int, fetch func(window int) ([]storage.Article, error)) ([]storage.Article, error) {
+	window := rf.window(limit, offset)
+	articles, err := fetch(window)
+	if err != nil {
+		return nil, err
+	}
+	if len(articles) == window {
+		// Silent truncation would read as "that is all there is".
+		log.Printf("herald: filter scan window of %d rows filled; later pages may be incomplete", window)
+	}
+
+	subjects := rf.subjects(articles, p.matcher)
+	kept := make([]storage.Article, 0, min(limit, len(articles)))
+	for i, a := range articles {
+		score, _ := p.matcher.Score(a.FeedID, subjects[i])
+		if score < *p.goThreshold {
+			continue
+		}
+		kept = append(kept, a)
+		if len(kept) >= offset+limit {
+			break
+		}
+	}
+	if offset >= len(kept) {
+		return nil, nil
+	}
+	return kept[offset:], nil
+}
+
+// highInterest returns unread articles whose rule-adjusted score reaches the
+// threshold, ranked as the reader's interest list ranks them.
+//
+// On the SQL path this is the pre-#274 query unchanged. On the Go path the
+// arithmetic moves out of SQL entirely: the store returns raw interest scores,
+// the rule sum is added here, the result is clamped to the 0-10 scale every
+// consumer reads, then decayed for recency and sorted. Clamping is why the raw
+// score is needed -- it is not invertible, so a clamped score cannot be
+// adjusted after the fact.
+//
+// The candidate window is ordered by undecorated score, so an article the
+// model rated poorly and a rule boosts hard can fall outside it. Rules that
+// demote -- which is what nearly all of them do -- are unaffected.
+// applyGate follows each caller's pre-existing behaviour: the reader's list
+// hides what the threshold hides, while the briefing and the CLI notification
+// paths have always ranked with rules but never hidden, and still do.
+func (rf ruleFilter) highInterest(userID int64, threshold float64, limit, offset int, applyGate bool) ([]storage.Article, []float64, error) {
+	p := rf.plan(userID)
+	if !applyGate {
+		p.sqlThreshold, p.goThreshold = nil, nil
+	}
+	if p.matcher == nil {
+		return rf.store.GetArticlesByInterestScore(userID, threshold, limit, offset, p.sqlThreshold, p.applySQL)
+	}
+
+	window := rf.window(limit, offset)
+	articles, raw, err := rf.store.GetScoredUnreadArticles(userID, window)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(articles) == window {
+		log.Printf("herald: interest ranking scanned its full window of %d rows; lower-ranked matches may be missing", window)
+	}
+
+	type scored struct {
+		article storage.Article
+		score   float64
+		decayed float64
+	}
+	subjects := rf.subjects(articles, p.matcher)
+	now := time.Now()
+	ranked := make([]scored, 0, len(articles))
+	for i, a := range articles {
+		ruleScore, _ := p.matcher.Score(a.FeedID, subjects[i])
+		if p.goThreshold != nil && ruleScore < *p.goThreshold {
+			continue // hidden by the visibility gate
+		}
+		// Same arithmetic as effectiveScoreExpr: add, then clamp to 0-10.
+		score := math.Min(10, math.Max(0, raw[i]+float64(ruleScore)))
+		if score < threshold {
+			continue
+		}
+		ranked = append(ranked, scored{
+			article: a,
+			score:   score,
+			decayed: score * storage.RecencyDecay(a.PublishedDate, a.FetchedDate, now),
+		})
+	}
+
+	// Stable so that equal scores keep the store's ordering rather than
+	// shuffling between page loads.
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].decayed > ranked[j].decayed })
+	if offset >= len(ranked) {
+		return nil, nil, nil
+	}
+	ranked = ranked[offset:min(offset+limit, len(ranked))]
+
+	outArticles := make([]storage.Article, len(ranked))
+	outScores := make([]float64, len(ranked))
+	for i, r := range ranked {
+		outArticles[i] = r.article
+		outScores[i] = r.decayed
+	}
+	return outArticles, outScores, nil
+}
+
+// HighInterestArticles returns a user's rule-adjusted high-interest articles
+// for a caller that has a Store but no Engine.
+//
+// The CLI's notification paths are the reason this is exported: a rule that
+// changes the web ranking but not what gets sent would leave the surface that
+// actually reaches the reader unfiltered.
+func HighInterestArticles(store storage.Store, cfg *storage.Config, userID int64, threshold float64, limit, offset int) ([]storage.Article, []float64, error) {
+	// The visibility gate stays off here, as it always has been on this path.
+	return ruleFilter{store: store, cfg: cfg}.highInterest(userID, threshold, limit, offset, false)
+}

--- a/internal/filtermatch/bench_test.go
+++ b/internal/filtermatch/bench_test.go
@@ -1,0 +1,99 @@
+package filtermatch
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A user at the pattern-rule quota, scoring a full page of articles. This is
+// the worst realistic case for the read path, and the number it produces is
+// what justifies not caching Matchers per user: if building and running one is
+// cheap next to the query that fetched the rows, there is nothing to cache.
+func benchRules(n int) []Rule {
+	rules := make([]Rule, n)
+	for i := range rules {
+		rules[i] = Rule{
+			ID:        int64(i + 1),
+			Axis:      AxisTitle,
+			MatchMode: MatchRegex,
+			Value:     fmt.Sprintf(`(?i)\bpattern %d\b`, i),
+			Score:     -1,
+		}
+	}
+	return rules
+}
+
+func benchSubjects(n int) []Subject {
+	subjects := make([]Subject, n)
+	body := strings.Repeat("The article body, of unremarkable length. ", 100)
+	for i := range subjects {
+		subjects[i] = Subject{
+			Title:      fmt.Sprintf("August 9th - 2026 Presidential Politics - Trump Administration Day %d", i),
+			Summary:    "A new daily thread for discussion is being introduced.",
+			Content:    body,
+			Author:     "Sundance",
+			Categories: []string{"Uncategorized"},
+		}
+	}
+	return subjects
+}
+
+// Building the matcher is included deliberately: it is done per request.
+func BenchmarkScorePage(b *testing.B) {
+	for _, pageSize := range []int{50, 150} {
+		b.Run(fmt.Sprintf("50rules/%darticles", pageSize), func(b *testing.B) {
+			rules := benchRules(50)
+			subjects := benchSubjects(pageSize)
+			b.ResetTimer()
+			for b.Loop() {
+				m, err := New(rules)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for _, s := range subjects {
+					m.Score(1, s)
+				}
+			}
+		})
+	}
+}
+
+// The content axis is the expensive one: full bodies rather than titles.
+func BenchmarkScorePageContentAxis(b *testing.B) {
+	rules := benchRules(50)
+	for i := range rules {
+		rules[i].Axis = AxisContent
+	}
+	subjects := benchSubjects(50)
+	b.ResetTimer()
+	for b.Loop() {
+		m, err := New(rules)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, s := range subjects {
+			m.Score(1, s)
+		}
+	}
+}
+
+// How the content axis scales with rule count, which is what decides its quota.
+func BenchmarkContentAxisByRuleCount(b *testing.B) {
+	for _, n := range []int{1, 3, 5, 10, 50} {
+		b.Run(fmt.Sprintf("%drules", n), func(b *testing.B) {
+			rules := benchRules(n)
+			for i := range rules {
+				rules[i].Axis = AxisContent
+			}
+			subjects := benchSubjects(50)
+			b.ResetTimer()
+			for b.Loop() {
+				m, _ := New(rules)
+				for _, s := range subjects {
+					m.Score(1, s)
+				}
+			}
+		})
+	}
+}

--- a/internal/filtermatch/filtermatch.go
+++ b/internal/filtermatch/filtermatch.go
@@ -18,9 +18,10 @@
 // new costume. Materialization is available later as a pure cache if profiling
 // asks for it; it must never become the semantics.
 //
-// The split is enforced from both sides: filterRuleMatch in internal/storage
-// qualifies on match_mode = 'exact', and New drops any rule that belongs to
-// SQL. A rule counted by both would have its score applied twice.
+// The choice is all-or-nothing per user, and New makes it: a nil Matcher means
+// SQL can handle every rule, and a non-nil one takes over the whole set. See
+// New for why splitting them is not an option. A rule counted by both
+// evaluators would have its score applied twice.
 package filtermatch
 
 import (
@@ -228,12 +229,6 @@ func (m *Matcher) Empty() bool { return m == nil || m.count == 0 }
 // tag axes, which live in their own tables and cost an extra query to load. A
 // user whose rules are all on title or summary should not pay for it.
 func (m *Matcher) NeedsMetadata() bool { return m != nil && m.needsMetadata }
-
-// NeedsContent reports whether any rule matches on the article body. Callers
-// that can avoid selecting it should ask first.
-func (m *Matcher) NeedsContent() bool {
-	return m != nil && slices.ContainsFunc(m.axes, func(ax *axisRules) bool { return ax.axis == AxisContent })
-}
 
 // Score returns the summed score of every rule matching this article, and the
 // ids of the rules that fired, in rule order.

--- a/internal/filtermatch/filtermatch.go
+++ b/internal/filtermatch/filtermatch.go
@@ -139,19 +139,33 @@ func compile(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// New builds a Matcher from a user's rules, silently dropping those the SQL
-// matcher owns.
+// New builds a Matcher for a user's rules, or returns nil when SQL can handle
+// all of them.
+//
+// A nil Matcher is the instruction to use the SQL path unchanged, and it is the
+// common case: most users have no pattern rules at all. When even one rule does
+// need Go, the Matcher takes over ALL of that user's rules, including the exact
+// metadata ones SQL could have matched, and the caller must then disable the
+// SQL rule join and the SQL visibility gate.
+//
+// All-or-nothing rather than splitting the work is forced by the visibility
+// gate, which compares the SUM of a user's matching rules against a threshold.
+// A split leaves neither side holding the whole sum: SQL cannot see the pattern
+// rules, and Go would have to be told the SQL subtotal for every row. Doing
+// every rule in one place is both simpler and the only version that is right.
+// The cost is that these users re-evaluate their exact rules in Go, which is a
+// handful of string comparisons.
 //
 // A pattern that does not compile is an error rather than a rule that quietly
 // matches nothing. Rules are validated at save time, so reaching this is a bug
 // or a hand-edited database, and either deserves to be noisy.
 func New(rules []Rule) (*Matcher, error) {
+	if !slices.ContainsFunc(rules, Rule.evaluatedInGo) {
+		return nil, nil
+	}
 	m := &Matcher{}
 	byAxis := make(map[string]*axisRules)
 	for _, r := range rules {
-		if !r.evaluatedInGo() {
-			continue
-		}
 		cr := compiledRule{Rule: r, order: m.count}
 		if r.MatchMode == MatchRegex {
 			re, err := compile(r.Value)
@@ -205,19 +219,20 @@ func (ax *axisRules) buildUnion() {
 	}
 }
 
-// Empty reports whether the matcher holds no rules, in which case callers can
-// skip building Subjects entirely.
-func (m *Matcher) Empty() bool { return m.count == 0 }
+// Empty reports whether there is nothing for this matcher to do. A nil
+// Matcher -- what New returns when SQL can handle every rule -- is empty, so
+// callers can hold one without nil checks at each use.
+func (m *Matcher) Empty() bool { return m == nil || m.count == 0 }
 
 // NeedsMetadata reports whether any rule matches on the author, category or
 // tag axes, which live in their own tables and cost an extra query to load. A
 // user whose rules are all on title or summary should not pay for it.
-func (m *Matcher) NeedsMetadata() bool { return m.needsMetadata }
+func (m *Matcher) NeedsMetadata() bool { return m != nil && m.needsMetadata }
 
 // NeedsContent reports whether any rule matches on the article body. Callers
 // that can avoid selecting it should ask first.
 func (m *Matcher) NeedsContent() bool {
-	return slices.ContainsFunc(m.axes, func(ax *axisRules) bool { return ax.axis == AxisContent })
+	return m != nil && slices.ContainsFunc(m.axes, func(ax *axisRules) bool { return ax.axis == AxisContent })
 }
 
 // Score returns the summed score of every rule matching this article, and the
@@ -227,6 +242,9 @@ func (m *Matcher) NeedsContent() bool {
 // rule matching the same article both apply, which is the same arithmetic the
 // SQL side does with SUM.
 func (m *Matcher) Score(feedID int64, s Subject) (int, []int64) {
+	if m == nil {
+		return 0, nil
+	}
 	var (
 		total int
 		fired []compiledRule

--- a/internal/filtermatch/filtermatch.go
+++ b/internal/filtermatch/filtermatch.go
@@ -1,0 +1,335 @@
+// Package filtermatch evaluates the pattern half of a user's filter rules
+// (#274).
+//
+// Filter rules are split between two evaluators. An exact comparison against a
+// metadata axis is an indexed CITEXT equality and stays in SQL, where it costs
+// nothing. Everything else -- any substring or regex rule, and any rule against
+// the article's own text -- is evaluated here, in Go, against rows the query
+// has already returned.
+//
+// Go rather than Postgres because article text is attacker-supplied. Postgres
+// regex backtracks, so a pattern that is merely careless, run over content a
+// feed controls, is a wedged page load. Go's regexp is RE2: linear in the input
+// with no catastrophic backtracking. The cost that remains is I/O, not CPU.
+//
+// Read time rather than ingest time because a filter rule should take effect
+// when it is saved. Materializing matches would mean a new rule did nothing
+// until the next processing cycle -- the complaint #259 was filed about, in a
+// new costume. Materialization is available later as a pure cache if profiling
+// asks for it; it must never become the semantics.
+//
+// The split is enforced from both sides: filterRuleMatch in internal/storage
+// qualifies on match_mode = 'exact', and New drops any rule that belongs to
+// SQL. A rule counted by both would have its score applied twice.
+package filtermatch
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// Match modes and axes. These mirror the constants in internal/storage; this
+// package deliberately does not import it, so the hot path stays free of the
+// storage layer's dependencies.
+const (
+	MatchExact     = "exact"
+	MatchSubstring = "substring"
+	MatchRegex     = "regex"
+
+	AxisAuthor   = "author"
+	AxisCategory = "category"
+	AxisTag      = "tag"
+	AxisTitle    = "title"
+	AxisSummary  = "summary"
+	AxisContent  = "content"
+)
+
+// Rule is the subset of a filter rule the evaluator needs.
+type Rule struct {
+	ID        int64
+	FeedID    *int64 // nil = applies to every feed
+	Axis      string
+	MatchMode string
+	Value     string
+	Score     int
+}
+
+// evaluatedInGo reports whether this rule belongs to this package rather than
+// to the SQL matcher. Exact matching on a metadata axis is the SQL half; the
+// text axes have no SQL implementation at all, so even an exact rule against
+// one lands here.
+func (r Rule) evaluatedInGo() bool {
+	if r.MatchMode != "" && r.MatchMode != MatchExact {
+		return true
+	}
+	switch r.Axis {
+	case AxisAuthor, AxisCategory, AxisTag:
+		return false
+	default:
+		return true
+	}
+}
+
+// Subject is the article text a rule is matched against.
+//
+// Author and Authors are both present because feeds disagree about where the
+// byline goes: many populate only the free-text field the item carried, others
+// only a structured author element. A pattern rule on the author axis matches
+// either.
+type Subject struct {
+	Title      string
+	Summary    string
+	Content    string
+	Author     string   // the item's free-text author, as published
+	Authors    []string // normalized authors, from article_authors
+	Categories []string // normalized categories and tags, from article_categories
+}
+
+// Matcher holds one user's compiled pattern rules. It is immutable once built
+// and safe for concurrent use.
+//
+// Rules are grouped by axis rather than kept in one list, so each field is
+// read, lowercased and prefiltered once per article instead of once per rule.
+// With rules at the per-user quota that is the difference between a page load
+// the reader notices and one they do not.
+type Matcher struct {
+	axes          []*axisRules
+	count         int
+	needsMetadata bool
+}
+
+type compiledRule struct {
+	Rule
+	order int            // position among this user's rules, for stable reporting
+	re    *regexp.Regexp // nil unless MatchMode is MatchRegex
+}
+
+// axisRules is every rule matching on one axis, plus the shortcuts that let
+// most articles be dismissed without running them individually.
+type axisRules struct {
+	axis string
+	// anyRe is the union of this axis's regex patterns. RE2 matches an
+	// alternation in a single pass, so when it does not match -- the common
+	// case, since filters exist to catch a minority of articles -- every regex
+	// rule on the axis is answered at once. nil when there are none, or when
+	// the union failed to compile, in which case the rules simply run
+	// individually.
+	anyRe        *regexp.Regexp
+	rules        []compiledRule
+	needsLowered bool // some rule here is exact or substring, which compare case-insensitively
+}
+
+// compiledPatterns memoizes compiled expressions across users and requests.
+// Patterns are immutable strings, so there is nothing to invalidate, and the
+// per-user pattern quota bounds how many distinct ones can accumulate.
+var compiledPatterns sync.Map // string -> *regexp.Regexp
+
+func compile(pattern string) (*regexp.Regexp, error) {
+	if v, ok := compiledPatterns.Load(pattern); ok {
+		return v.(*regexp.Regexp), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	compiledPatterns.Store(pattern, re)
+	return re, nil
+}
+
+// New builds a Matcher from a user's rules, silently dropping those the SQL
+// matcher owns.
+//
+// A pattern that does not compile is an error rather than a rule that quietly
+// matches nothing. Rules are validated at save time, so reaching this is a bug
+// or a hand-edited database, and either deserves to be noisy.
+func New(rules []Rule) (*Matcher, error) {
+	m := &Matcher{}
+	byAxis := make(map[string]*axisRules)
+	for _, r := range rules {
+		if !r.evaluatedInGo() {
+			continue
+		}
+		cr := compiledRule{Rule: r, order: m.count}
+		if r.MatchMode == MatchRegex {
+			re, err := compile(r.Value)
+			if err != nil {
+				return nil, fmt.Errorf("filter rule %d: invalid pattern %q: %w", r.ID, r.Value, err)
+			}
+			cr.re = re
+		}
+		if r.Axis == AxisAuthor || r.Axis == AxisCategory || r.Axis == AxisTag {
+			m.needsMetadata = true
+		}
+
+		ax := byAxis[r.Axis]
+		if ax == nil {
+			ax = &axisRules{axis: r.Axis}
+			byAxis[r.Axis] = ax
+			m.axes = append(m.axes, ax)
+		}
+		ax.rules = append(ax.rules, cr)
+		if r.MatchMode != MatchRegex {
+			ax.needsLowered = true
+		}
+		m.count++
+	}
+	for _, ax := range m.axes {
+		ax.buildUnion()
+	}
+	return m, nil
+}
+
+// buildUnion compiles the alternation of this axis's regex patterns. It is a
+// prefilter only: a union match still runs the individual rules, because the
+// caller needs to know WHICH fired. The win is on the articles that match
+// nothing, which is nearly all of them.
+//
+// Skipped below two patterns, where the union is the same work twice. A union
+// that will not compile is not an error -- the individual patterns already
+// compiled, so the rules are correct and only the shortcut is lost.
+func (ax *axisRules) buildUnion() {
+	var patterns []string
+	for _, r := range ax.rules {
+		if r.re != nil {
+			patterns = append(patterns, "(?:"+r.Value+")")
+		}
+	}
+	if len(patterns) < 2 {
+		return
+	}
+	if re, err := compile(strings.Join(patterns, "|")); err == nil {
+		ax.anyRe = re
+	}
+}
+
+// Empty reports whether the matcher holds no rules, in which case callers can
+// skip building Subjects entirely.
+func (m *Matcher) Empty() bool { return m.count == 0 }
+
+// NeedsMetadata reports whether any rule matches on the author, category or
+// tag axes, which live in their own tables and cost an extra query to load. A
+// user whose rules are all on title or summary should not pay for it.
+func (m *Matcher) NeedsMetadata() bool { return m.needsMetadata }
+
+// NeedsContent reports whether any rule matches on the article body. Callers
+// that can avoid selecting it should ask first.
+func (m *Matcher) NeedsContent() bool {
+	return slices.ContainsFunc(m.axes, func(ax *axisRules) bool { return ax.axis == AxisContent })
+}
+
+// Score returns the summed score of every rule matching this article, and the
+// ids of the rules that fired, in rule order.
+//
+// Scores are additive and order-independent: a global rule and a feed-scoped
+// rule matching the same article both apply, which is the same arithmetic the
+// SQL side does with SUM.
+func (m *Matcher) Score(feedID int64, s Subject) (int, []int64) {
+	var (
+		total int
+		fired []compiledRule
+	)
+	for _, ax := range m.axes {
+		total += ax.score(feedID, s, &fired)
+	}
+	if fired == nil {
+		return total, nil
+	}
+	// Report in rule order rather than axis order, so the caller sees the same
+	// sequence the user's rule list has.
+	slices.SortFunc(fired, func(a, b compiledRule) int { return a.order - b.order })
+	ids := make([]int64, len(fired))
+	for i, r := range fired {
+		ids[i] = r.ID
+	}
+	return total, ids
+}
+
+// score evaluates one axis, reading and folding its text once for all of the
+// axis's rules.
+func (ax *axisRules) score(feedID int64, s Subject, fired *[]compiledRule) int {
+	var values []string
+	switch ax.axis {
+	case AxisTitle:
+		values = []string{s.Title}
+	case AxisSummary:
+		values = []string{s.Summary}
+	case AxisContent:
+		values = []string{s.Content}
+	case AxisAuthor:
+		// Both, because feeds disagree about where the byline goes.
+		values = append(append(make([]string, 0, len(s.Authors)+1), s.Author), s.Authors...)
+	case AxisCategory, AxisTag:
+		values = s.Categories
+	default:
+		return 0
+	}
+
+	f := fields{values: values}
+	if ax.needsLowered {
+		f.lowered = make([]string, len(values))
+		for i, v := range values {
+			f.lowered[i] = strings.ToLower(v)
+		}
+	}
+
+	// One alternation pass answers every regex rule on this axis at once when
+	// it fails, which is the usual outcome.
+	skipRegex := ax.anyRe != nil && !f.anyMatches(ax.anyRe)
+
+	total := 0
+	for _, r := range ax.rules {
+		if r.FeedID != nil && *r.FeedID != feedID {
+			continue
+		}
+		if r.re != nil && skipRegex {
+			continue
+		}
+		if r.matches(f) {
+			total += r.Score
+			*fired = append(*fired, r)
+		}
+	}
+	return total
+}
+
+// fields is one axis's text for one article: the values as published, plus a
+// lowercased copy when some rule needs one. Folding a 4KB article body once per
+// axis instead of once per rule is most of why this type exists.
+type fields struct {
+	values  []string
+	lowered []string
+}
+
+func (f fields) anyMatches(re *regexp.Regexp) bool {
+	return slices.ContainsFunc(f.values, re.MatchString)
+}
+
+// matches compares a rule against every value on its axis.
+//
+// Exact and substring are case-insensitive, matching the CITEXT columns the
+// SQL half compares against; a user who writes "open thread" expects it to
+// catch "Open Thread". Regex is left exactly as written, because case is part
+// of what a pattern expresses -- (?i) is how a user asks for the other
+// behaviour, and silently forcing it would take that choice away.
+func (r compiledRule) matches(f fields) bool {
+	if r.MatchMode == MatchRegex {
+		return r.re != nil && f.anyMatches(r.re)
+	}
+	needle := strings.ToLower(r.Value)
+	for i, v := range f.values {
+		if v == "" {
+			continue
+		}
+		if r.MatchMode == MatchSubstring {
+			if strings.Contains(f.lowered[i], needle) {
+				return true
+			}
+		} else if f.lowered[i] == needle { // MatchExact, and "" meaning it
+			return true
+		}
+	}
+	return false
+}

--- a/internal/filtermatch/filtermatch_test.go
+++ b/internal/filtermatch/filtermatch_test.go
@@ -190,7 +190,7 @@ func TestNoMatcherWhenSQLCanHandleEverything(t *testing.T) {
 		t.Fatal("expected a nil matcher: SQL can match all three rules")
 	}
 	// A nil matcher is usable without a nil check.
-	if !m.Empty() || m.NeedsMetadata() || m.NeedsContent() {
+	if !m.Empty() || m.NeedsMetadata() {
 		t.Error("a nil matcher should report empty and need nothing")
 	}
 	if score, fired := m.Score(1, Subject{Author: "Sundance"}); score != 0 || fired != nil {

--- a/internal/filtermatch/filtermatch_test.go
+++ b/internal/filtermatch/filtermatch_test.go
@@ -1,0 +1,268 @@
+package filtermatch
+
+import (
+	"slices"
+	"testing"
+)
+
+func rule(id int64, axis, mode, value string, score int) Rule {
+	return Rule{ID: id, Axis: axis, MatchMode: mode, Value: value, Score: score}
+}
+
+func feedRule(id, feedID int64, axis, mode, value string, score int) Rule {
+	r := rule(id, axis, mode, value, score)
+	r.FeedID = &feedID
+	return r
+}
+
+// The case this whole feature exists for: a feed publishing the same
+// auto-generated post every day under a title whose date changes.
+func TestMatchesRecurringTitles(t *testing.T) {
+	m, err := New([]Rule{
+		rule(1, AxisTitle, MatchRegex, `(?i)\bopen thread\b`, -5),
+		rule(2, AxisTitle, MatchRegex, `(?i)trump administration day \d+`, -5),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for _, tc := range []struct {
+		title string
+		want  int
+	}{
+		{"Sunday August 9th - Open Thread", -5},
+		{"Monday August 10th - Open Thread", -5},
+		{"August 9th - 2026 Presidential Politics - Trump Administration Day 567", -5},
+		{"August 8th - 2026 Presidential Politics - Trump Administration Day 566", -5},
+		{"Senate Votes Overnight to Confirm Todd Blanche as U.S. Attorney General", 0},
+		{"Employers Using J1 Student Visas for Seasonal Work Pay NO Social Security Taxes", 0},
+	} {
+		got, _ := m.Score(1, Subject{Title: tc.title})
+		if got != tc.want {
+			t.Errorf("Score(%q) = %d, want %d", tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestMatchModes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mode    string
+		value   string
+		title   string
+		matches bool
+	}{
+		{"exact matches whole string", MatchExact, "Open Thread", "Open Thread", true},
+		{"exact does not match a substring", MatchExact, "Open Thread", "Sunday - Open Thread", false},
+		{"exact ignores case", MatchExact, "open thread", "Open Thread", true},
+		{"substring matches inside", MatchSubstring, "Open Thread", "Sunday - Open Thread", true},
+		{"substring ignores case", MatchSubstring, "open THREAD", "Sunday - Open Thread", true},
+		{"substring does not match absent text", MatchSubstring, "Open Thread", "Senate Votes", false},
+		{"regex matches", MatchRegex, `Day \d+`, "Administration Day 567", true},
+		{"regex is case sensitive unless told otherwise", MatchRegex, `day \d+`, "Administration Day 567", false},
+		{"regex honours an inline flag", MatchRegex, `(?i)day \d+`, "Administration Day 567", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := New([]Rule{rule(1, AxisTitle, tc.mode, tc.value, -3)})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			score, fired := m.Score(1, Subject{Title: tc.title})
+			if tc.matches && (score != -3 || !slices.Equal(fired, []int64{1})) {
+				t.Errorf("expected a match, got score %d fired %v", score, fired)
+			}
+			if !tc.matches && (score != 0 || len(fired) != 0) {
+				t.Errorf("expected no match, got score %d fired %v", score, fired)
+			}
+		})
+	}
+}
+
+func TestAxes(t *testing.T) {
+	subject := Subject{
+		Title:      "Sunday August 9th - Open Thread",
+		Summary:    "A new daily thread for discussion.",
+		Content:    "<p>Users are encouraged to post anything relating to the topic.</p>",
+		Author:     "Sundance",
+		Authors:    []string{"Sundance", "Guest Contributor"},
+		Categories: []string{"Uncategorized", "Open Threads"},
+	}
+
+	for _, tc := range []struct {
+		axis    string
+		value   string
+		matches bool
+	}{
+		{AxisTitle, "open thread", true},
+		{AxisTitle, "encouraged", false},
+		{AxisSummary, "daily thread", true},
+		{AxisSummary, "open thread", false},
+		{AxisContent, "encouraged to post", true},
+		{AxisContent, "daily thread", false},
+		{AxisAuthor, "sundance", true},
+		{AxisAuthor, "guest contributor", true},
+		{AxisAuthor, "margaret", false},
+		{AxisCategory, "uncategorized", true},
+		{AxisCategory, "open threads", true},
+		{AxisCategory, "security", false},
+		{AxisTag, "uncategorized", true},
+	} {
+		t.Run(tc.axis+"/"+tc.value, func(t *testing.T) {
+			m, err := New([]Rule{rule(1, tc.axis, MatchSubstring, tc.value, -2)})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			score, _ := m.Score(1, subject)
+			if got := score != 0; got != tc.matches {
+				t.Errorf("axis %s value %q: matched=%v, want %v", tc.axis, tc.value, got, tc.matches)
+			}
+		})
+	}
+}
+
+// The author axis reaches both the normalized names and the feed's free-text
+// author field, because plenty of feeds populate only the latter. Exact-mode
+// rules, matched in SQL, see only the normalized table -- a difference the UI
+// has to be honest about.
+func TestAuthorAxisReachesFreeTextAuthor(t *testing.T) {
+	m, err := New([]Rule{rule(1, AxisAuthor, MatchRegex, `^Sundance$`, -4)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	score, _ := m.Score(1, Subject{Author: "Sundance"})
+	if score != -4 {
+		t.Errorf("free-text author: score = %d, want -4", score)
+	}
+	score, _ = m.Score(1, Subject{Authors: []string{"Sundance"}})
+	if score != -4 {
+		t.Errorf("normalized author: score = %d, want -4", score)
+	}
+}
+
+// Scores are additive, and a global rule and a feed-scoped rule matching the
+// same article both apply.
+func TestScoresAreAdditive(t *testing.T) {
+	m, err := New([]Rule{
+		rule(1, AxisTitle, MatchSubstring, "open thread", -3),
+		feedRule(2, 7, AxisTitle, MatchSubstring, "sunday", -2),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	score, fired := m.Score(7, Subject{Title: "Sunday - Open Thread"})
+	if score != -5 {
+		t.Errorf("score = %d, want -5", score)
+	}
+	if !slices.Equal(fired, []int64{1, 2}) {
+		t.Errorf("fired = %v, want [1 2]", fired)
+	}
+}
+
+// A feed-scoped rule must not touch another feed's articles.
+func TestFeedScoping(t *testing.T) {
+	m, err := New([]Rule{feedRule(1, 7, AxisTitle, MatchSubstring, "open thread", -3)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if score, _ := m.Score(7, Subject{Title: "Open Thread"}); score != -3 {
+		t.Errorf("own feed: score = %d, want -3", score)
+	}
+	if score, _ := m.Score(8, Subject{Title: "Open Thread"}); score != 0 {
+		t.Errorf("other feed: score = %d, want 0", score)
+	}
+}
+
+// Exact rules on the metadata axes are matched in SQL. Handing them to the
+// evaluator as well would count them twice.
+func TestSQLEvaluatedRulesAreIgnored(t *testing.T) {
+	m, err := New([]Rule{
+		rule(1, AxisAuthor, MatchExact, "Sundance", -5),
+		rule(2, AxisCategory, MatchExact, "Uncategorized", -5),
+		rule(3, AxisTag, MatchExact, "Uncategorized", -5),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !m.Empty() {
+		t.Error("matcher should hold no rules: all three belong to the SQL path")
+	}
+
+	score, fired := m.Score(1, Subject{Author: "Sundance", Categories: []string{"Uncategorized"}})
+	if score != 0 || len(fired) != 0 {
+		t.Errorf("score = %d fired = %v, want 0 and none", score, fired)
+	}
+}
+
+// Exact mode on a TEXT axis has no SQL implementation, so it does belong here.
+func TestExactOnTextAxisIsEvaluatedHere(t *testing.T) {
+	m, err := New([]Rule{rule(1, AxisTitle, MatchExact, "Open Thread", -5)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if m.Empty() {
+		t.Fatal("exact-mode title rule should be evaluated in Go")
+	}
+	if score, _ := m.Score(1, Subject{Title: "Open Thread"}); score != -5 {
+		t.Errorf("score = %d, want -5", score)
+	}
+}
+
+func TestNewRejectsUncompilablePattern(t *testing.T) {
+	if _, err := New([]Rule{rule(1, AxisTitle, MatchRegex, `(unclosed`, -1)}); err == nil {
+		t.Fatal("expected New to reject an uncompilable pattern")
+	}
+}
+
+func TestEmptyMatcher(t *testing.T) {
+	m, err := New(nil)
+	if err != nil {
+		t.Fatalf("New(nil): %v", err)
+	}
+	if !m.Empty() {
+		t.Error("a matcher with no rules should report Empty")
+	}
+	if score, fired := m.Score(1, Subject{Title: "anything"}); score != 0 || fired != nil {
+		t.Errorf("score = %d fired = %v, want 0 and nil", score, fired)
+	}
+}
+
+// The evaluator reads article text supplied by a feed. It must be safe against
+// whatever a feed puts there.
+func TestHostileInput(t *testing.T) {
+	m, err := New([]Rule{rule(1, AxisContent, MatchRegex, `(a+)+b`, -1)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// A pattern that would backtrack catastrophically under a PCRE engine. RE2
+	// runs it in linear time; if this ever hangs, the engine has been swapped.
+	long := make([]byte, 40000)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if score, _ := m.Score(1, Subject{Content: string(long)}); score != 0 {
+		t.Errorf("score = %d, want 0", score)
+	}
+}
+
+// Which axes a user's rules actually reference decides how much per-article
+// data has to be assembled for them. A user with no metadata pattern rules
+// should not cause authors and categories to be fetched.
+func TestNeedsMetadata(t *testing.T) {
+	textOnly, _ := New([]Rule{rule(1, AxisTitle, MatchRegex, `x`, -1)})
+	if textOnly.NeedsMetadata() {
+		t.Error("title-only rules should not require author/category lookups")
+	}
+
+	withCategory, _ := New([]Rule{rule(1, AxisCategory, MatchSubstring, "x", -1)})
+	if !withCategory.NeedsMetadata() {
+		t.Error("a category pattern rule requires the normalized categories")
+	}
+
+	withAuthor, _ := New([]Rule{rule(1, AxisAuthor, MatchSubstring, "x", -1)})
+	if !withAuthor.NeedsMetadata() {
+		t.Error("an author pattern rule requires the normalized authors")
+	}
+}

--- a/internal/filtermatch/filtermatch_test.go
+++ b/internal/filtermatch/filtermatch_test.go
@@ -175,9 +175,9 @@ func TestFeedScoping(t *testing.T) {
 	}
 }
 
-// Exact rules on the metadata axes are matched in SQL. Handing them to the
-// evaluator as well would count them twice.
-func TestSQLEvaluatedRulesAreIgnored(t *testing.T) {
+// A user whose rules are all exact metadata matches keeps the SQL path
+// untouched, which is the common case and must stay free.
+func TestNoMatcherWhenSQLCanHandleEverything(t *testing.T) {
 	m, err := New([]Rule{
 		rule(1, AxisAuthor, MatchExact, "Sundance", -5),
 		rule(2, AxisCategory, MatchExact, "Uncategorized", -5),
@@ -186,13 +186,44 @@ func TestSQLEvaluatedRulesAreIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if !m.Empty() {
-		t.Error("matcher should hold no rules: all three belong to the SQL path")
+	if m != nil {
+		t.Fatal("expected a nil matcher: SQL can match all three rules")
+	}
+	// A nil matcher is usable without a nil check.
+	if !m.Empty() || m.NeedsMetadata() || m.NeedsContent() {
+		t.Error("a nil matcher should report empty and need nothing")
+	}
+	if score, fired := m.Score(1, Subject{Author: "Sundance"}); score != 0 || fired != nil {
+		t.Errorf("nil matcher scored %d %v, want 0 and nil", score, fired)
+	}
+}
+
+// Once ANY rule needs Go, the matcher takes over all of them -- including the
+// exact metadata rules SQL could have matched. Splitting the rule set would
+// leave neither evaluator holding the whole sum the visibility gate compares
+// against. The caller's side of that bargain is disabling the SQL rule join;
+// if it does not, these rules are counted twice.
+func TestOnePatternRuleTakesOverTheWholeSet(t *testing.T) {
+	m, err := New([]Rule{
+		rule(1, AxisAuthor, MatchExact, "Sundance", -5),
+		rule(2, AxisTitle, MatchRegex, `(?i)open thread`, -3),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if m.Empty() {
+		t.Fatal("expected a matcher")
+	}
+	if !m.NeedsMetadata() {
+		t.Error("the exact author rule came along, so authors must be loaded for it")
 	}
 
-	score, fired := m.Score(1, Subject{Author: "Sundance", Categories: []string{"Uncategorized"}})
-	if score != 0 || len(fired) != 0 {
-		t.Errorf("score = %d fired = %v, want 0 and none", score, fired)
+	score, fired := m.Score(1, Subject{Author: "Sundance", Title: "Sunday - Open Thread"})
+	if score != -8 {
+		t.Errorf("score = %d, want -8 (both rules)", score)
+	}
+	if !slices.Equal(fired, []int64{1, 2}) {
+		t.Errorf("fired = %v, want [1 2]", fired)
 	}
 }
 

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -62,7 +62,11 @@ type Config struct {
 	Limits struct {
 		MaxFeedsPerUser       int `toml:"max_feeds_per_user"`
 		MaxFilterRulesPerUser int `toml:"max_filter_rules_per_user"`
-		MaxNewslettersPerUser int `toml:"max_newsletters_per_user"`
+		// Pattern rules (substring or regex) are evaluated in Go against every
+		// candidate row on every listing query, so they are metered far more
+		// tightly than exact rules, which are an indexed equality in SQL.
+		MaxPatternFilterRulesPerUser int `toml:"max_pattern_filter_rules_per_user"`
+		MaxNewslettersPerUser        int `toml:"max_newsletters_per_user"`
 	} `toml:"limits"`
 
 	Preferences struct {
@@ -196,6 +200,7 @@ func DefaultConfig() *Config {
 	cfg.Thresholds.SecurityBorderlineThreat = 6.0
 	cfg.Limits.MaxFeedsPerUser = 1000
 	cfg.Limits.MaxFilterRulesPerUser = 1000
+	cfg.Limits.MaxPatternFilterRulesPerUser = 50
 	cfg.Limits.MaxNewslettersPerUser = 50
 	// Default temperatures (can be overridden in config)
 	cfg.Temperatures.Security = 0.3

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -71,7 +71,15 @@ type Config struct {
 		// per rule per 50-article page (internal/filtermatch benchmarks), so
 		// the default of 5 buys about 10ms and 50 would buy 90ms.
 		MaxContentFilterRulesPerUser int `toml:"max_content_filter_rules_per_user"`
-		MaxNewslettersPerUser        int `toml:"max_newsletters_per_user"`
+		// Pattern rules hide rows after the query returns, so a page of N
+		// articles has to fetch more than N to stand a chance of filling.
+		// Bounded rather than looped until full: a short page is a small
+		// annoyance, an unbounded fetch on every page load is not.
+		FilterOverfetchFactor int `toml:"filter_overfetch_factor"`
+		// Hard ceiling on rows examined for one filtered page, whatever the
+		// over-fetch factor works out to.
+		FilterMaxScan         int `toml:"filter_max_scan"`
+		MaxNewslettersPerUser int `toml:"max_newsletters_per_user"`
 	} `toml:"limits"`
 
 	Preferences struct {
@@ -207,6 +215,8 @@ func DefaultConfig() *Config {
 	cfg.Limits.MaxFilterRulesPerUser = 1000
 	cfg.Limits.MaxPatternFilterRulesPerUser = 50
 	cfg.Limits.MaxContentFilterRulesPerUser = 5
+	cfg.Limits.FilterOverfetchFactor = 3
+	cfg.Limits.FilterMaxScan = 2000
 	cfg.Limits.MaxNewslettersPerUser = 50
 	// Default temperatures (can be overridden in config)
 	cfg.Temperatures.Security = 0.3

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -66,6 +66,11 @@ type Config struct {
 		// candidate row on every listing query, so they are metered far more
 		// tightly than exact rules, which are an indexed equality in SQL.
 		MaxPatternFilterRulesPerUser int `toml:"max_pattern_filter_rules_per_user"`
+		// Pattern rules on the content axis are metered tighter still: they
+		// scan full article bodies rather than titles. Measured at roughly 2ms
+		// per rule per 50-article page (internal/filtermatch benchmarks), so
+		// the default of 5 buys about 10ms and 50 would buy 90ms.
+		MaxContentFilterRulesPerUser int `toml:"max_content_filter_rules_per_user"`
 		MaxNewslettersPerUser        int `toml:"max_newsletters_per_user"`
 	} `toml:"limits"`
 
@@ -201,6 +206,7 @@ func DefaultConfig() *Config {
 	cfg.Limits.MaxFeedsPerUser = 1000
 	cfg.Limits.MaxFilterRulesPerUser = 1000
 	cfg.Limits.MaxPatternFilterRulesPerUser = 50
+	cfg.Limits.MaxContentFilterRulesPerUser = 5
 	cfg.Limits.MaxNewslettersPerUser = 50
 	// Default temperatures (can be overridden in config)
 	cfg.Temperatures.Security = 0.3

--- a/internal/storage/db/filter.sql.go
+++ b/internal/storage/db/filter.sql.go
@@ -10,17 +10,18 @@ import (
 )
 
 const addFilterRule = `-- name: AddFilterRule :one
-INSERT INTO filter_rules (user_id, feed_id, axis, value, score)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO filter_rules (user_id, feed_id, axis, match_mode, value, score)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id
 `
 
 type AddFilterRuleParams struct {
-	UserID int64
-	FeedID *int64
-	Axis   string
-	Value  string
-	Score  int64
+	UserID    int64
+	FeedID    *int64
+	Axis      string
+	MatchMode string
+	Value     string
+	Score     int64
 }
 
 func (q *Queries) AddFilterRule(ctx context.Context, arg AddFilterRuleParams) (int64, error) {
@@ -28,6 +29,7 @@ func (q *Queries) AddFilterRule(ctx context.Context, arg AddFilterRuleParams) (i
 		arg.UserID,
 		arg.FeedID,
 		arg.Axis,
+		arg.MatchMode,
 		arg.Value,
 		arg.Score,
 	)
@@ -54,7 +56,7 @@ func (q *Queries) DeleteFilterRule(ctx context.Context, arg DeleteFilterRulePara
 }
 
 const getFilterRules = `-- name: GetFilterRules :many
-SELECT id, user_id, feed_id, axis, value, score, created_at FROM filter_rules
+SELECT id, user_id, feed_id, axis, value, score, created_at, match_mode FROM filter_rules
 WHERE user_id = $1
   AND ($2::bigint IS NULL OR feed_id IS NULL OR feed_id = $2)
 ORDER BY axis, value
@@ -84,6 +86,7 @@ func (q *Queries) GetFilterRules(ctx context.Context, arg GetFilterRulesParams) 
 			&i.Value,
 			&i.Score,
 			&i.CreatedAt,
+			&i.MatchMode,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/storage/db/metadata.sql.go
+++ b/internal/storage/db/metadata.sql.go
@@ -38,6 +38,40 @@ func (q *Queries) GetArticleAuthors(ctx context.Context, articleID int64) ([]Get
 	return items, nil
 }
 
+const getArticleAuthorsBatch = `-- name: GetArticleAuthorsBatch :many
+SELECT article_id, name FROM article_authors
+WHERE article_id = ANY($1::bigint[])
+ORDER BY article_id, name
+`
+
+type GetArticleAuthorsBatchRow struct {
+	ArticleID int64
+	Name      string
+}
+
+// Authors for a page of articles in one round trip. The per-article query above
+// is an N+1 when a listing path needs metadata for every row it is about to
+// score (#274).
+func (q *Queries) GetArticleAuthorsBatch(ctx context.Context, articleIds []int64) ([]GetArticleAuthorsBatchRow, error) {
+	rows, err := q.db.Query(ctx, getArticleAuthorsBatch, articleIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetArticleAuthorsBatchRow{}
+	for rows.Next() {
+		var i GetArticleAuthorsBatchRow
+		if err := rows.Scan(&i.ArticleID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getArticleCategories = `-- name: GetArticleCategories :many
 SELECT category FROM article_categories WHERE article_id = $1 ORDER BY category
 `
@@ -55,6 +89,32 @@ func (q *Queries) GetArticleCategories(ctx context.Context, articleID int64) ([]
 			return nil, err
 		}
 		items = append(items, category)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getArticleCategoriesBatch = `-- name: GetArticleCategoriesBatch :many
+SELECT article_id, category FROM article_categories
+WHERE article_id = ANY($1::bigint[])
+ORDER BY article_id, category
+`
+
+func (q *Queries) GetArticleCategoriesBatch(ctx context.Context, articleIds []int64) ([]ArticleCategory, error) {
+	rows, err := q.db.Query(ctx, getArticleCategoriesBatch, articleIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ArticleCategory{}
+	for rows.Next() {
+		var i ArticleCategory
+		if err := rows.Scan(&i.ArticleID, &i.Category); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/storage/db/models.go
+++ b/internal/storage/db/models.go
@@ -211,6 +211,7 @@ type FilterRule struct {
 	Value     string
 	Score     int64
 	CreatedAt time.Time
+	MatchMode string
 }
 
 type GroupSummary struct {

--- a/internal/storage/db/queries/filter.sql
+++ b/internal/storage/db/queries/filter.sql
@@ -1,6 +1,6 @@
 -- name: AddFilterRule :one
-INSERT INTO filter_rules (user_id, feed_id, axis, value, score)
-VALUES (@user_id, @feed_id, @axis, @value, @score)
+INSERT INTO filter_rules (user_id, feed_id, axis, match_mode, value, score)
+VALUES (@user_id, @feed_id, @axis, @match_mode, @value, @score)
 RETURNING id;
 
 -- name: GetFilterRules :many

--- a/internal/storage/db/queries/metadata.sql
+++ b/internal/storage/db/queries/metadata.sql
@@ -25,3 +25,16 @@ SELECT DISTINCT ac.category FROM article_categories ac
 JOIN articles a ON a.id = ac.article_id
 WHERE a.feed_id = @feed_id
 ORDER BY ac.category;
+
+-- name: GetArticleAuthorsBatch :many
+-- Authors for a page of articles in one round trip. The per-article query above
+-- is an N+1 when a listing path needs metadata for every row it is about to
+-- score (#274).
+SELECT article_id, name FROM article_authors
+WHERE article_id = ANY(@article_ids::bigint[])
+ORDER BY article_id, name;
+
+-- name: GetArticleCategoriesBatch :many
+SELECT article_id, category FROM article_categories
+WHERE article_id = ANY(@article_ids::bigint[])
+ORDER BY article_id, category;

--- a/internal/storage/filterpattern_test.go
+++ b/internal/storage/filterpattern_test.go
@@ -1,0 +1,142 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+// Pattern matching for filter rules (#274). These tests cover the schema half:
+// what the table will now accept and store. The evaluation half is in Go, above
+// the storage layer, and is tested there.
+
+// Every rule that existed before #274 was an exact match, and none of them were
+// rewritten by the migration. The default has to carry that meaning forward, or
+// the upgrade silently changes what those rules do.
+func TestFilterRuleMatchModeDefaultsToExact(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	if _, err := store.AddFilterRule(&FilterRule{UserID: 1, Axis: "author", Value: "Alice", Score: 5}); err != nil {
+		t.Fatalf("AddFilterRule: %v", err)
+	}
+
+	rules, err := store.GetFilterRules(1, nil)
+	if err != nil {
+		t.Fatalf("GetFilterRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	if rules[0].MatchMode != MatchExact {
+		t.Errorf("match mode = %q, want %q", rules[0].MatchMode, MatchExact)
+	}
+}
+
+func TestFilterRulePatternModesRoundTrip(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	for _, tc := range []struct {
+		axis  string
+		mode  string
+		value string
+	}{
+		{"title", MatchRegex, `(?i)\bopen thread\b`},
+		{"title", MatchSubstring, "Open Thread"},
+		{"summary", MatchRegex, `day \d+`},
+		{"content", MatchSubstring, "sponsored post"},
+		{"author", MatchRegex, `^Sundance$`},
+		{"category", MatchSubstring, "uncategor"},
+		{"tag", MatchRegex, `sec(urity)?`},
+	} {
+		t.Run(tc.axis+"/"+tc.mode, func(t *testing.T) {
+			id, err := store.AddFilterRule(&FilterRule{
+				UserID:    1,
+				Axis:      tc.axis,
+				MatchMode: tc.mode,
+				Value:     tc.value,
+				Score:     -5,
+			})
+			if err != nil {
+				t.Fatalf("AddFilterRule: %v", err)
+			}
+
+			rules, err := store.GetFilterRules(1, nil)
+			if err != nil {
+				t.Fatalf("GetFilterRules: %v", err)
+			}
+			var got *FilterRule
+			for i := range rules {
+				if rules[i].ID == id {
+					got = &rules[i]
+				}
+			}
+			if got == nil {
+				t.Fatalf("rule %d not returned", id)
+			}
+			if got.Axis != tc.axis || got.MatchMode != tc.mode || got.Value != tc.value {
+				t.Errorf("round trip: axis=%q mode=%q value=%q, want %q/%q/%q",
+					got.Axis, got.MatchMode, got.Value, tc.axis, tc.mode, tc.value)
+			}
+		})
+	}
+}
+
+// A substring rule for "open thread" and a regex rule for the same string are
+// different rules, so match_mode has to be part of the uniqueness key. Before
+// #274 the key was (user, feed, axis, value) and the second insert would have
+// been rejected as a duplicate.
+func TestFilterRuleUniquePerMatchMode(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	base := func(mode string) *FilterRule {
+		return &FilterRule{UserID: 1, Axis: "title", MatchMode: mode, Value: "open thread", Score: -3}
+	}
+
+	for _, mode := range []string{MatchExact, MatchSubstring, MatchRegex} {
+		if _, err := store.AddFilterRule(base(mode)); err != nil {
+			t.Fatalf("AddFilterRule(%s): %v", mode, err)
+		}
+	}
+
+	// Same mode twice is still a duplicate.
+	if _, err := store.AddFilterRule(base(MatchRegex)); err == nil {
+		t.Error("expected duplicate error for a second regex rule with the same axis and value")
+	}
+}
+
+func TestFilterRuleRejectsUnknownMatchMode(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	_, err := store.AddFilterRule(&FilterRule{
+		UserID: 1, Axis: "title", MatchMode: "glob", Value: "x*", Score: 1,
+	})
+	if err == nil {
+		t.Fatal("expected the match_mode CHECK constraint to reject 'glob'")
+	}
+}
+
+func TestFilterRuleRejectsUnknownAxis(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	_, err := store.AddFilterRule(&FilterRule{
+		UserID: 1, Axis: "byline", MatchMode: MatchExact, Value: "x", Score: 1,
+	})
+	if err == nil {
+		t.Fatal("expected the axis CHECK constraint to reject 'byline'")
+	}
+}
+
+// The SQL matcher and the Go evaluator partition the rule set between them:
+// SQL takes exact matches on the metadata axes, Go takes everything else. If
+// the SQL side stopped filtering on match_mode it would also match the pattern
+// rules -- as exact comparisons, wrongly -- and every such rule would be
+// counted twice in the effective score.
+func TestSQLMatcherIsLimitedToExactMode(t *testing.T) {
+	if !strings.Contains(filterRuleMatch("?"), "fr.match_mode = 'exact'") {
+		t.Error("the SQL matcher no longer restricts itself to exact-mode rules; pattern rules will be double counted")
+	}
+}

--- a/internal/storage/filterscore.go
+++ b/internal/storage/filterscore.go
@@ -28,8 +28,15 @@ package storage
 // "?" for the fragment-assembled queries that pass through rebindNumeric, "$1"
 // for the hand-numbered feedback insert. It is always a compile-time literal
 // chosen by this package; no caller data reaches it.
+// Since #274 it covers only half the rule set. A rule is matched here when it
+// is an exact comparison against a metadata axis; pattern rules and the text
+// axes are evaluated in Go at read time, above the storage layer. The
+// match_mode qualifier below is what keeps the two halves disjoint -- without
+// it this predicate would also match every pattern rule, comparing it as an
+// equality, and the effective score would count those rules twice.
 func filterRuleMatch(userIDParam string) string {
 	return `fr.user_id = ` + userIDParam + `
+		  AND fr.match_mode = 'exact'
 		  AND (fr.feed_id IS NULL OR fr.feed_id = a.feed_id)
 		  AND (
 			(fr.axis = 'author' AND EXISTS (

--- a/internal/storage/filterscore.go
+++ b/internal/storage/filterscore.go
@@ -1,5 +1,7 @@
 package storage
 
+import "time"
+
 // Filter rules applied to the interest score (#259).
 //
 // Filter rules have always had one consumer: a visibility gate that hides an
@@ -28,6 +30,7 @@ package storage
 // "?" for the fragment-assembled queries that pass through rebindNumeric, "$1"
 // for the hand-numbered feedback insert. It is always a compile-time literal
 // chosen by this package; no caller data reaches it.
+//
 // Since #274 it covers only half the rule set. A rule is matched here when it
 // is an exact comparison against a metadata axis; pattern rules and the text
 // axes are evaluated in Go at read time, above the storage layer. The
@@ -94,6 +97,28 @@ func effectiveScoreExpr(applyRules bool) string {
 		return `COALESCE(rs.interest_score, 0)`
 	}
 	return `LEAST(10.0, GREATEST(0.0, COALESCE(rs.interest_score, 0) + frs.rule_score))`
+}
+
+// recencyDecaySQL is the multiplier that ranks a fresh article above a stale
+// one of the same score. It expects articles aliased as `a`.
+//
+// RecencyDecay below is its Go twin, for the read-time evaluator that ranks in
+// Go instead. A test asserts the two agree; if this expression changes, that
+// function has to change with it.
+const recencyDecaySQL = `(1.0 / (1.0 + GREATEST(0, EXTRACT(epoch FROM (NOW() - COALESCE(a.published_date, a.fetched_date))) / 86400.0) * 0.1))`
+
+// RecencyDecay is recencyDecaySQL evaluated in Go, for callers that rank
+// rule-adjusted scores after the query rather than inside it (#274).
+func RecencyDecay(published *time.Time, fetched, now time.Time) float64 {
+	ts := fetched
+	if published != nil {
+		ts = *published
+	}
+	days := now.Sub(ts).Seconds() / 86400.0
+	if days < 0 {
+		days = 0
+	}
+	return 1.0 / (1.0 + days*0.1)
 }
 
 // effectiveMembershipPredicate is the "is this interesting enough" test, up to

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -42,8 +42,8 @@ func TestMigrationsBuildAndAreIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT max(version_id) FROM goose_db_version").Scan(&maxVersion); err != nil {
 		t.Fatalf("read goose version: %v", err)
 	}
-	if maxVersion != 13 {
-		t.Errorf("goose max version = %d, want 13", maxVersion)
+	if maxVersion != 14 {
+		t.Errorf("goose max version = %d, want 14", maxVersion)
 	}
 
 	// 0003 must leave the embedding columns as pgvector vectors, not BYTEA.

--- a/internal/storage/migrations/0014_filter_rule_pattern_matching.sql
+++ b/internal/storage/migrations/0014_filter_rule_pattern_matching.sql
@@ -1,0 +1,71 @@
+-- +goose Up
+--
+-- Pattern matching for filter rules (#274).
+--
+-- Two additions. New axes -- title, summary, content -- reach the article's own
+-- text, which no rule could match before: every axis was a lookup against
+-- normalized metadata. And match_mode says HOW value is compared, where the
+-- only comparison until now was equality.
+--
+-- The motivating case is a feed that publishes the same two auto-generated
+-- posts daily ("Sunday August 9th - Open Thread"). Every post on it shares one
+-- author and carries no distinguishing category, so the metadata axes cannot
+-- separate the boilerplate from the articles. The title can, and only a pattern
+-- can match a title whose date changes every day.
+--
+-- match_mode defaults to 'exact' so the migration does not rewrite the meaning
+-- of any rule that already exists. Nothing here backfills, and nothing needs
+-- reprocessing: matching stays a read-time operation.
+--
+-- WHERE a rule is evaluated follows from the (axis, match_mode) pair, and the
+-- split is exhaustive and non-overlapping:
+--
+--   exact + author/category/tag  -> SQL, as before (filterRuleMatch)
+--   everything else              -> Go, at read time
+--
+-- Go rather than Postgres for the pattern half because Postgres regex
+-- backtracks, and article text is attacker-supplied: a pattern that is merely
+-- careless, over content a feed controls, is a wedged page load. Go's regexp is
+-- RE2 and runs in time linear in the input. The two sets not overlapping is
+-- what keeps a rule from being counted twice in the effective score.
+
+ALTER TABLE filter_rules DROP CONSTRAINT IF EXISTS filter_rules_axis_check;
+ALTER TABLE filter_rules ADD CONSTRAINT filter_rules_axis_check
+    CHECK (axis IN ('author', 'category', 'tag', 'title', 'summary', 'content'));
+
+ALTER TABLE filter_rules ADD COLUMN IF NOT EXISTS match_mode TEXT NOT NULL DEFAULT 'exact'
+    CONSTRAINT filter_rules_match_mode_check CHECK (match_mode IN ('exact', 'substring', 'regex'));
+
+-- A substring rule for "open thread" and a regex rule for the same string are
+-- different rules. Without match_mode in the key the second is rejected as a
+-- duplicate of the first.
+DROP INDEX IF EXISTS idx_filter_rules_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_filter_rules_unique
+    ON filter_rules(user_id, COALESCE(feed_id, -1), axis, match_mode, value);
+
+-- The SQL matcher now qualifies on match_mode, so the covering index carries it.
+DROP INDEX IF EXISTS idx_filter_rules_lookup;
+CREATE INDEX IF NOT EXISTS idx_filter_rules_lookup
+    ON filter_rules(user_id, axis, match_mode, value);
+
+-- +goose Down
+--
+-- Rules the old schema cannot represent are dropped, not coerced. Rewriting a
+-- regex into an exact match would leave the user a rule that silently matches
+-- nothing, which is worse than its absence.
+DELETE FROM filter_rules
+    WHERE match_mode <> 'exact' OR axis NOT IN ('author', 'category', 'tag');
+
+DROP INDEX IF EXISTS idx_filter_rules_unique;
+DROP INDEX IF EXISTS idx_filter_rules_lookup;
+
+ALTER TABLE filter_rules DROP COLUMN IF EXISTS match_mode;
+
+ALTER TABLE filter_rules DROP CONSTRAINT IF EXISTS filter_rules_axis_check;
+ALTER TABLE filter_rules ADD CONSTRAINT filter_rules_axis_check
+    CHECK (axis IN ('author', 'category', 'tag'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_filter_rules_unique
+    ON filter_rules(user_id, COALESCE(feed_id, -1), axis, value);
+CREATE INDEX IF NOT EXISTS idx_filter_rules_lookup
+    ON filter_rules(user_id, axis, value);

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1251,12 +1251,17 @@ func (s *PostgresStore) GetFeedCategories(feedID int64) ([]string, error) {
 // --- Filter rules ---
 
 func (s *PostgresStore) AddFilterRule(rule *FilterRule) (int64, error) {
+	mode := rule.MatchMode
+	if mode == "" {
+		mode = MatchExact
+	}
 	id, err := s.q.AddFilterRule(context.Background(), db.AddFilterRuleParams{
-		UserID: rule.UserID,
-		FeedID: rule.FeedID,
-		Axis:   rule.Axis,
-		Value:  rule.Value,
-		Score:  int64(rule.Score),
+		UserID:    rule.UserID,
+		FeedID:    rule.FeedID,
+		Axis:      rule.Axis,
+		MatchMode: mode,
+		Value:     rule.Value,
+		Score:     int64(rule.Score),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("add filter rule: %w", err)
@@ -1279,6 +1284,7 @@ func (s *PostgresStore) GetFilterRules(userID int64, feedID *int64) ([]FilterRul
 			UserID:    r.UserID,
 			FeedID:    r.FeedID,
 			Axis:      r.Axis,
+			MatchMode: r.MatchMode,
 			Value:     r.Value,
 			Score:     int(r.Score),
 			CreatedAt: r.CreatedAt,

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -776,7 +776,7 @@ func buildInterestScoreQuery(applyRules bool, filterSQL string) string {
 	return `
 		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
 		       a.author, a.published_date, a.fetched_date,
-		       ` + effectiveScoreExpr(applyRules) + ` * (1.0 / (1.0 + GREATEST(0, EXTRACT(epoch FROM (NOW() - COALESCE(a.published_date, a.fetched_date))) / 86400.0) * 0.1)) AS decayed_score
+		       ` + effectiveScoreExpr(applyRules) + ` * ` + recencyDecaySQL + ` AS decayed_score
 		FROM articles a
 		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = ?` +
 		ruleScoreJoin(applyRules, "?") + `
@@ -784,6 +784,57 @@ func buildInterestScoreQuery(applyRules bool, filterSQL string) string {
 		` + filterSQL + `
 		ORDER BY decayed_score DESC
 		LIMIT ? OFFSET ?`
+}
+
+// GetScoredUnreadArticles returns unread articles curation has scored, with
+// their RAW interest scores -- no rule adjustment, no clamping, no decay.
+//
+// It exists for the read-time evaluator (#274). A caller that computes a
+// user's rule scores in Go needs the unadjusted number to add them to: the
+// decayed, clamped score the ranking query returns cannot be unwound, because
+// clamping is not invertible.
+//
+// Rows come back ordered by decayed raw score, which is the ranking the reader
+// would see with no rules at all. That makes the window the caller takes a
+// reasonable candidate set, though not a perfect one: a low-scoring article
+// that some rule boosts hard could sit past the end of it.
+func (s *PostgresStore) GetScoredUnreadArticles(userID int64, limit int) ([]Article, []float64, error) {
+	const query = `
+		SELECT a.id, a.feed_id, a.guid, a.title, a.url, a.content, a.summary,
+		       a.author, a.published_date, a.fetched_date, rs.interest_score
+		FROM articles a
+		JOIN read_state rs ON a.id = rs.article_id AND rs.user_id = $1
+		WHERE rs.interest_score IS NOT NULL AND rs.read = FALSE
+		ORDER BY rs.interest_score * ` + recencyDecaySQL + ` DESC
+		LIMIT $2`
+
+	rows, err := s.pool.Query(context.Background(), query, userID, limit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get scored unread articles: %w", err)
+	}
+	defer rows.Close()
+
+	var (
+		articles []Article
+		scores   []float64
+	)
+	for rows.Next() {
+		var (
+			id, feedID               int64
+			guid, title, url         string
+			content, summary, author *string
+			published                *time.Time
+			fetched                  time.Time
+			score                    float64
+		)
+		if err := rows.Scan(&id, &feedID, &guid, &title, &url,
+			&content, &summary, &author, &published, &fetched, &score); err != nil {
+			return nil, nil, fmt.Errorf("scan scored article: %w", err)
+		}
+		articles = append(articles, coreArticle(id, feedID, guid, title, url, content, summary, author, published, fetched))
+		scores = append(scores, score)
+	}
+	return articles, scores, rows.Err()
 }
 
 func (s *PostgresStore) GetArticlesByInterestScore(userID int64, threshold float64, limit, offset int, filterThreshold *int, applyRules bool) ([]Article, []float64, error) {

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1230,6 +1230,38 @@ func (s *PostgresStore) GetArticleCategories(articleID int64) ([]string, error) 
 	return cats, nil
 }
 
+// GetArticleMetadataBatch returns the normalized authors and categories for a
+// page of articles, keyed by article id.
+//
+// Two round trips for a whole page, rather than the two per article the
+// singular getters above would cost. Pattern filter rules on the author,
+// category or tag axes need this for every row they score (#274); rules that
+// only touch the article's own text do not, and callers should not ask.
+func (s *PostgresStore) GetArticleMetadataBatch(articleIDs []int64) (map[int64][]string, map[int64][]string, error) {
+	authors := make(map[int64][]string, len(articleIDs))
+	categories := make(map[int64][]string, len(articleIDs))
+	if len(articleIDs) == 0 {
+		return authors, categories, nil
+	}
+
+	authorRows, err := s.q.GetArticleAuthorsBatch(context.Background(), articleIDs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get article authors batch: %w", err)
+	}
+	for _, r := range authorRows {
+		authors[r.ArticleID] = append(authors[r.ArticleID], r.Name)
+	}
+
+	categoryRows, err := s.q.GetArticleCategoriesBatch(context.Background(), articleIDs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get article categories batch: %w", err)
+	}
+	for _, r := range categoryRows {
+		categories[r.ArticleID] = append(categories[r.ArticleID], r.Category)
+	}
+	return authors, categories, nil
+}
+
 // --- Feed metadata discovery ---
 
 func (s *PostgresStore) GetFeedAuthors(feedID int64) ([]string, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -214,15 +214,55 @@ type ArticleAuthor struct {
 	Email string
 }
 
+// Match modes for a FilterRule (#274). MatchExact is the pre-#274 behaviour
+// and the column default, so a rule that predates pattern matching keeps its
+// meaning without being rewritten.
+const (
+	MatchExact     = "exact"
+	MatchSubstring = "substring"
+	MatchRegex     = "regex"
+)
+
+// Filter rule axes. The first three match normalized metadata; the last three
+// match the article's own text and are reachable only since #274.
+const (
+	AxisAuthor   = "author"
+	AxisCategory = "category"
+	AxisTag      = "tag"
+	AxisTitle    = "title"
+	AxisSummary  = "summary"
+	AxisContent  = "content"
+)
+
 // FilterRule represents a user-defined scoring rule for article filtering.
 type FilterRule struct {
 	ID        int64
 	UserID    int64
 	FeedID    *int64 // nil = global rule
-	Axis      string // "author", "category", "tag"
+	Axis      string // one of the Axis* constants
+	MatchMode string // one of the Match* constants; "" is treated as MatchExact
 	Value     string
 	Score     int
 	CreatedAt time.Time
+}
+
+// EvaluatedInGo reports whether this rule is matched by the Go evaluator at
+// read time rather than by the SQL matcher.
+//
+// The two are exhaustive and must not overlap: an exact match on a metadata
+// axis is an indexed CITEXT equality and belongs in SQL, everything else needs
+// a pattern engine that does not backtrack. A rule counted by both paths would
+// have its score applied twice.
+func (r FilterRule) EvaluatedInGo() bool {
+	if r.MatchMode != "" && r.MatchMode != MatchExact {
+		return true
+	}
+	switch r.Axis {
+	case AxisAuthor, AxisCategory, AxisTag:
+		return false
+	default:
+		return true
+	}
 }
 
 // applyErrorBackoff returns base doubled for each consecutive error, capped at 30 days.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -221,6 +221,9 @@ type Store interface {
 	StoreArticleCategories(articleID int64, categories []string) error
 	GetArticleAuthors(articleID int64) ([]ArticleAuthor, error)
 	GetArticleCategories(articleID int64) ([]string, error)
+	// GetArticleMetadataBatch returns authors and categories for a page of
+	// articles, keyed by article id, for pattern filter rules on those axes.
+	GetArticleMetadataBatch(articleIDs []int64) (map[int64][]string, map[int64][]string, error)
 
 	// Feed metadata discovery
 	GetFeedAuthors(feedID int64) ([]string, error)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -191,6 +191,9 @@ type Store interface {
 	// independent of filterThreshold: the threshold gates VISIBILITY, while
 	// rules adjust the SCORE whenever the user has any.
 	GetArticlesByInterestScore(userID int64, threshold float64, limit, offset int, filterThreshold *int, applyRules bool) ([]Article, []float64, error)
+	// GetScoredUnreadArticles returns scored unread articles with RAW interest
+	// scores, for callers that apply filter rules in Go and rank afterwards.
+	GetScoredUnreadArticles(userID int64, limit int) ([]Article, []float64, error)
 	GetUnreadArticlesForUser(userID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error)
 	GetUnreadArticlesByFeed(userID, feedID int64, limit, offset int, filterThreshold *int, includeRead bool) ([]Article, error)
 	GetUnscoredArticleCount(userID int64) (int, error)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -316,6 +316,7 @@ type readerGauge struct {
 	Pending   int
 	Ready     int
 	Read      int
+	Hidden    int // subset of Ready that filter rules are suppressing (#274)
 	Total     int
 	GreyEnd   int // cumulative percent: end of the pending (grey) arc
 	YellowEnd int // cumulative percent: end of the ready (yellow) arc
@@ -325,7 +326,9 @@ type readerGauge struct {
 // cumulative arc boundaries with integer round-half-up (no math import needed).
 func buildReaderGauge(g herald.ReaderGauge) readerGauge {
 	total := g.Pending + g.Ready + g.Read
-	rg := readerGauge{Pending: g.Pending, Ready: g.Ready, Read: g.Read, Total: total}
+	// Hidden is deliberately left out of the total: it is a slice of Ready,
+	// not a fourth state, so counting it again would distort the ring.
+	rg := readerGauge{Pending: g.Pending, Ready: g.Ready, Read: g.Read, Hidden: g.Hidden, Total: total}
 	if total > 0 {
 		rg.GreyEnd = (g.Pending*100 + total/2) / total
 		rg.YellowEnd = ((g.Pending+g.Ready)*100 + total/2) / total
@@ -459,6 +462,7 @@ type filtersData struct {
 type filterRuleRow struct {
 	ID        int64
 	Axis      string
+	MatchMode string
 	Value     string
 	Score     int
 	FeedTitle string
@@ -2238,10 +2242,11 @@ func (h *handlers) handleFilters(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, r := range rules {
 		row := filterRuleRow{
-			ID:    r.ID,
-			Axis:  r.Axis,
-			Value: r.Value,
-			Score: r.Score,
+			ID:        r.ID,
+			Axis:      r.Axis,
+			MatchMode: r.MatchMode,
+			Value:     r.Value,
+			Score:     r.Score,
 		}
 		if r.FeedID != nil {
 			row.FeedTitle = feedTitles[*r.FeedID]
@@ -2256,6 +2261,7 @@ func (h *handlers) handleFilterAdd(w http.ResponseWriter, r *http.Request) {
 	uid := userFromContext(r.Context()).ID
 
 	axis := strings.TrimSpace(r.FormValue("axis"))
+	matchMode := strings.TrimSpace(r.FormValue("match_mode"))
 	value := strings.TrimSpace(r.FormValue("value"))
 	scoreStr := r.FormValue("score")
 	feedIDStr := r.FormValue("feed_id")
@@ -2272,9 +2278,10 @@ func (h *handlers) handleFilterAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rule := herald.FilterRule{
-		Axis:  axis,
-		Value: value,
-		Score: score,
+		Axis:      axis,
+		MatchMode: matchMode,
+		Value:     value,
+		Score:     score,
 	}
 	if feedIDStr != "" {
 		fid, err := strconv.ParseInt(feedIDStr, 10, 64)
@@ -2285,7 +2292,11 @@ func (h *handlers) handleFilterAdd(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := h.engine.AddFilterRule(uid, rule); err != nil {
 		log.Printf("herald-web: add filter rule failed for user %d: %v", uid, err)
-		h.renderError(w, http.StatusBadRequest, "Could not add filter rule. Check the values and try again.")
+		// The engine's message names the problem -- an uncompilable pattern, a
+		// quota, a bad axis -- and a user staring at a rejected regex needs it.
+		// These errors are generated from the submitted rule, not from feed
+		// content, and renderError escapes them.
+		h.renderError(w, http.StatusBadRequest, "Could not add filter rule: "+err.Error())
 		return
 	}
 
@@ -2369,10 +2380,29 @@ func (h *handlers) handleFeedMetadataByQuery(w http.ResponseWriter, r *http.Requ
 func (h *handlers) handleFilterValues(w http.ResponseWriter, r *http.Request) {
 	feedIDStr := r.URL.Query().Get("feed_id")
 	axis := r.URL.Query().Get("axis")
+	matchMode := r.URL.Query().Get("match_mode")
 
 	// No axis selected yet — return placeholder select
 	if axis == "" {
 		fmt.Fprint(w, `<select name="value" id="value-select" required><option value="">— select axis first —</option></select>`)
+		return
+	}
+
+	// A pattern is typed, never picked: the point of one is to match values
+	// that are not in the list yet (#274). Same for the text axes, which have
+	// no enumerable values at all.
+	if matchMode == herald.MatchSubstring || matchMode == herald.MatchRegex {
+		placeholder := "text to look for"
+		if matchMode == herald.MatchRegex {
+			placeholder = `RE2 pattern, e.g. (?i)\bopen thread\b`
+		}
+		fmt.Fprintf(w, `<input type="text" name="value" id="value-select" placeholder="%s" required>`,
+			template.HTMLEscapeString(placeholder))
+		return
+	}
+	switch axis {
+	case herald.AxisTitle, herald.AxisSummary, herald.AxisContent:
+		fmt.Fprint(w, `<input type="text" name="value" id="value-select" placeholder="the exact text, in full" required>`)
 		return
 	}
 
@@ -2428,10 +2458,11 @@ func (h *handlers) renderFilterRulesFragment(w http.ResponseWriter, userID int64
 	data := filtersData{}
 	for _, r := range rules {
 		row := filterRuleRow{
-			ID:    r.ID,
-			Axis:  r.Axis,
-			Value: r.Value,
-			Score: r.Score,
+			ID:        r.ID,
+			Axis:      r.Axis,
+			MatchMode: r.MatchMode,
+			Value:     r.Value,
+			Score:     r.Score,
 		}
 		if r.FeedID != nil {
 			row.FeedTitle = feedTitles[*r.FeedID]

--- a/internal/web/static/herald.css
+++ b/internal/web/static/herald.css
@@ -497,6 +497,9 @@
     --rg-grey: var(--pico-muted-color, #9ca3af);
     --rg-yellow: #d9a400;
     --rg-green: #2e9e5b;
+    /* Muted violet: distinct from the three pipeline states, and clearly not
+       one of them. */
+    --rg-hidden: #8b7bb8;
     display: flex;
     align-items: center;
     gap: 0.6rem;
@@ -558,6 +561,10 @@
 .rg-grey::before { color: var(--rg-grey); }
 .rg-yellow::before { color: var(--rg-yellow); }
 .rg-green::before { color: var(--rg-green); }
+/* Hidden (#274) is a slice of "unread", not a fourth pipeline state, so it has
+   no arc on the ring -- only a legend entry, dimmed to read as a footnote. */
+.rg-hidden { color: var(--pico-muted-color); }
+.rg-hidden::before { color: var(--rg-hidden); }
 
 /* Unsubscribe reason menu (#252): inline, not a modal -- the reason is
    optional and must not cost more than the unsubscribe itself. */

--- a/internal/web/templates/feed_sidebar.html
+++ b/internal/web/templates/feed_sidebar.html
@@ -12,6 +12,9 @@
         <span class="rg-dot rg-grey">{{.Pending}} <span class="rg-label">pending</span></span>
         <span class="rg-dot rg-yellow">{{.Ready}} <span class="rg-label">unread</span></span>
         <span class="rg-dot rg-green">{{.Read}} <span class="rg-label">read</span></span>
+        {{if .Hidden}}
+        <span class="rg-dot rg-hidden" title="Unread articles your filter rules are suppressing. Counted over a bounded window, so it can undercount a large backlog.">{{.Hidden}} <span class="rg-label">hidden</span></span>
+        {{end}}
     </div>
 </div>
 {{end}}

--- a/internal/web/templates/filters.html
+++ b/internal/web/templates/filters.html
@@ -7,11 +7,29 @@
     {{template "settings-subnav" (dict "Active" "filters" "IsAdmin" .IsAdmin)}}
 
     <p class="secondary">
-        Rules adjust an article's interest score by author, category, or tag, and
-        scores are additive. A positive rule ranks matching articles higher and
-        makes them likelier to reach your digest and notifications; a negative
-        rule pushes them down. This takes effect immediately, including on
-        articles already scored -- nothing is re-run.
+        Rules adjust an article's interest score, and scores are additive. A
+        positive rule ranks matching articles higher and makes them likelier to
+        reach your digest and notifications; a negative rule pushes them down.
+        This takes effect immediately, including on articles already scored --
+        nothing is re-run.
+    </p>
+    <p class="secondary">
+        <strong>Author</strong>, <strong>category</strong> and
+        <strong>tag</strong> match the labels a feed publishes.
+        <strong>Title</strong>, <strong>summary</strong> and
+        <strong>content</strong> match the article's own text -- use these for
+        recurring posts whose title changes slightly each time, like a daily
+        open thread. Content rules read whole article bodies, so they are the
+        slow ones and are limited to a handful; prefer title where it will do.
+    </p>
+    <p class="secondary">
+        <strong>Exact</strong> matches the whole value, ignoring case.
+        <strong>Contains</strong> matches anywhere in it, also ignoring case.
+        <strong>Pattern</strong> is a
+        <a href="https://github.com/google/re2/wiki/Syntax">RE2 regular
+        expression</a>, matched as written -- start it with <code>(?i)</code> to
+        ignore case. RE2 has no backreferences or lookahead; an expression that
+        does not compile is refused when you add it.
     </p>
     <p class="secondary">
         The <strong>filter threshold</strong> below is separate: it hides
@@ -43,7 +61,7 @@
                     <label for="rule-feed">Feed (optional)</label>
                     <select id="rule-feed" name="feed_id"
                             hx-get="/filters/values"
-                            hx-include="[name='axis']"
+                            hx-include="[name='axis'],[name='match_mode']"
                             hx-target="#value-field"
                             hx-swap="innerHTML"
                             hx-trigger="change">
@@ -57,14 +75,34 @@
                     <label for="rule-axis">Axis</label>
                     <select id="rule-axis" name="axis" required
                             hx-get="/filters/values"
-                            hx-include="[name='feed_id']"
+                            hx-include="[name='feed_id'],[name='match_mode']"
                             hx-target="#value-field"
                             hx-swap="innerHTML"
                             hx-trigger="change">
                         <option value="">— select —</option>
-                        <option value="author">Author</option>
-                        <option value="category">Category</option>
-                        <option value="tag">Tag</option>
+                        <optgroup label="Feed metadata">
+                            <option value="author">Author</option>
+                            <option value="category">Category</option>
+                            <option value="tag">Tag</option>
+                        </optgroup>
+                        <optgroup label="Article text">
+                            <option value="title">Title</option>
+                            <option value="summary">Summary</option>
+                            <option value="content">Content (slow)</option>
+                        </optgroup>
+                    </select>
+                </div>
+                <div>
+                    <label for="rule-match-mode">Match</label>
+                    <select id="rule-match-mode" name="match_mode" required
+                            hx-get="/filters/values"
+                            hx-include="[name='feed_id'],[name='axis']"
+                            hx-target="#value-field"
+                            hx-swap="innerHTML"
+                            hx-trigger="change">
+                        <option value="exact">Exact</option>
+                        <option value="substring">Contains</option>
+                        <option value="regex">Pattern (regex)</option>
                     </select>
                 </div>
                 <div>
@@ -117,6 +155,7 @@
         <tr>
             <th>Feed</th>
             <th>Axis</th>
+            <th>Match</th>
             <th>Value</th>
             <th>Score</th>
             <th></th>
@@ -127,7 +166,8 @@
         <tr>
             <td>{{if .FeedTitle}}{{.FeedTitle}}{{else}}Global{{end}}</td>
             <td>{{.Axis}}</td>
-            <td>{{.Value}}</td>
+            <td>{{.MatchMode}}</td>
+            <td>{{if eq .MatchMode "regex"}}<code>{{.Value}}</code>{{else}}{{.Value}}{{end}}</td>
             <td>{{.Score}}</td>
             <td>
                 <button class="outline secondary" style="padding:0.25rem 0.5rem;font-size:0.8rem;"

--- a/types.go
+++ b/types.go
@@ -1,6 +1,10 @@
 package herald
 
-import "time"
+import (
+	"time"
+
+	"github.com/matthewjhunter/herald/internal/storage"
+)
 
 // EngineConfig configures the Herald content engine.
 type EngineConfig struct {
@@ -309,12 +313,28 @@ type UserPreferences struct {
 	NotifyMinScore    float64  `json:"notify_min_score"`
 }
 
+// Filter rule match modes and axes, re-exported from the storage package so
+// callers of the public API do not have to reach into internal/.
+const (
+	MatchExact     = storage.MatchExact
+	MatchSubstring = storage.MatchSubstring
+	MatchRegex     = storage.MatchRegex
+
+	AxisAuthor   = storage.AxisAuthor
+	AxisCategory = storage.AxisCategory
+	AxisTag      = storage.AxisTag
+	AxisTitle    = storage.AxisTitle
+	AxisSummary  = storage.AxisSummary
+	AxisContent  = storage.AxisContent
+)
+
 // FilterRule represents a user-defined scoring rule for article filtering.
 type FilterRule struct {
 	ID        int64     `json:"id"`
 	UserID    int64     `json:"user_id"`
 	FeedID    *int64    `json:"feed_id,omitempty"`
 	Axis      string    `json:"axis"`
+	MatchMode string    `json:"match_mode"`
 	Value     string    `json:"value"`
 	Score     int       `json:"score"`
 	CreatedAt time.Time `json:"created_at"`

--- a/types.go
+++ b/types.go
@@ -286,6 +286,10 @@ type ReaderGauge struct {
 	Pending int
 	Ready   int
 	Read    int
+	// Hidden is how many of Ready the user's filter rules are suppressing.
+	// It is a subset of Ready, not a fourth state, and is approximate: see
+	// ruleFilter.hiddenUnreadCount.
+	Hidden int
 }
 
 // CycleStats is one completed run of the fetch+process daemon cycle, persisted so


### PR DESCRIPTION
Closes #274.

Filter rules could only match normalized metadata -- author, category, tag -- by exact equality. The article's own text was unreachable, so a feed that publishes the same auto-generated post every day under a title whose date changes could not be filtered at all: every post shares one author and carries no distinguishing category.

Checked against the live feed that prompted this. The two recurring posts carry exactly one category, `Uncategorized`, and so do roughly a third of the real articles -- so no metadata rule could separate them. The title was the only usable signal, and no rule could see it.

## What this adds

Three text axes (`title`, `summary`, `content`) and a match mode of `exact`, `substring` or `regex`. The motivating case becomes two feed-scoped title rules:

- `(?i)\bopen thread\b`
- `(?i)trump administration day \d+`

Those six real headlines are the fixture in `TestPatternRuleHidesRecurringPosts`.

## Where rules are evaluated

|  | `exact` | `substring` / `regex` |
|---|---|---|
| `author` / `category` / `tag` | SQL | Go |
| `title` / `summary` / `content` | Go | Go |

Go rather than Postgres for patterns because article text is attacker-supplied and Postgres regex backtracks: a careless pattern over content a feed controls is a wedged page load. Go's `regexp` is RE2, linear in the input. A test runs a classically catastrophic pattern over 40KB of `a`.

Read time rather than ingest time because a rule should take effect when it is saved. Materializing matches would mean a new rule did nothing until the next processing cycle -- which is what #259 was filed about. Materialization stays available as a cache; it must not become the semantics.

**A user's rules are evaluated entirely in one place or entirely in the other.** The visibility gate forces this: it compares the SUM of a user's matching rules against a threshold, and a split rule set leaves neither evaluator holding the number being compared. `filtermatch.New` returns a nil Matcher when SQL suffices -- the common case, which stays free -- and otherwise takes the whole set including the exact rules SQL could have matched. `filterRuleMatch` grows a `match_mode = 'exact'` qualifier so the SQL side cannot also match pattern rules and double their scores.

## Surfaces

Rules now reach the four date-ordered lists, the interest ranking, the briefing, both CLI notification paths, and the Fever API. **Fever previously ignored filter rules entirely**, so an article hidden in the web reader still synced to every connected client; that is a behaviour change for anyone with a synced client.

On the Go ranking path the score arithmetic leaves SQL: the store returns raw interest scores because the ranking query's number is clamped and clamping is not invertible. A test pins the order of operations -- summing then clamping gives 8 where clamping in stages gives 4. The recency decay now has one definition with a Go twin and a test that ranks the same article down both paths and compares, so an article cannot rank differently depending on whether its owner happens to own a pattern rule.

## Costs and limits, measured

Benchmarks in `internal/filtermatch`:

| | per page of 50 |
|---|---|
| 50 title rules | 1.5ms |
| 1 content rule | 2.4ms |
| 5 content rules | 11ms |
| 50 content rules | 93ms |

So content rules get their own quota (`max_content_filter_rules_per_user`, default 5) below the general pattern quota (default 50). The alternation prefilter that takes titles from 2.5ms to 1.5ms does not rescue the content axis -- cost stays linear in rule count, because a wider alternation over a 4KB body costs proportionally more to scan.

Two deliberate limitations:

- A page can come back short under an aggressive filter. The window is bounded (`filter_overfetch_factor` × page, capped at `filter_max_scan`) rather than looped until full, and a filled window is logged. #277 is where page composition gets designed properly.
- The ranking candidate window is ordered by unadjusted score, so an article the model rated poorly that a rule *boosts* hard can fall outside it. Demotion -- what nearly every rule does -- is unaffected.

## Counts

Unread counts have never applied the visibility gate, so a filtered list could always show fewer articles than the badge promised. Rather than make them exact -- which would mean evaluating every unread article on every page load -- the reader gauge reports the gap as its own figure: "12 unread, 7 hidden". A legend entry in its own colour, with no arc on the ring, since hidden is a slice of unread rather than a fourth pipeline state.

## Per-user, not sitewide

Filter rules are per-user taste and stay that way: `filter_rule` evaluation is scoped to the requesting user, compiled patterns are never shared between users, and no filter rule can move an article's threat score. The sitewide screen -- airlock's regexes plus the LLM verdict, stored on the article because the verdict is a property of the article -- is untouched. Cross-user leakage is tested directly on the reader lists, the Fever API and the hidden count.

## Compatibility

Existing rules are untouched: `match_mode` defaults to `exact`, exact metadata rules keep the SQL path and their instant effect, and there is nothing to backfill or reprocess. The Down migration deletes rules the old schema cannot represent rather than coercing a regex into an exact match that would silently match nothing; it was verified by hand against a scratch schema.

## Testing

`go test -race -count=1 ./...` green, `golangci-lint` clean. New coverage: each mode against each axis, feed scoping, additive scores, uncompilable patterns refused at save, both quotas, pagination consistency under an active filter, the double-count case, SQL/Go decay agreement, clamp ordering, the Fever gate, the hidden count, and multi-user isolation on every surface that filters.
